### PR TITLE
Neon本番DBマイグレーション用makeコマンドの追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help ruff mypy migrate upgrade downgrade revision seed db-clear db-reset db-connect upgrade-local downgrade-local revision-local
+.PHONY: help ruff mypy migrate upgrade downgrade revision seed db-clear db-reset db-connect upgrade-local downgrade-local revision-local upgrade-prod
 
 help: ## このヘルプメッセージを表示
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -41,3 +41,6 @@ db-reset: ## データベースを完全にリセット
 
 db-connect: ## PostgreSQL CLIに接続
 	docker compose exec db sh -c 'psql -U $$POSTGRES_USER $$POSTGRES_DB'
+
+upgrade-prod: ## Neon本番DBにマイグレーション実行
+	VERCEL_ENV=production uv run alembic upgrade head


### PR DESCRIPTION
## 概要
- Neon本番DBに対してローカルからマイグレーションを実行する`make upgrade-prod`コマンドを追加
- `VERCEL_ENV=production`を設定し、`.env`の`POSTGRES_URL`経由で本番DBに接続

## 変更内容
- `Makefile`: `upgrade-prod`ターゲット追加

## 使い方
```bash
make upgrade-prod
```

## 背景
- Vercelデプロイ後、Neon DBにテーブルが存在せず`relation "categories" does not exist`エラーが発生
- 本番DBへのマイグレーション手段が必要