### PR TITLE
fix: ExpenseTemplateフォームのiOS自動ズーム防止

### DIFF
--- a/frontend/src/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/pages/ExpenseTemplatePage.tsx
@@ -139,7 +139,7 @@ export const ExpenseTemplatePage = () => {
             }
             required
             maxLength={100}
-            className="flex-1 rounded-xl bg-gray-50 px-4 py-2.5 text-sm outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+            className="flex-1 rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
           />
           <input
             type="text"
@@ -152,7 +152,7 @@ export const ExpenseTemplatePage = () => {
               setForm((prev) => ({ ...prev, amount: formatted }))
             }}
             required
-            className="w-28 rounded-xl bg-gray-50 px-4 py-2.5 text-sm outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+            className="w-28 rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
           />
         </div>
         <div className="flex items-center gap-2">
@@ -163,7 +163,7 @@ export const ExpenseTemplatePage = () => {
                 setForm((prev) => ({ ...prev, categoryUuid: e.target.value }))
               }
               required
-              className="w-full appearance-none rounded-xl bg-gray-50 py-2.5 pr-8 pl-4 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+              className="w-full appearance-none rounded-xl bg-gray-50 py-2.5 pr-8 pl-4 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
             >
               <option value="" disabled>
                 Category
@@ -203,7 +203,7 @@ export const ExpenseTemplatePage = () => {
                         )
                       }
                       maxLength={100}
-                      className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+                      className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
                     />
                     <input
                       type="text"
@@ -218,7 +218,7 @@ export const ExpenseTemplatePage = () => {
                           prev ? { ...prev, amount: formatted } : null,
                         )
                       }}
-                      className="w-24 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+                      className="w-24 rounded-lg bg-gray-50 px-3 py-1.5 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
                     />
                   </div>
                   <div className="flex items-center gap-2">
@@ -232,7 +232,7 @@ export const ExpenseTemplatePage = () => {
                               : null,
                           )
                         }
-                        className="w-full appearance-none rounded-lg bg-gray-50 py-1.5 pr-8 pl-3 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+                        className="w-full appearance-none rounded-lg bg-gray-50 py-1.5 pr-8 pl-3 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
                       >
                         {categories.map((c) => (
                           <option key={c.uuid} value={c.uuid}>

--- a/frontend/src/pages/ExpenseTemplateRecordPage.tsx
+++ b/frontend/src/pages/ExpenseTemplateRecordPage.tsx
@@ -107,7 +107,7 @@ export const ExpenseTemplateRecordPage = () => {
         value={expensedAt}
         onChange={(e) => setExpensedAt(e.target.value)}
         required
-        className="shrink-0 rounded-xl bg-white px-4 py-2.5 text-sm shadow-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-800 dark:text-gray-100"
+        className="shrink-0 rounded-xl bg-white px-4 py-2.5 text-base shadow-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-800 dark:text-gray-100"
       />
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
@@ -139,7 +139,7 @@ export const ExpenseTemplateRecordPage = () => {
                       value={r.amount}
                       onClick={(e) => e.stopPropagation()}
                       onChange={(e) => updateAmount(idx, e.target.value)}
-                      className="w-24 rounded-lg bg-gray-50 px-3 py-1 text-right text-sm tabular-nums outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+                      className="w-24 rounded-lg bg-gray-50 px-3 py-1 text-right text-base tabular-nums outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
                     />
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary
- ExpenseTemplateフォームのinput/selectの`text-sm`(14px)を`text-base`(16px)に変更
- iOSでフォーカス時に画面が自動ズームされる問題を解消

Closes #9

## 変更ファイル
- `frontend/src/pages/ExpenseTemplatePage.tsx` - 作成フォーム・編集フォームの6箇所
- `frontend/src/pages/ExpenseTemplateRecordPage.tsx` - 日時入力・金額入力の2箇所

## Test plan
- [ ] iPhoneのChromeでExpenseTemplate画面を開き、各入力フィールドにフォーカスしてズームが発生しないことを確認
- [ ] デスクトップブラウザで表示崩れがないことを確認