### PR TITLE
feat: 月別分析のカテゴリチップをlistタブ時のみタブ直下に表示

### DIFF
--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -144,25 +144,6 @@ export const ExpenseMonthlyPage = () => {
         </button>
       </div>
 
-      {categories.length > 1 && (
-        <div className="flex shrink-0 gap-2 overflow-x-auto pb-2">
-          {categories.map((cat) => (
-            <button
-              key={cat}
-              type="button"
-              onClick={() => setSelectedCategory(selectedCategory === cat ? null : cat)}
-              className={`shrink-0 rounded-full border px-3 py-1 text-xs transition-colors ${
-                selectedCategory === cat
-                  ? "border-primary bg-primary text-white"
-                  : "border-gray-200 text-gray-500 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600"
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
-      )}
-
       <div className="flex shrink-0 gap-4 border-b border-gray-100 dark:border-gray-700">
         {[
           { key: "list" as const, label: "list", icon: ListBulletIcon },
@@ -185,6 +166,25 @@ export const ExpenseMonthlyPage = () => {
           </button>
         ))}
       </div>
+
+      {tab === "list" && categories.length > 1 && (
+        <div className="flex shrink-0 gap-2 overflow-x-auto pt-2 pb-1">
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              type="button"
+              onClick={() => setSelectedCategory(selectedCategory === cat ? null : cat)}
+              className={`shrink-0 rounded-full border px-3 py-1 text-xs transition-colors ${
+                selectedCategory === cat
+                  ? "border-primary bg-primary text-white"
+                  : "border-gray-200 text-gray-500 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600"
+              }`}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      )}
 
       <div ref={swipeRef} className="flex min-h-0 flex-1 flex-col">
         {tab === "list" && <ExpenseList expenses={filteredExpenses} />}


### PR DESCRIPTION
## Summary
- カテゴリチップをタブ上部からタブ直下に移動
- listタブ選択時のみ表示（pie/heatmap/bubbleは各コンポーネント内の凡例で切替可能）

Closes #32

## Test plan
- [ ] listタブでカテゴリチップがタブ直下に表示される
- [ ] pie/heatmap/bubbleタブでカテゴリチップが非表示
- [ ] カテゴリチップのフィルター機能が正常動作
- [ ] タブ切替時の表示が正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)