### PR TITLE
feat: JSONインポート機能の実装

### DIFF
--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -6,6 +6,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from src.api.deps import get_current_user
+from src.model.category import Category
+from src.model.expense import Expense
+from src.model.expense_category_association import ExpenseCategoryAssociation
+from src.model.expense_template import ExpenseTemplate
 from src.model.user import User
 from src.repository.category_repository import get_all_categories
 from src.repository.database import get_db
@@ -14,7 +18,7 @@ from src.repository.user_repository import delete_user, update_user
 from src.schema.auth import UserResponse, UserUpdateRequest
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
-from src.schema.user import UserExportResponse
+from src.schema.user import UserExportResponse, UserImportRequest, UserImportResponse
 
 user_router = APIRouter(tags=["users"])
 
@@ -49,6 +53,61 @@ def export_me(
         name=str(current_user.name),
         categories=[CategoryResponse.model_validate(c) for c in categories],
         expenses=[ExpenseResponse.model_validate(e) for e in expenses],
+    )
+
+
+@user_router.post("/me/import")
+def import_me(
+    body: UserImportRequest,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> UserImportResponse:
+    """エクスポートしたJSONデータをインポート"""
+    user_uuid = str(current_user.uuid)
+
+    # 既存データを削除(FK制約を考慮した順序)
+    db.query(ExpenseCategoryAssociation).filter(
+        ExpenseCategoryAssociation.expense_uuid.in_(
+            db.query(Expense.uuid).filter(Expense.user_uuid == user_uuid),
+        ),
+    ).delete(synchronize_session=False)
+    db.query(ExpenseTemplate).filter(ExpenseTemplate.user_uuid == user_uuid).delete(synchronize_session=False)
+    db.query(Expense).filter(Expense.user_uuid == user_uuid).delete(synchronize_session=False)
+    db.query(Category).filter(Category.user_uuid == user_uuid).delete(synchronize_session=False)
+
+    # カテゴリをインポート(旧UUID -> 新UUIDのマッピング)
+    category_uuid_map: dict[str, str] = {}
+    for cat in body.categories:
+        new_category = Category(user_uuid=user_uuid, name=cat.name)
+        db.add(new_category)
+        db.flush()
+        category_uuid_map[cat.uuid] = str(new_category.uuid)
+
+    # 支出をインポート
+    for exp in body.expenses:
+        expense = Expense(
+            user_uuid=user_uuid,
+            name=exp.name,
+            amount=exp.amount,
+            expensed_at=exp.expensed_at,
+            created_at=exp.created_at,
+            updated_at=exp.updated_at,
+            deleted_at=exp.deleted_at,
+        )
+        db.add(expense)
+        db.flush()
+
+        for cat in exp.categories:
+            new_category_uuid = category_uuid_map.get(cat.uuid)
+            if new_category_uuid:
+                db.add(ExpenseCategoryAssociation(expense_uuid=expense.uuid, category_uuid=new_category_uuid))
+
+    db.commit()
+
+    return UserImportResponse(
+        categories_count=len(body.categories),
+        expenses_count=len(body.expenses),
+        message=f"カテゴリ{len(body.categories)}件、支出{len(body.expenses)}件をインポートしました",
     )
 
 

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -107,7 +107,7 @@ def import_me(
     return UserImportResponse(
         categories_count=len(body.categories),
         expenses_count=len(body.expenses),
-        message=f"カテゴリ{len(body.categories)}件、支出{len(body.expenses)}件をインポートしました",
+        message=f"Imported {len(body.categories)} categories and {len(body.expenses)} expenses",
     )
 
 

--- a/backend/src/schema/user.py
+++ b/backend/src/schema/user.py
@@ -4,9 +4,36 @@ from pydantic import BaseModel
 
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
+from src.schema.types import JstInputDatetime
 
 
 class UserExportResponse(BaseModel):
     name: str
     categories: list[CategoryResponse]
     expenses: list[ExpenseResponse]
+
+
+class ImportCategory(BaseModel):
+    uuid: str
+    name: str
+
+
+class ImportExpense(BaseModel):
+    name: str
+    amount: int
+    expensed_at: JstInputDatetime
+    created_at: JstInputDatetime
+    updated_at: JstInputDatetime
+    deleted_at: JstInputDatetime | None = None
+    categories: list[ImportCategory]
+
+
+class UserImportRequest(BaseModel):
+    categories: list[ImportCategory]
+    expenses: list[ImportExpense]
+
+
+class UserImportResponse(BaseModel):
+    categories_count: int
+    expenses_count: int
+    message: str

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react"
 interface ConfirmDialogProps {
   message: string
   onConfirm: () => void
+  confirmText?: string
 }
 
 export const useConfirmDialog = () => {
@@ -14,6 +15,7 @@ export const useConfirmDialog = () => {
 export const ConfirmDialog = ({
   message,
   onConfirm,
+  confirmText = "Delete",
   dialogRef,
 }: ConfirmDialogProps & {
   dialogRef: React.RefObject<HTMLDialogElement | null>
@@ -37,7 +39,7 @@ export const ConfirmDialog = ({
           onClick={onConfirm}
           className="rounded-full bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
         >
-          Delete
+          {confirmText}
         </button>
       </div>
     </dialog>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   ExpenseTemplateResponse,
   ExpenseTemplateUpdate,
   ExpenseUpdate,
+  ImportResponse,
   RegisterOptionsResponse,
   RegisterVerifyResponse,
   SignInOptionsResponse,
@@ -69,6 +70,9 @@ const deleteMe = (): Promise<void> => client.delete<void>("/me")
 
 const exportMe = (): Promise<unknown> => client.get<unknown>("/me/export")
 
+const importMe = (data: unknown): Promise<ImportResponse> =>
+  client.post<ImportResponse>("/me/import", data)
+
 // --- カテゴリ ---
 
 const getCategories = (): Promise<CategoryResponse[]> =>
@@ -127,6 +131,7 @@ export const api = {
   updateMe,
   deleteMe,
   exportMe,
+  importMe,
   getCategories,
   createCategory,
   updateCategory,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -78,3 +78,9 @@ export interface ExpenseTemplateUpdate {
   amount?: number
   category_uuid?: string
 }
+
+export interface ImportResponse {
+  categories_count: number
+  expenses_count: number
+  message: string
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -99,7 +99,7 @@ export const SettingsPage = () => {
         importDataRef.current = JSON.parse(event.target?.result as string)
         openImportDialog()
       } catch {
-        setError("無効なJSONファイルです")
+        setError("Invalid JSON file")
       }
     })
     reader.readAsText(file)
@@ -258,7 +258,7 @@ export const SettingsPage = () => {
         dialogRef={dialogRef}
       />
       <ConfirmDialog
-        message="既存のカテゴリ・支出・テンプレートデータが全て削除され、JSONファイルのデータに置き換わります。続行しますか？"
+        message="All existing categories, expenses, and templates will be deleted and replaced with the imported data. Continue?"
         onConfirm={handleImport}
         confirmText="Import"
         dialogRef={importDialogRef}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -8,8 +8,9 @@ import {
   Pencil1Icon,
   ResetIcon,
   TrashIcon,
+  UploadIcon,
 } from "@radix-ui/react-icons"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { useNavigate, useOutletContext } from "react-router"
 
 import { ConfirmDialog, useConfirmDialog } from "../components/ConfirmDialog"
@@ -32,7 +33,11 @@ export const SettingsPage = () => {
   const [editing, setEditing] = useState(false)
   const [name, setName] = useState("")
   const [theme, setTheme] = useState<ThemeMode>(getStoredTheme)
+  const [success, setSuccess] = useState("")
   const { dialogRef, open: openDialog } = useConfirmDialog()
+  const { dialogRef: importDialogRef, open: openImportDialog } = useConfirmDialog()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const importDataRef = useRef<unknown>(null)
 
   const changeTheme = (mode: ThemeMode) => {
     setTheme(mode)
@@ -83,9 +88,41 @@ export const SettingsPage = () => {
     }
   }
 
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = ""
+
+    const reader = new FileReader()
+    reader.addEventListener("load", (event) => {
+      try {
+        importDataRef.current = JSON.parse(event.target?.result as string)
+        openImportDialog()
+      } catch {
+        setError("無効なJSONファイルです")
+      }
+    })
+    reader.readAsText(file)
+  }
+
+  const handleImport = async () => {
+    setError("")
+    setSuccess("")
+    importDialogRef.current?.close()
+    try {
+      const result = await api.importMe(importDataRef.current)
+      setSuccess(result.message)
+    } catch (err) {
+      setError(getErrorMessage(err, "Import failed"))
+    } finally {
+      importDataRef.current = null
+    }
+  }
+
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6">
       {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+      {success && <p className="text-sm text-green-600 dark:text-green-400">{success}</p>}
 
       {/* Profile */}
       <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
@@ -178,6 +215,22 @@ export const SettingsPage = () => {
         </button>
         <button
           type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          <UploadIcon className="size-4 text-gray-400 dark:text-gray-500" />
+          <span className="flex-1">Import Data</span>
+          <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json"
+          onChange={handleFileSelect}
+          className="hidden"
+        />
+        <button
+          type="button"
           onClick={onLogout}
           className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
         >
@@ -203,6 +256,12 @@ export const SettingsPage = () => {
         message="All your expense data will be permanently deleted. Are you sure?"
         onConfirm={handleDelete}
         dialogRef={dialogRef}
+      />
+      <ConfirmDialog
+        message="既存のカテゴリ・支出・テンプレートデータが全て削除され、JSONファイルのデータに置き換わります。続行しますか？"
+        onConfirm={handleImport}
+        confirmText="Import"
+        dialogRef={importDialogRef}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- POST `/me/import` エンドポイント追加
- 既存データ(categories, expenses, expense_templates)を削除後、JSONデータをインポート
- SettingsPageにImport Dataボタン追加(ファイル選択 → 確認ダイアログ → インポート実行)

closes #40

## Test plan
- [ ] エクスポートしたJSONをインポートしてデータが正しく復元されること
- [ ] インポート後、カテゴリ・支出の関連付けが維持されること
- [ ] 無効なJSONファイル選択時にエラー表示されること
- [ ] インポート確認ダイアログでキャンセル可能なこと
- [ ] 既存データが正しく削除されてからインポートされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)