### PR TITLE
fix: expense/monthlyのスクロール箇所をタブの下に限定

### DIFF
--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -191,7 +191,7 @@ export const ExpenseMonthlyPage = () => {
         ))}
       </div>
 
-      <div ref={swipeRef} className="min-h-0 flex-1">
+      <div ref={swipeRef} className="flex min-h-0 flex-1 flex-col">
         {tab === "list" && <ExpenseList expenses={filteredExpenses} />}
 
         {tab === "pie" && (

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -120,7 +120,7 @@ export const ExpenseMonthlyPage = () => {
   })
 
   return (
-    <div className="mx-auto flex h-full max-w-2xl flex-col px-6">
+    <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden px-6">
       {error && (
         <p className="mt-6 text-sm text-red-600 dark:text-red-400">{error}</p>
       )}


### PR DESCRIPTION
## Summary
- ExpenseMonthlyPageのルートdivに`overflow-hidden`を追加
- ヘッダー・カテゴリフィルター・タブナビゲーションを固定表示に
- タブ下のコンテンツ領域のみスクロール可能

Closes #11

## Test plan
- [ ] `/expense/monthly`でスクロール時にヘッダー・タブが固定されること
- [ ] 各タブ（リスト/円グラフ/ヒートマップ/バブルチャート）のコンテンツがスクロール可能なこと
- [ ] 他のページのスクロール動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)