### PR TITLE
fix: ダークモード時にiPhoneステータスバーの背景色がアプリと一致するよう修正

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/apple-touch-icon.png" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
-    <meta name="theme-color" content="#1E3A5F" />
+    <meta name="theme-color" content="#f7fafc" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BurnStyle</title>
   </head>
@@ -16,6 +16,7 @@
         var t = localStorage.getItem("theme")
         var d = t === "dark" || (t !== "light" && matchMedia("(prefers-color-scheme: dark)").matches)
         if (d) document.documentElement.classList.add("dark")
+        document.querySelector('meta[name="theme-color"]').content = d ? "#1a1a1a" : "#f7fafc"
       })()
     </script>
     <script type="module" src="/src/main.tsx"></script>

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -13,6 +13,8 @@ const isDarkPreferred = () => window.matchMedia("(prefers-color-scheme: dark)").
 
 const applyClass = (dark: boolean) => {
   document.documentElement.classList.toggle("dark", dark)
+  const meta = document.querySelector('meta[name="theme-color"]')
+  if (meta) meta.setAttribute("content", dark ? "#1a1a1a" : "#f7fafc")
 }
 
 export const applyTheme = (mode: ThemeMode) => {


### PR DESCRIPTION
## Summary
- `index.html`のインラインスクリプトでダーク判定時に`theme-color`を動的設定
- `applyTheme`（テーマ切替時）でも`meta[name="theme-color"]`を更新
- ライト: `#f7fafc` / ダーク: `#1a1a1a`（アプリ背景色と一致）

Closes #37

## Test plan
- [ ] ダークモード時にステータスバーが`#1a1a1a`になる
- [ ] ライトモード時にステータスバーが`#f7fafc`になる
- [ ] 設定画面でテーマ切替時にステータスバーが即座に追従する
- [ ] system設定時にOS側のダーク切替に追従する

🤖 Generated with [Claude Code](https://claude.com/claude-code)