### PR TITLE
fix: テンプレート画面の金額表示オーバーフロー修正

### DIFF
--- a/frontend/src/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/pages/ExpenseTemplatePage.tsx
@@ -176,7 +176,7 @@ export const ExpenseTemplatePage = () => {
       {templates.length > 0 && (
         <div className="flex items-center justify-between rounded-2xl bg-white px-5 py-3.5 shadow-sm dark:bg-gray-800">
           <span className="text-sm text-gray-500 dark:text-gray-400">合計</span>
-          <span className="text-sm font-semibold tabular-nums">
+          <span className="min-w-0 truncate text-sm font-semibold tabular-nums">
             ¥{totalAmount.toLocaleString()}
           </span>
         </div>
@@ -249,13 +249,15 @@ export const ExpenseTemplatePage = () => {
                 </div>
               ) : (
                 <>
-                  <div className="flex flex-1 flex-col">
-                    <span className="text-sm">{t.name}</span>
-                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="truncate text-sm">{t.name}</span>
+                    <span className="truncate text-xs text-gray-400 dark:text-gray-500">
                       {t.category.name}
                     </span>
                   </div>
-                  <span className="text-sm tabular-nums">¥{t.amount.toLocaleString()}</span>
+                  <span className="min-w-0 shrink-0 truncate text-sm tabular-nums">
+                    ¥{t.amount.toLocaleString()}
+                  </span>
                   <button
                     type="button"
                     onClick={() => startEdit(t)}

--- a/frontend/src/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/pages/ExpenseTemplatePage.tsx
@@ -120,30 +120,28 @@ export const ExpenseTemplatePage = () => {
         onSubmit={handleCreate}
         className="flex shrink-0 flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-800"
       >
-        <div className="flex items-center gap-2">
-          <input
-            type="text"
-            placeholder="Netflix"
-            value={form.name}
-            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-            required
-            maxLength={100}
-            className="flex-1 rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
-          <input
-            type="text"
-            inputMode="numeric"
-            placeholder="1,490"
-            value={form.amount}
-            onChange={(e) => {
-              const raw = e.target.value.replace(/[^0-9]/g, "")
-              const formatted = raw ? Number(raw).toLocaleString() : ""
-              setForm((prev) => ({ ...prev, amount: formatted }))
-            }}
-            required
-            className="w-28 rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
-        </div>
+        <input
+          type="text"
+          placeholder="Netflix"
+          value={form.name}
+          onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+          required
+          maxLength={100}
+          className="w-full rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+        />
+        <input
+          type="text"
+          inputMode="numeric"
+          placeholder="1,490"
+          value={form.amount}
+          onChange={(e) => {
+            const raw = e.target.value.replace(/[^0-9]/g, "")
+            const formatted = raw ? Number(raw).toLocaleString() : ""
+            setForm((prev) => ({ ...prev, amount: formatted }))
+          }}
+          required
+          className="w-full rounded-xl bg-gray-50 px-4 py-2.5 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+        />
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <select

--- a/frontend/src/pages/ExpenseTemplateRecordPage.tsx
+++ b/frontend/src/pages/ExpenseTemplateRecordPage.tsx
@@ -135,11 +135,13 @@ export const ExpenseTemplateRecordPage = () => {
                       value={r.amount}
                       onClick={(e) => e.stopPropagation()}
                       onChange={(e) => updateAmount(idx, e.target.value)}
-                      className="w-24 rounded-lg bg-gray-50 px-3 py-1 text-right text-base tabular-nums outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+                      className="w-28 rounded-lg bg-gray-50 px-3 py-1 text-right text-base tabular-nums outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
                     />
                   </div>
                 ) : (
-                  <span className="text-sm tabular-nums text-gray-400">¥{r.amount}</span>
+                  <span className="min-w-0 truncate text-sm tabular-nums text-gray-400">
+                    ¥{r.amount}
+                  </span>
                 )}
               </div>
             </button>


### PR DESCRIPTION
## Summary
- テンプレート画面の金額表示に`truncate`/`min-w-0`を追加し、大きな金額が枠からはみ出す問題を修正
- 記帳画面の金額入力フィールド幅を`w-24`→`w-28`に拡大
- テンプレート名・カテゴリ名にも`truncate`を追加

Closes #28

## Test plan
- [ ] テンプレート一覧で大きな金額（¥999,999,999等）が枠内に収まることを確認
- [ ] 合計金額が大きい場合も枠内に収まることを確認
- [ ] 記帳画面で大きな金額の入力・表示が正常であることを確認
- [ ] テンプレート名が長い場合に省略表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)