### PR TITLE
feat: seedスクリプトをdelete/insert方式に変更

### DIFF
--- a/backend/scripts/seed_all.py
+++ b/backend/scripts/seed_all.py
@@ -1,5 +1,7 @@
 """Category、Expense テーブルに順番に seed データを投入するスクリプト
 
+既存データ(users, webauthn_credentials以外)を削除してからクリーンに再投入する。
+
 Usage:
     uv run python scripts/seed_all.py              # 1件目のユーザーを使用
     uv run python scripts/seed_all.py <user_name>  # 指定ユーザーを使用
@@ -20,6 +22,9 @@ from sqlalchemy.orm import Session  # noqa: E402
 from scripts.seed_categories import seed_categories  # noqa: E402
 from scripts.seed_expense_templates import seed_expense_templates  # noqa: E402
 from scripts.seed_expenses import seed_expenses  # noqa: E402
+from src.model import Category, Expense  # noqa: E402
+from src.model.expense_category_association import ExpenseCategoryAssociation  # noqa: E402
+from src.model.expense_template import ExpenseTemplate  # noqa: E402
 from src.model.user import User  # noqa: E402
 from src.repository.database import get_session_local  # noqa: E402
 
@@ -38,14 +43,46 @@ def resolve_user(db: Session, user_name: str | None) -> User:
     return user
 
 
+def delete_existing_data(db: Session, user: User) -> None:
+    """対象ユーザーのseedデータを全削除(FK制約を考慮した順序)"""
+    # 1. 中間テーブル(expense_category_association)
+    assoc_count = db.query(ExpenseCategoryAssociation).filter(
+        ExpenseCategoryAssociation.expense_uuid.in_(
+            db.query(Expense.uuid).filter(Expense.user_uuid == user.uuid),
+        ),
+    ).delete(synchronize_session=False)
+
+    # 2. expenses
+    expense_count = db.query(Expense).filter(Expense.user_uuid == user.uuid).delete(synchronize_session=False)
+
+    # 3. expense_templates
+    template_count = db.query(ExpenseTemplate).filter(
+        ExpenseTemplate.user_uuid == user.uuid,
+    ).delete(synchronize_session=False)
+
+    # 4. categories
+    category_count = db.query(Category).filter(Category.user_uuid == user.uuid).delete(synchronize_session=False)
+
+    db.commit()
+
+    print(f"既存データを削除: カテゴリ {category_count}件, 支出 {expense_count}件, "
+          f"関連付け {assoc_count}件, テンプレート {template_count}件")
+
+
 def seed_all(user_name: str | None = None) -> None:
-    """Category、Expense テーブルに順番に seed データを投入"""
+    """既存データを削除し、Category、Expense テーブルにクリーンに seed データを投入"""
     db: Session = get_session_local()()
     try:
         user = resolve_user(db, user_name)
         print("=" * 60)
         print(f"対象ユーザー: {user.name} (UUID: {user.uuid})")
         print("=" * 60)
+        print()
+
+        # 0. 既存データの削除
+        print("[0/3] 既存データの削除...")
+        print("-" * 60)
+        delete_existing_data(db, user)
         print()
 
         # 1. カテゴリを投入

--- a/backend/scripts/seed_categories.py
+++ b/backend/scripts/seed_categories.py
@@ -16,18 +16,8 @@ CATEGORY_NAMES = [
 
 
 def seed_categories(db: Session, user: User) -> None:
-    """Category テーブルに seed データを投入(既存カテゴリはスキップ)"""
-    existing = {
-        str(c.name)
-        for c in db.query(Category).filter(Category.user_uuid == user.uuid).all()
-    }
-
-    new_names = [name for name in CATEGORY_NAMES if name not in existing]
-    if not new_names:
-        print("すべてのカテゴリが既に存在します。スキップ。")
-        return
-
-    categories = [Category(user_uuid=user.uuid, name=name) for name in new_names]
+    """Category テーブルに seed データを投入"""
+    categories = [Category(user_uuid=user.uuid, name=name) for name in CATEGORY_NAMES]
     db.add_all(categories)
     db.commit()
 

--- a/backend/scripts/seed_expense_templates.py
+++ b/backend/scripts/seed_expense_templates.py
@@ -19,27 +19,14 @@ TEMPLATE_DATA = [
 
 
 def seed_expense_templates(db: Session, user: User) -> None:
-    """ExpenseTemplate テーブルに seed データを投入(既存テンプレートはスキップ)"""
-    existing = {
-        str(t.name)
-        for t in db.query(ExpenseTemplate).filter(
-            ExpenseTemplate.user_uuid == user.uuid,
-            ExpenseTemplate.deleted_at.is_(None),
-        ).all()
-    }
-
+    """ExpenseTemplate テーブルに seed データを投入"""
     categories = {
         str(c.name): c
         for c in db.query(Category).filter(Category.user_uuid == user.uuid).all()
     }
 
-    new_templates = [d for d in TEMPLATE_DATA if d["name"] not in existing]
-    if not new_templates:
-        print("すべてのテンプレートが既に存在します。スキップ。")
-        return
-
     templates = []
-    for data in new_templates:
+    for data in TEMPLATE_DATA:
         category_name = str(data["category"])
         category = categories.get(category_name)
         if not category:

--- a/backend/scripts/seed_expenses.py
+++ b/backend/scripts/seed_expenses.py
@@ -123,12 +123,7 @@ def _generate_expenses(rng: random.Random) -> list[ExpenseRecord]:
 
 
 def seed_expenses(db: Session, user: User) -> None:
-    """Expense テーブルに3年分の seed データを投入(既存データがあればスキップ)"""
-    existing_count = db.query(Expense).filter(Expense.user_uuid == user.uuid).count()
-    if existing_count > 0:
-        print(f"既に {existing_count} 件の支出が存在します。スキップ。")
-        return
-
+    """Expense テーブルに3年分の seed データを投入"""
     categories = db.query(Category).filter(Category.user_uuid == user.uuid).all()
     categories_dict: dict[str, Category] = {str(c.name): c for c in categories}
 


### PR DESCRIPTION
## Summary
- seed実行時に`users`/`webauthn_credentials`以外のテーブルを全削除→再投入する方式に変更
- FK制約を考慮した削除順序: association → expenses → expense_templates → categories
- 各seedスクリプトの既存データスキップロジックを除去

Closes #24

## Test plan
- [x] `make lint` 通過
- [x] `make test-backend` 全27テスト通過
- [ ] `make seed` でクリーンな投入を確認
- [ ] `make seed` 再実行で冪等性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)