### PR TITLE
feat: フッターナビのPlusアイコンを丸型青背景で強調

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -10,7 +10,7 @@ import { LayoutPhone } from "./LayoutPhone"
 
 const navItems = [
   { label: "Dashboard", to: "/", icon: HomeIcon },
-  { label: "Expense", to: "/expense/new", icon: PlusIcon },
+  { label: "Expense", to: "/expense/new", icon: PlusIcon, accent: true },
   { label: "Setting", to: "/setting", icon: GearIcon },
 ]
 

--- a/frontend/src/components/LayoutPhone.tsx
+++ b/frontend/src/components/LayoutPhone.tsx
@@ -5,6 +5,7 @@ interface NavItem {
   label: string
   to: string
   icon?: ComponentType<{ className?: string }>
+  accent?: boolean
 }
 
 interface LayoutPhoneProps {
@@ -22,7 +23,17 @@ export const LayoutPhone = ({ navItems }: LayoutPhoneProps) => {
             `flex flex-1 items-center justify-center py-3 text-xs font-medium ${isActive ? "text-primary" : "text-gray-400 dark:text-gray-500"}`
           }
         >
-          {item.icon ? <item.icon className="size-5" /> : item.label}
+          {item.icon ? (
+            item.accent ? (
+              <span className="flex size-10 items-center justify-center rounded-full bg-primary text-white">
+                <item.icon className="size-5" />
+              </span>
+            ) : (
+              <item.icon className="size-5" />
+            )
+          ) : (
+            item.label
+          )}
         </NavLink>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- NavItemに`accent`フラグを追加
- Plusアイコンを丸型（`size-10 rounded-full`）の青背景（`bg-primary`）+ 白アイコン（`text-white`）で描画

closes #50

## Test plan
- [ ] モバイル表示でPlusアイコンが丸型青背景で表示されること
- [ ] Dashboard・Settingアイコンは従来通りの表示であること
- [ ] ダークモードで表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)