### PR TITLE
fix: GitHub Releaseのタイトルを明示的に指定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,6 +54,6 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
-        run: gh release create "v${{ inputs.version }}" --notes "${{ steps.notes.outputs.body }}" --target main
+        run: gh release create "v${{ inputs.version }}" --title "v${{ inputs.version }}" --notes "${{ steps.notes.outputs.body }}" --target main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `gh release create` に `--title "v${{ inputs.version }}"` を追加
- リリースタイトルが常に `vX.X.X` 形式になるよう保証

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)