### PR TITLE
feat: ヒートマップ・バブルチャートのカテゴリチップから色ドットを除去

### DIFF
--- a/frontend/src/components/CategoryBubbleChart.tsx
+++ b/frontend/src/components/CategoryBubbleChart.tsx
@@ -10,7 +10,7 @@ import {
   ZAxis,
 } from "recharts"
 
-import { CHART_COLORS, RANGE_COLORS } from "../lib/colors"
+import { RANGE_COLORS } from "../lib/colors"
 import type { ExpenseResponse } from "../lib/types"
 
 const AMOUNT_RANGES = [
@@ -156,26 +156,19 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
         </ScatterChart>
       </ResponsiveContainer>
       <ul className="flex flex-wrap gap-x-3 gap-y-1.5 px-1">
-        {allCategories.map((cat, i) => {
+        {allCategories.map((cat) => {
           const isHidden = hidden.has(cat)
           return (
             <li key={cat}>
               <button
                 type="button"
                 onClick={() => toggle(cat)}
-                className={`flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] transition-opacity ${
+                className={`rounded-full border px-2.5 py-0.5 text-[11px] transition-opacity ${
                   isHidden
                     ? "border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
                     : "border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-300"
                 }`}
               >
-                <span
-                  className="inline-block size-2 rounded-full"
-                  style={{
-                    backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
-                    opacity: isHidden ? 0.2 : 1,
-                  }}
-                />
                 {cat}
               </button>
             </li>

--- a/frontend/src/components/ExpenseHeatmap.tsx
+++ b/frontend/src/components/ExpenseHeatmap.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react"
 
-import { CHART_COLORS } from "../lib/colors"
 import type { ExpenseResponse } from "../lib/types"
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
@@ -119,26 +118,19 @@ export const ExpenseHeatmap = ({ year, month, expenses }: ExpenseHeatmapProps) =
         })}
       </div>
       <ul className="flex flex-wrap gap-x-3 gap-y-1.5 px-1">
-        {allCategories.map((cat, i) => {
+        {allCategories.map((cat) => {
           const isHidden = hidden.has(cat)
           return (
             <li key={cat}>
               <button
                 type="button"
                 onClick={() => toggle(cat)}
-                className={`flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] transition-opacity ${
+                className={`rounded-full border px-2.5 py-0.5 text-[11px] transition-opacity ${
                   isHidden
                     ? "border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
                     : "border-gray-300 text-gray-700 dark:border-gray-600 dark:text-gray-300"
                 }`}
               >
-                <span
-                  className="inline-block size-2 rounded-full"
-                  style={{
-                    backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
-                    opacity: isHidden ? 0.2 : 1,
-                  }}
-                />
                 {cat}
               </button>
             </li>


### PR DESCRIPTION
## Summary
- ExpenseHeatmap・CategoryBubbleChartのカテゴリチップから色付き丸ドットを削除
- カテゴリ名のみのシンプルなチップ表示に変更
- 未使用になったCHART_COLORSのimportを削除

Closes #44

## Test plan
- [ ] ヒートマップタブのカテゴリチップに色ドットがない
- [ ] バブルチャートタブのカテゴリチップに色ドットがない
- [ ] カテゴリチップのトグル（表示/非表示切替）が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)