### PR TITLE
feat: unify repository language to English

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,33 +1,36 @@
-# BurnStyle - プロジェクト規約
+# BurnStyle - Project Guidelines
 
-## 実装方針
-- **シンプルであることを最優先とする**
-- 最小限のコードで要件を満たす
-- 不要な抽象化・過度な設計を避ける
-- 迷ったらシンプルな方を選ぶ
+## Language Policy
+- All text in the repository (code, comments, documentation, commit messages) must be written in English.
 
-## 概要
-- 家計管理アプリ（フルスタック）
-- バックエンド: FastAPI + SQLAlchemy + PostgreSQL
-- フロントエンド: React + Vite + Tailwind CSS v4
-- 認証: WebAuthn/パスキー + JWT
-- クライアント: iPhoneのGoogle Chromeで「ホーム画面に追加」したWebアプリ利用が前提
+## Implementation Policy
+- **Simplicity is the top priority**
+- Meet requirements with minimal code
+- Avoid unnecessary abstraction and over-engineering
+- When in doubt, choose the simpler approach
 
-## ルールファイル
+## Overview
+- Expense management app (full-stack)
+- Backend: FastAPI + SQLAlchemy + PostgreSQL
+- Frontend: React + Vite + Tailwind CSS v4
+- Auth: WebAuthn/Passkey + JWT
+- Client: Web app added to home screen via Google Chrome on iPhone
 
-### 開発規約
-- [アーキテクチャ](rules/architecture.md) - レイヤド設計・ディレクトリ構造
-- [バックエンド](rules/backend.md) - Python / FastAPI / SQLAlchemy 規約
-- [フロントエンド](rules/frontend.md) - React / TypeScript / Tailwind CSS 規約
-- [データベース](rules/database.md) - PostgreSQL / Alembic / 接続設定
-- [開発フロー](rules/development.md) - lint・テスト必須プロセス
-- [開発コマンド](rules/commands.md) - Makefile コマンド一覧
-- [Git・デプロイ](rules/git.md) - Conventional Commits / GitHub Actions / Vercel
+## Rule Files
 
-### アプリケーション仕様
-- [プロダクトコンセプト](rules/concept.md) - ビジョン・ターゲット・設計思想
-- [画面構成](rules/screens.md) - 画面一覧・遷移フロー・データ可視化
-- [API仕様](rules/api.md) - エンドポイント・リクエスト・レスポンス
-- [認証](rules/auth.md) - WebAuthn/パスキー + JWT フロー
-- [データモデル](rules/data-model.md) - テーブル定義・ER図
-- [インフラ・デプロイ](rules/infra.md) - Docker / CI/CD / Vercel / 環境変数
+### Development Guidelines
+- [Architecture](rules/architecture.md) - Layered design & directory structure
+- [Backend](rules/backend.md) - Python / FastAPI / SQLAlchemy conventions
+- [Frontend](rules/frontend.md) - React / TypeScript / Tailwind CSS conventions
+- [Database](rules/database.md) - PostgreSQL / Alembic / connection settings
+- [Development Flow](rules/development.md) - Required lint & test processes
+- [Development Commands](rules/commands.md) - Makefile command reference
+- [Git & Deploy](rules/git.md) - Conventional Commits / GitHub Actions / Vercel
+
+### Application Specifications
+- [Product Concept](rules/concept.md) - Vision, target users & design philosophy
+- [Screens](rules/screens.md) - Screen list, navigation flow & data visualization
+- [API Specification](rules/api.md) - Endpoints, requests & responses
+- [Authentication](rules/auth.md) - WebAuthn/Passkey + JWT flow
+- [Data Model](rules/data-model.md) - Table definitions & ER diagram
+- [Infrastructure & Deploy](rules/infra.md) - Docker / CI/CD / Vercel / environment variables

--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -1,49 +1,49 @@
-# API仕様
+# API Specification
 
-ベースURL: `/` (バックエンドサーバー)
+Base URL: `/` (backend server)
 
-認証: `Authorization: Bearer <JWT>` ヘッダー（認証必須エンドポイント）
+Authentication: `Authorization: Bearer <JWT>` header (for authenticated endpoints)
 
-## ヘルスチェック
+## Health Check
 
-| メソッド | パス | レスポンス |
-|---------|------|-----------|
+| Method | Path | Response |
+|--------|------|----------|
 | GET | `/` | `{ message: "BurnStyle API is running" }` |
 | GET | `/health` | `{ status: "healthy" }` |
 
-## 認証 `/auth`
+## Authentication `/auth`
 
-### パスキー登録
+### Passkey Registration
 
-| メソッド | パス | リクエスト | レスポンス |
-|---------|------|-----------|-----------|
+| Method | Path | Request | Response |
+|--------|------|---------|----------|
 | POST | `/auth/register/options` | `{ name }` | `{ options }` |
 | POST | `/auth/register/verify` | `{ name, credential }` | `{ message }` |
 
-### パスキー認証
+### Passkey Authentication
 
-| メソッド | パス | リクエスト | レスポンス |
-|---------|------|-----------|-----------|
+| Method | Path | Request | Response |
+|--------|------|---------|----------|
 | POST | `/auth/signin/options` | `{ name }` | `{ options }` |
 | POST | `/auth/signin/verify` | `{ name, credential }` | `{ access_token, token_type }` |
 
-## ユーザー `/me`
+## User `/me`
 
-全エンドポイント認証必須。
+All endpoints require authentication.
 
-| メソッド | パス | リクエスト | レスポンス | ステータス |
-|---------|------|-----------|-----------|-----------|
+| Method | Path | Request | Response | Status |
+|--------|------|---------|----------|--------|
 | GET | `/me` | - | `{ uuid, name }` | 200 |
 | PATCH | `/me` | `{ name }` | `{ uuid, name }` | 200 |
 | DELETE | `/me` | - | - | 204 |
 | GET | `/me/export` | - | `{ name, categories, expenses }` | 200 |
 
-## カテゴリ `/categories`
+## Categories `/categories`
 
-全エンドポイント認証必須。
+All endpoints require authentication.
 
-| メソッド | パス | リクエスト | レスポンス | ステータス |
-|---------|------|-----------|-----------|-----------|
+| Method | Path | Request | Response | Status |
+|--------|------|---------|----------|--------|
 | GET | `/categories` | - | `CategoryResponse[]` | 200 |
 | POST | `/categories` | `{ name }` | `CategoryResponse` | 201 |
 | PATCH | `/categories/{uuid}` | `{ name? }` | `CategoryResponse` | 200 |
@@ -51,12 +51,12 @@
 
 **CategoryResponse**: `{ uuid, name }`
 
-## 支出 `/expenses`
+## Expenses `/expenses`
 
-全エンドポイント認証必須。
+All endpoints require authentication.
 
-| メソッド | パス | パラメータ | リクエスト | レスポンス | ステータス |
-|---------|------|-----------|-----------|-----------|-----------|
+| Method | Path | Params | Request | Response | Status |
+|--------|------|--------|---------|----------|--------|
 | GET | `/expenses` | `?year=&month=` | - | `ExpenseResponse[]` | 200 |
 | GET | `/expenses/{uuid}` | - | - | `ExpenseResponse` | 200 |
 | POST | `/expenses` | - | `ExpenseCreate` | `ExpenseResponse` | 201 |
@@ -81,22 +81,22 @@
 }
 ```
 
-## 支出テンプレート `/expense-templates`
+## Expense Templates `/expense-templates`
 
-全エンドポイント認証必須。
+All endpoints require authentication.
 
-| メソッド | パス | リクエスト | レスポンス | ステータス |
-|---------|------|-----------|-----------|-----------|
+| Method | Path | Request | Response | Status |
+|--------|------|---------|----------|--------|
 | GET | `/expense-templates` | - | `ExpenseTemplateResponse[]` | 200 |
 | POST | `/expense-templates` | `{ name, amount, category_uuid }` | `ExpenseTemplateResponse` | 201 |
 | PATCH | `/expense-templates/{uuid}` | `{ name?, amount?, category_uuid? }` | `ExpenseTemplateResponse` | 200 |
 | DELETE | `/expense-templates/{uuid}` | - | - | 204 |
 | POST | `/expense-templates/bulk-record` | `{ template_uuids }` | `{ created_count, message }` | 200 |
 
-## 共通仕様
+## Common Specifications
 
-- **タイムゾーン**: DB保存はUTC、APIレスポンスはJST変換
-- **UUID**: v7、32文字ハイフンなし
-- **論理削除**: `deleted_at`カラム（GET時は削除済み除外、exportは全件）
-- **金額**: 正の整数のみ（`amount > 0`）
-- **トークンリフレッシュ**: 認証リクエスト毎にレスポンスヘッダー`X-New-Token`で新JWTを返却
+- **Timezone**: Stored in UTC, API responses converted to JST
+- **UUID**: v7, 32 characters without hyphens
+- **Soft Delete**: `deleted_at` column (excluded from GET, included in export)
+- **Amount**: Positive integers only (`amount > 0`)
+- **Token Refresh**: New JWT returned via `X-New-Token` response header on every authenticated request

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,33 +1,33 @@
-# アーキテクチャ
+# Architecture
 
-## レイヤド設計
+## Layered Design
 - `backend/src/api/` → `backend/src/service/` → `backend/src/repository/` → `backend/src/model/`
-- Pydanticスキーマ: `backend/src/schema/`
-- エントリーポイント: `backend/src/main.py`
-- 設定: `backend/src/config.py`
+- Pydantic schemas: `backend/src/schema/`
+- Entry point: `backend/src/main.py`
+- Configuration: `backend/src/config.py`
 
-## ディレクトリ構造
+## Directory Structure
 ```
 burn-style/
 ├── backend/
 │   ├── src/
-│   │   ├── api/          # ルーター・エンドポイント定義
-│   │   ├── service/      # ビジネスロジック
-│   │   ├── repository/   # DB操作
-│   │   ├── model/        # SQLAlchemyモデル
-│   │   ├── schema/       # Pydanticスキーマ
-│   │   ├── config.py     # 環境設定
-│   │   └── main.py       # FastAPIアプリ初期化
-│   ├── alembic/          # マイグレーション
-│   └── scripts/          # seedスクリプト等
+│   │   ├── api/          # Router & endpoint definitions
+│   │   ├── service/      # Business logic
+│   │   ├── repository/   # DB operations
+│   │   ├── model/        # SQLAlchemy models
+│   │   ├── schema/       # Pydantic schemas
+│   │   ├── config.py     # Environment settings
+│   │   └── main.py       # FastAPI app initialization
+│   ├── alembic/          # Migrations
+│   └── scripts/          # Seed scripts, etc.
 ├── frontend/
-│   └── src/              # Reactアプリ
+│   └── src/              # React app
 ├── .github/workflows/    # GitHub Actions
-├── Makefile              # 開発コマンド
-└── docker-compose.yml    # ローカル開発環境
+├── Makefile              # Development commands
+└── docker-compose.yml    # Local development environment
 ```
 
-## 認証
-- WebAuthn/パスキーによるパスワードレス認証
-- JWT (JSON Web Token) によるセッション管理
-- 関連モデル: `User`, `WebAuthnCredential`
+## Authentication
+- Passwordless authentication via WebAuthn/Passkey
+- Session management via JWT (JSON Web Token)
+- Related models: `User`, `WebAuthnCredential`

--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -1,70 +1,70 @@
-# 認証
+# Authentication
 
-## 概要
+## Overview
 
-パスワードレス認証を採用。WebAuthn/パスキーでユーザー認証し、JWTでセッション管理。
+Passwordless authentication. User authentication via WebAuthn/passkeys, session management via JWT.
 
-## 認証フロー
+## Authentication Flow
 
-### 1. パスキー登録
+### 1. Passkey Registration
 
 ```
 Client                        Server
   │                              │
-  ├─ POST /auth/register/options ─→│ (username送信)
-  │                              ├─ WebAuthn options生成
-  │                              ├─ Challenge保存 (TTL 5分)
+  ├─ POST /auth/register/options ─→│ (send username)
+  │                              ├─ Generate WebAuthn options
+  │                              ├─ Store challenge (TTL 5 min)
   │←─────── options ─────────────┤
-  ├─ パスキー生成 (ブラウザ)       │
-  ├─ POST /auth/register/verify ──→│ (credential送信)
-  │                              ├─ Challenge検証
-  │                              ├─ User + Credential作成
+  ├─ Generate passkey (browser)    │
+  ├─ POST /auth/register/verify ──→│ (send credential)
+  │                              ├─ Verify challenge
+  │                              ├─ Create User + Credential
   │←─────── { message } ─────────┤
 ```
 
-### 2. パスキー認証
+### 2. Passkey Authentication
 
 ```
 Client                        Server
   │                              │
-  ├─ POST /auth/signin/options ──→│ (username送信)
-  │                              ├─ WebAuthn options生成
-  │                              ├─ Challenge保存 (TTL 5分)
+  ├─ POST /auth/signin/options ──→│ (send username)
+  │                              ├─ Generate WebAuthn options
+  │                              ├─ Store challenge (TTL 5 min)
   │←─────── options ─────────────┤
-  ├─ パスキー認証 (ブラウザ)       │
-  ├─ POST /auth/signin/verify ───→│ (credential送信)
-  │                              ├─ Challenge検証
-  │                              ├─ sign_count更新
-  │                              ├─ JWT生成
+  ├─ Authenticate passkey (browser)│
+  ├─ POST /auth/signin/verify ───→│ (send credential)
+  │                              ├─ Verify challenge
+  │                              ├─ Update sign_count
+  │                              ├─ Generate JWT
   │←─── { access_token } ────────┤
 ```
 
-### 3. 認証済みリクエスト
+### 3. Authenticated Request
 
 ```
 Client                        Server
   │                              │
   ├─ GET /expenses ──────────────→│ (Authorization: Bearer <JWT>)
-  │                              ├─ JWT検証
-  │                              ├─ ユーザー取得
-  │                              ├─ 新JWT生成
+  │                              ├─ Verify JWT
+  │                              ├─ Get user
+  │                              ├─ Generate new JWT
   │←─── data + X-New-Token ──────┤
-  ├─ トークン更新 (localStorage)   │
+  ├─ Update token (localStorage)   │
 ```
 
-## JWT仕様
+## JWT Specification
 
-| 項目 | 値 |
-|------|-----|
-| アルゴリズム | HS256 |
-| 有効期限 | 15分 |
-| ペイロード | `{ sub: user_uuid, exp }` |
-| リフレッシュ | リクエスト毎に`X-New-Token`ヘッダーで自動再発行 |
+| Item | Value |
+|------|-------|
+| Algorithm | HS256 |
+| Expiration | 15 minutes |
+| Payload | `{ sub: user_uuid, exp }` |
+| Refresh | Auto-reissued via `X-New-Token` header on every request |
 
-## セキュリティ
+## Security
 
 - **SecurityHeadersMiddleware**: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`
-- **CORS**: フロントエンドオリジンのみ許可
-- **JWT秘密鍵**: 本番環境では32文字以上必須
-- **Challenge TTL**: 5分で自動失効
-- **401時**: クライアント側で自動的に`/signin`へリダイレクト
+- **CORS**: Only frontend origin allowed
+- **JWT Secret Key**: Must be 32+ characters in production
+- **Challenge TTL**: Auto-expires after 5 minutes
+- **On 401**: Client automatically redirects to `/signin`

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,25 +1,25 @@
-# バックエンド規約
+# Backend Conventions
 
-## 技術スタック
-- **言語**: Python 3.14
-- **パッケージ管理**: uv
-- **フレームワーク**: FastAPI
+## Tech Stack
+- **Language**: Python 3.14
+- **Package Manager**: uv
+- **Framework**: FastAPI
 - **ORM**: SQLAlchemy 2.x
-- **バリデーション**: Pydantic
-- **型チェック**: mypy (strict モード)
-- **リンター/フォーマッター**: ruff (行長120文字)
+- **Validation**: Pydantic
+- **Type Checker**: mypy (strict mode)
+- **Linter/Formatter**: ruff (line length 120)
 
-## コーディング規約
-- `from __future__ import annotations` を各ファイル先頭に追加
-- **UUID**: uuid6 (v7) を使用、32文字ハイフンなし
-- **削除**: 論理削除 (`deleted_at` カラム)
-- `scripts/` 配下のみ `print()` 使用可
-- `.env` はコミット禁止（`.env.template` を使用）
+## Coding Conventions
+- Add `from __future__ import annotations` at the top of each file
+- **UUID**: Use uuid6 (v7), 32 characters without hyphens
+- **Deletion**: Soft delete (`deleted_at` column)
+- `print()` is only allowed in `scripts/` directory
+- `.env` must not be committed (use `.env.template` instead)
 
 ## mypy
-- strict モード必須
-- 型アノテーションを全関数・変数に付与
+- Strict mode required
+- Type annotations on all functions and variables
 
 ## ruff
-- 行長: 120文字
-- `ruff check --fix .` で自動修正
+- Line length: 120
+- Auto-fix with `ruff check --fix .`

--- a/.claude/rules/commands.md
+++ b/.claude/rules/commands.md
@@ -1,30 +1,30 @@
-# 開発コマンド
+# Development Commands
 
-## 起動
-| コマンド | 説明 |
-|---------|------|
-| `docker compose watch` | ローカル開発起動（ホットリロード） |
+## Startup
+| Command | Description |
+|---------|-------------|
+| `docker compose watch` | Start local development (hot reload) |
 
 ## Lint
-| コマンド | 説明 |
-|---------|------|
-| `make lint` | backend (mypy + ruff) + frontend (oxlint + oxfmt) 実行 |
+| Command | Description |
+|---------|-------------|
+| `make lint` | Run backend (mypy + ruff) + frontend (oxlint + oxfmt) |
 
-## テスト
-| コマンド | 説明 |
-|---------|------|
-| `make test-backend` | backendのテスト実行 |
+## Test
+| Command | Description |
+|---------|-------------|
+| `make test-backend` | Run backend tests |
 
-## データベース（ローカル）
-| コマンド | 説明 |
-|---------|------|
-| `make upgrade` | マイグレーション適用 |
-| `make downgrade` | 1つ前にダウングレード |
-| `make seed` | seedデータ投入（`SEED_USER="名前"` でユーザー指定可） |
-| `make db-clear` | DB完全クリア（volumes削除） |
-| `make db-connect` | PostgreSQL CLIに接続 |
+## Database (Local)
+| Command | Description |
+|---------|-------------|
+| `make upgrade` | Apply migrations |
+| `make downgrade` | Downgrade by one revision |
+| `make seed` | Insert seed data (specify user with `SEED_USER="name"`) |
+| `make db-clear` | Clear DB completely (delete volumes) |
+| `make db-connect` | Connect to PostgreSQL CLI |
 
-## データベース（本番 Neon）
-| コマンド | 説明 |
-|---------|------|
-| `make prod-upgrade` | 本番DBにマイグレーション実行 |
+## Database (Production - Neon)
+| Command | Description |
+|---------|-------------|
+| `make prod-upgrade` | Run migrations on production DB |

--- a/.claude/rules/concept.md
+++ b/.claude/rules/concept.md
@@ -1,37 +1,37 @@
-# プロダクトコンセプト
+# Product Concept
 
-## ビジョン
+## Vision
 
-**支出のみを管理して、ユーザーの個性を可視化する手助けをする**
+**Track only expenses to help users visualize their individuality**
 
-収入や資産管理は扱わず、「何にお金を使っているか」に特化。
-支出パターンから自分自身の価値観や生活スタイルを客観的に把握できる。
+No income or asset management — focused solely on "what you spend money on."
+Understand your own values and lifestyle objectively through spending patterns.
 
-## ターゲットユーザー
+## Target Users
 
-- 個人利用（組織・チーム向けではない）
-- 自分の消費傾向を知りたい人
-- 複雑な家計簿が続かなかった人
+- Personal use (not for organizations or teams)
+- People who want to understand their spending habits
+- People who couldn't keep up with complex budgeting apps
 
-## 設計思想
+## Design Philosophy
 
-### シンプルなUIで直感的な操作
+### Simple UI with Intuitive Interaction
 
-- 最小限の入力項目（名前・金額・日時・カテゴリ）
-- ワンタップで支出を記録
-- パスワードレス認証（パスキー）でログインの手間を排除
+- Minimal input fields (name, amount, date, category)
+- Record an expense with a single tap
+- Passwordless authentication (passkeys) to eliminate login friction
 
-### 可視化による気づき
+### Insights Through Visualization
 
-- 月別・年別の推移トレンド
-- カテゴリ別の支出割合
-- ヒートマップで日別の消費パターン
-- バブルチャートで金額帯の分布
+- Monthly and annual trend charts
+- Category-based spending breakdown
+- Heatmap for daily spending patterns
+- Bubble chart for amount range distribution
 
-### やらないこと
+### Out of Scope
 
-- 収入管理
-- 資産管理・口座連携
-- 予算設定・アラート
-- チーム・家族での共有機能
-- 広告表示
+- Income management
+- Asset management / bank account linking
+- Budget setting / alerts
+- Team or family sharing
+- Advertisements

--- a/.claude/rules/data-model.md
+++ b/.claude/rules/data-model.md
@@ -1,6 +1,6 @@
-# データモデル
+# Data Model
 
-## ER図（概要）
+## ER Diagram (Overview)
 
 ```
 User (1) ──── (N) WebAuthnCredential
@@ -14,12 +14,12 @@ User (1) ──── (N) WebAuthnCredential
   └── (1) ──── (N) ExpenseTemplate ──── (N:1) Category
 ```
 
-## テーブル定義
+## Table Definitions
 
 ### users
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | uuid | String(32) | PK, UUID v7 |
 | name | String | UNIQUE, NOT NULL |
 | created_at | DateTime(UTC) | |
@@ -27,29 +27,29 @@ User (1) ──── (N) WebAuthnCredential
 
 ### webauthn_credentials
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | uuid | String(32) | PK |
 | user_uuid | String(32) | FK → users.uuid, CASCADE |
 | credential_id | LargeBinary | UNIQUE, NOT NULL |
 | credential_public_key | LargeBinary | NOT NULL |
 | sign_count | Integer | default 0 |
-| transports | Text | nullable, JSON文字列 |
+| transports | Text | nullable, JSON string |
 | created_at | DateTime(UTC) | |
 | updated_at | DateTime(UTC) | |
 
 ### categories
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | uuid | String(32) | PK |
 | user_uuid | String(32) | FK → users.uuid, CASCADE |
 | name | String | NOT NULL |
 
 ### expenses
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | uuid | String(32) | PK |
 | user_uuid | String(32) | FK → users.uuid, CASCADE |
 | name | String | NOT NULL |
@@ -57,22 +57,22 @@ User (1) ──── (N) WebAuthnCredential
 | expensed_at | DateTime(UTC) | default now() |
 | created_at | DateTime(UTC) | |
 | updated_at | DateTime(UTC) | |
-| deleted_at | DateTime | nullable（論理削除） |
+| deleted_at | DateTime | nullable (soft delete) |
 
 ### expense_category_association
 
-支出とカテゴリの多対多中間テーブル。
+Many-to-many join table between expenses and categories.
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | expense_uuid | String(32) | PK, FK → expenses.uuid, CASCADE |
 | category_uuid | String(32) | PK, FK → categories.uuid, CASCADE |
 | created_at | DateTime(UTC) | |
 
 ### expense_templates
 
-| カラム | 型 | 制約 |
-|--------|-----|------|
+| Column | Type | Constraints |
+|--------|------|-------------|
 | uuid | String(32) | PK |
 | user_uuid | String(32) | FK → users.uuid, CASCADE |
 | name | String | NOT NULL |
@@ -80,11 +80,11 @@ User (1) ──── (N) WebAuthnCredential
 | category_uuid | String(32) | FK → categories.uuid, CASCADE |
 | created_at | DateTime(UTC) | |
 | updated_at | DateTime(UTC) | |
-| deleted_at | DateTime | nullable（論理削除） |
+| deleted_at | DateTime | nullable (soft delete) |
 
-## 設計方針
+## Design Principles
 
-- **UUID v7**: 時系列ソート可能なID生成（uuid6ライブラリ）
-- **論理削除**: expenses, expense_templatesは`deleted_at`による論理削除
-- **CASCADE削除**: ユーザー削除時に関連データを全削除
-- **タイムゾーン**: DB保存はUTC、アプリケーション層でJST変換
+- **UUID v7**: Time-sortable ID generation (uuid6 library)
+- **Soft Delete**: expenses and expense_templates use `deleted_at` for soft deletion
+- **CASCADE Delete**: All related data deleted when user is deleted
+- **Timezone**: Stored in UTC, converted to JST at the application layer

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,20 +1,20 @@
-# データベース規約
+# Database Conventions
 
-## 技術スタック
+## Tech Stack
 - **DB**: PostgreSQL
 - **ORM**: SQLAlchemy 2.x
-- **マイグレーション**: Alembic (autogenerate)
+- **Migration**: Alembic (autogenerate)
 
-## 接続先切替
-- `VERCEL_ENV=production` → Neon（本番）
-- それ以外 → ローカルDocker
+## Connection Switching
+- `VERCEL_ENV=production` → Neon (production)
+- Otherwise → Local Docker
 
-## ローカル開発
-- `docker compose up -d db` でPostgreSQL起動
-- `docker compose watch` で全サービス起動（ホットリロード対応）
-- `docker compose exec db sh -c 'psql -U $POSTGRES_USER $POSTGRES_DB'` でCLI接続
+## Local Development
+- Start PostgreSQL with `docker compose up -d db`
+- Start all services with hot reload via `docker compose watch`
+- Connect to CLI with `docker compose exec db sh -c 'psql -U $POSTGRES_USER $POSTGRES_DB'`
 
 ## Alembic
-- `--autogenerate` でモデルからマイグレーション自動生成
-- マイグレーションファイル: `backend/alembic/versions/`
-- `db-reset` 時はversionsディレクトリをクリアして再生成
+- Auto-generate migrations from models with `--autogenerate`
+- Migration files: `backend/alembic/versions/`
+- On `db-reset`, clear the versions directory and regenerate

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -1,6 +1,6 @@
-# 開発フロー
+# Development Flow
 
-## 必須プロセス
-- コード修正後は必ず `make lint` と `make test-backend` を実行
-- エラーがあれば全て修正してから完了とする
-- ファイル変更後は commit & push まで実行する
+## Required Process
+- Always run `make lint` and `make test-backend` after code changes
+- Fix all errors before considering the task complete
+- Commit and push after file changes

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,32 +1,32 @@
-# フロントエンド規約
+# Frontend Conventions
 
-## 技術スタック
-- **言語**: TypeScript 5.9
-- **UIライブラリ**: React 19
-- **ビルドツール**: Vite 8
+## Tech Stack
+- **Language**: TypeScript 5.9
+- **UI Library**: React 19
+- **Build Tool**: Vite 8
 - **CSS**: Tailwind CSS v4
-- **UIコンポーネント**: Radix UI Themes
-- **リンター**: oxlint
-- **フォーマッター**: oxfmt
+- **UI Components**: Radix UI Themes
+- **Linter**: oxlint
+- **Formatter**: oxfmt
 
-## oxlint 設定
-- correctness + suspicious カテゴリ有効
+## oxlint Configuration
+- correctness + suspicious categories enabled
 
-## oxfmt 設定
-- インデント: スペース
-- クォート: ダブルクォート (`"`)
-- セミコロン: なし（ASI保護時のみ自動付与）
-- import自動整理: 有効
+## oxfmt Configuration
+- Indent: spaces
+- Quotes: double quotes (`"`)
+- Semicolons: none (auto-inserted only for ASI protection)
+- Auto import sorting: enabled
 
 ## Tailwind CSS v4
-- Viteプラグイン (`@tailwindcss/vite`) で統合
-- CSS-firstの設定（`tailwind.config.js` 不要）
+- Integrated via Vite plugin (`@tailwindcss/vite`)
+- CSS-first configuration (`tailwind.config.js` not required)
 
-## コーディング規約
-- 関数定義はアロー関数 (`const fn = () => {}`) を使用（`function` 宣言は不可）
-- 型定義は可能な限り `interface` を使用（`type` は union型等 `interface` で表現できない場合のみ）
-- named export に統一（`export default` は使用しない）
+## Coding Conventions
+- Use arrow functions for function definitions (`const fn = () => {}`) — `function` declarations are not allowed
+- Prefer `interface` for type definitions — use `type` only when `interface` cannot express it (e.g., union types)
+- Use named exports only — `export default` is not allowed
 
-## ビルド
-- `tsc -b && vite build` でビルド
-- `vite` で開発サーバー起動
+## Build
+- Build with `tsc -b && vite build`
+- Start dev server with `vite`

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,21 +1,21 @@
-# Git・デプロイ規約
+# Git & Deploy Guidelines
 
-## コミットメッセージ
-- Conventional Commits形式: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:` 等
-- 日本語で記述
+## Commit Messages
+- Conventional Commits format: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, etc.
+- Written in English
 
-## デプロイ
-- **プラットフォーム**: Vercel
-- **トリガー**: GitHub Actions `workflow_dispatch`（手動実行）
-- **環境**: production / preview を選択可能
+## Deploy
+- **Platform**: Vercel
+- **Trigger**: GitHub Actions `workflow_dispatch` (manual execution)
+- **Environments**: production / preview selectable
 
-## GitHub Actions ワークフロー
-| ファイル | 対象 |
-|---------|------|
-| `deploy_backend.yml` | バックエンドデプロイ |
-| `deploy_frontend.yml` | フロントエンドデプロイ |
+## GitHub Actions Workflows
+| File | Target |
+|------|--------|
+| `deploy_backend.yml` | Backend deploy |
+| `deploy_frontend.yml` | Frontend deploy |
 
-## デプロイフロー
-1. GitHubのActionsタブから手動実行
-2. 環境（production / preview）を選択
-3. Vercel CLIでビルド＆デプロイ
+## Deploy Flow
+1. Manually trigger from GitHub Actions tab
+2. Select environment (production / preview)
+3. Build & deploy via Vercel CLI

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -1,53 +1,53 @@
-# インフラ・デプロイ
+# Infrastructure & Deploy
 
-## 技術スタック
+## Tech Stack
 
-| レイヤー | 技術 |
-|---------|------|
-| フロントエンド | React 19 + Vite 8 + TypeScript 5.9 + Tailwind CSS v4 |
-| バックエンド | FastAPI + SQLAlchemy 2.x + Python 3.14 |
-| データベース | PostgreSQL 18 |
-| パッケージ管理 | npm (frontend) / uv (backend) |
-| リンター | oxlint + oxfmt (frontend) / ruff + mypy strict (backend) |
-| 認証 | WebAuthn + JWT |
-| デプロイ | Vercel |
+| Layer | Technology |
+|-------|------------|
+| Frontend | React 19 + Vite 8 + TypeScript 5.9 + Tailwind CSS v4 |
+| Backend | FastAPI + SQLAlchemy 2.x + Python 3.14 |
+| Database | PostgreSQL 18 |
+| Package Manager | npm (frontend) / uv (backend) |
+| Linter | oxlint + oxfmt (frontend) / ruff + mypy strict (backend) |
+| Authentication | WebAuthn + JWT |
+| Deploy | Vercel |
 | CI/CD | GitHub Actions |
 
-## ローカル開発環境
+## Local Development Environment
 
-### Docker Compose構成
+### Docker Compose Configuration
 
-| サービス | イメージ | ポート |
-|---------|---------|--------|
+| Service | Image | Port |
+|---------|-------|------|
 | backend | Python 3.14-slim + uvicorn | 9999 |
 | frontend | Node 22-slim + Vite | 5173 |
 | db | PostgreSQL 18 | 5432 |
 
-### ホットリロード
+### Hot Reload
 
-`docker compose watch` で以下を自動同期:
+Auto-sync with `docker compose watch`:
 
-| サービス | 同期対象 | アクション |
-|---------|---------|-----------|
+| Service | Sync Target | Action |
+|---------|-------------|--------|
 | backend | `src/`, `pyproject.toml`, `uv.lock` | sync |
 | backend | `Dockerfile` | rebuild |
 | frontend | `src/`, `public/`, `index.html` | sync |
 | frontend | `package.json` | rebuild |
 
-## デプロイ
+## Deploy
 
-### プラットフォーム
+### Platform
 
-Vercel（バックエンド・フロントエンドともに）
+Vercel (both backend and frontend)
 
-本番DB: Neon (PostgreSQL)
+Production DB: Neon (PostgreSQL)
 
-### CI/CDワークフロー
+### CI/CD Workflow
 
-手動実行（`workflow_dispatch`）で環境を選択。
+Environment selected via manual execution (`workflow_dispatch`).
 
 ```
-deploy.yml (統合)
+deploy.yml (unified)
   ├─ deploy_backend.yml
   │     ├─ lint-and-test (mypy + ruff + pytest)
   │     └─ deploy (Vercel CLI)
@@ -56,38 +56,38 @@ deploy.yml (統合)
         └─ deploy (Vercel CLI)
 ```
 
-### 環境
+### Environments
 
-| 環境 | 用途 |
-|------|------|
-| production | 本番（`--prod`フラグ） |
-| preview | プレビュー |
+| Environment | Purpose |
+|-------------|---------|
+| production | Production (`--prod` flag) |
+| preview | Preview |
 
-## 環境変数
+## Environment Variables
 
-### ローカル専用
+### Local Only
 
-| 変数 | 用途 |
-|------|------|
-| `API_PORT` | バックエンドポート（9999） |
-| `POSTGRES_USER` / `PASSWORD` / `DB` | DB接続情報 |
-| `POSTGRES_PORT` | DBポート（5432） |
-| `DATABASE_URL` | DB接続URL |
-| `FRONTEND_PORT` | フロントエンドポート（5173） |
+| Variable | Purpose |
+|----------|---------|
+| `API_PORT` | Backend port (9999) |
+| `POSTGRES_USER` / `PASSWORD` / `DB` | DB connection info |
+| `POSTGRES_PORT` | DB port (5432) |
+| `DATABASE_URL` | DB connection URL |
+| `FRONTEND_PORT` | Frontend port (5173) |
 
-### ローカル + 本番
+### Local + Production
 
-| 変数 | 用途 |
-|------|------|
-| `JWT_SECRET_KEY` | JWT署名用秘密鍵 |
+| Variable | Purpose |
+|----------|---------|
+| `JWT_SECRET_KEY` | JWT signing secret key |
 | `WEBAUTHN_RP_ID` | WebAuthn RP ID |
-| `WEBAUTHN_RP_NAME` | WebAuthn RP名 |
-| `FRONTEND_ORIGIN` | CORSオリジン |
+| `WEBAUTHN_RP_NAME` | WebAuthn RP name |
+| `FRONTEND_ORIGIN` | CORS origin |
 
-### 本番専用
+### Production Only
 
-| 変数 | 用途 |
-|------|------|
-| `VITE_API_URL` | APIエンドポイントURL |
-| `POSTGRES_URL` | Neon DB接続URL |
-| `VERCEL_ENV` | `production`で本番DB接続 |
+| Variable | Purpose |
+|----------|---------|
+| `VITE_API_URL` | API endpoint URL |
+| `POSTGRES_URL` | Neon DB connection URL |
+| `VERCEL_ENV` | Connect to production DB with `production` |

--- a/.claude/rules/screens.md
+++ b/.claude/rules/screens.md
@@ -1,57 +1,57 @@
-# 画面構成
+# Screen Structure
 
-## 画面遷移フロー
+## Screen Transition Flow
 
 ```
-/signup (パスキー登録)
-    ↓ 登録成功
-/signin (パスキー認証)
-    ↓ 認証成功
-/ (ダッシュボード)
-    ├─ /expense/monthly (月別分析)
-    │     └─ /expense/:uuid (支出編集)
-    ├─ /expense/annual (年別分析)
-    ├─ /expense/new (支出作成)
-    ├─ /category (カテゴリ管理)
-    └─ /setting (ユーザー設定)
+/signup (Passkey Registration)
+    ↓ Registration success
+/signin (Passkey Authentication)
+    ↓ Authentication success
+/ (Dashboard)
+    ├─ /expense/monthly (Monthly Analysis)
+    │     └─ /expense/:uuid (Expense Edit)
+    ├─ /expense/annual (Annual Analysis)
+    ├─ /expense/new (New Expense)
+    ├─ /category (Category Management)
+    └─ /setting (User Settings)
 ```
 
-## レイアウト
+## Layout
 
-| 画面幅 | ナビゲーション |
-|--------|---------------|
-| デスクトップ (768px以上) | 左サイドバー（w-56） |
-| モバイル (768px未満) | 下部フッター（h-20） |
+| Screen Width | Navigation |
+|-------------|------------|
+| Desktop (768px+) | Left sidebar (w-56) |
+| Mobile (< 768px) | Bottom footer (h-20) |
 
-## 画面一覧
+## Screen List
 
-### 認証
+### Authentication
 
-| 画面 | パス | 機能 |
-|------|------|------|
-| サインアップ | `/signup` | パスキー登録 → /signin へ遷移 |
-| サインイン | `/signin` | パスキー認証 → JWT取得 → / へ遷移 |
+| Screen | Path | Function |
+|--------|------|----------|
+| Sign Up | `/signup` | Passkey registration → navigate to /signin |
+| Sign In | `/signin` | Passkey authentication → get JWT → navigate to / |
 
-### メイン（認証必須）
+### Main (Authentication Required)
 
-| 画面 | パス | 機能 |
-|------|------|------|
-| ダッシュボード | `/` | 当月の支出合計・カテゴリ別円グラフ・年間棒グラフ |
-| 支出作成 | `/expense/new` | 名前・金額・日時・カテゴリを入力して支出を登録 |
-| 支出詳細 | `/expense/:uuid` | 支出の編集・削除 |
-| 月別分析 | `/expense/monthly` | 4つのタブ（リスト / 円グラフ / ヒートマップ / バブルチャート） |
-| 年別分析 | `/expense/annual` | 3つのタブ（リスト / エリアチャート / ラインチャート） |
-| カテゴリ管理 | `/category` | カテゴリの作成・編集・削除 |
-| 設定 | `/setting` | ユーザー名編集・データエクスポート・ログアウト・アカウント削除 |
+| Screen | Path | Function |
+|--------|------|----------|
+| Dashboard | `/` | Current month total, category pie chart, annual bar chart |
+| New Expense | `/expense/new` | Register expense with name, amount, date, category |
+| Expense Detail | `/expense/:uuid` | Edit / delete expense |
+| Monthly Analysis | `/expense/monthly` | 4 tabs (List / Pie Chart / Heatmap / Bubble Chart) |
+| Annual Analysis | `/expense/annual` | 3 tabs (List / Area Chart / Line Chart) |
+| Category Management | `/category` | Create / edit / delete categories |
+| Settings | `/setting` | Edit username, data export, logout, delete account |
 
-## データ可視化
+## Data Visualization
 
-| チャート | 画面 | 用途 |
-|---------|------|------|
-| 円グラフ（小） | ダッシュボード | 当月カテゴリ別割合 |
-| 棒グラフ | ダッシュボード | 直近12ヶ月の推移 |
-| 円グラフ（大） | 月別分析 | カテゴリ別支出額・割合 |
-| ヒートマップ | 月別分析 | 日別の支出強度 |
-| バブルチャート | 月別分析 | 金額帯ごとの頻度・合計 |
-| エリアチャート | 年別分析 | カテゴリ別月次推移（積み上げ） |
-| ラインチャート | 年別分析 | カテゴリ別月次推移（個別） |
+| Chart | Screen | Purpose |
+|-------|--------|---------|
+| Pie Chart (small) | Dashboard | Current month category breakdown |
+| Bar Chart | Dashboard | Last 12 months trend |
+| Pie Chart (large) | Monthly Analysis | Category-based amount and ratio |
+| Heatmap | Monthly Analysis | Daily spending intensity |
+| Bubble Chart | Monthly Analysis | Frequency and total by amount range |
+| Area Chart | Annual Analysis | Stacked category monthly trend |
+| Line Chart | Annual Analysis | Individual category monthly trend |

--- a/README.md
+++ b/README.md
@@ -2,22 +2,19 @@
 
 > **Burn** your money, show your **Style**.
 
-お金の使い方には、その人の個性が宿る。
+How you spend money reveals who you are.
 
-収入は環境が決める。だが支出は自分が決める。
+Income is shaped by circumstance. But spending is shaped by choice.
 
-同じ収入でも何に使うかは人によってまるで違う。
-コーヒーに月1万円使う人と、本に月1万円使う人は、同じ金額でもまったく別の人生を歩いている。
+Two people with the same income can live entirely different lives — one spends ¥10,000 a month on coffee, another on books. Same amount, different stories.
 
-支出とは、日々繰り返される小さな意思決定の集積。
-何を買い、何を買わないか。その選択の連なりが、言語化されない価値観を映す。
+Spending is the accumulation of small, daily decisions. What you buy and what you don't — that chain of choices reflects values you may never put into words.
 
-「節約」ではなく「発見」。
-BurnStyleは支出を減らすためのツールではない。
-自分が何に価値を感じているのかを知るためのツール。
-削るべき無駄を見つけるのではなく、自分だけの消費の輪郭を眺める。
+Not "saving." Discovery.
+BurnStyle is not a tool for cutting expenses. It's a tool for understanding what you truly value.
+Not finding waste to eliminate, but observing the contours of your own consumption.
 
-自分のことは自分が一番よく知っている？
-あなたの支出が語る物語を、あなたはまだ読んでいない。
+You think you know yourself best?
+The story your spending tells — you haven't read it yet.
 
-お金の燃やし方に、あなたのスタイルが宿る。
+Your style lives in the way you burn.

--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -44,7 +44,7 @@ def register_options(
     body: RegisterOptionsRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> RegisterOptionsResponse:
-    """登録オプション生成"""
+    """Generate registration options."""
     existing = get_user_by_name(db, body.name)
     if existing is not None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Registration failed")
@@ -66,7 +66,7 @@ def register_verify(
     body: RegisterVerifyRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> RegisterVerifyResponse:
-    """登録検証 → ユーザー+クレデンシャル作成"""
+    """Verify registration and create user + credential."""
     challenge = challenge_store.get(body.name)
     if challenge is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Challenge not found or expired")
@@ -104,7 +104,7 @@ def sign_in_options(
     body: SignInOptionsRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> SignInOptionsResponse:
-    """認証オプション生成"""
+    """Generate authentication options."""
     user = get_user_by_name(db, body.name)
     if user is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authentication failed")
@@ -137,7 +137,7 @@ def sign_in_verify(
     body: SignInVerifyRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> SignInVerifyResponse:
-    """認証検証 → JWTトークン返却"""
+    """Verify authentication and return JWT token."""
     challenge = challenge_store.get(body.name)
     if challenge is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Challenge not found or expired")

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -18,7 +18,7 @@ def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     db: Annotated[Session, Depends(get_db)],
 ) -> User:
-    """JWTトークンからユーザーを取得"""
+    """Retrieve the current user from the JWT token."""
     try:
         payload = decode_access_token(credentials.credentials)
     except Exception:

--- a/backend/src/api/expense_templates.py
+++ b/backend/src/api/expense_templates.py
@@ -145,4 +145,4 @@ def bulk_record(
 
     db.commit()
 
-    return BulkRecordResponse(created_count=len(templates), message=f"{len(templates)}件の支出を記帳しました")
+    return BulkRecordResponse(created_count=len(templates), message=f"Recorded {len(templates)} expenses")

--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -25,7 +25,7 @@ user_router = APIRouter(tags=["users"])
 
 @user_router.get("/me")
 def me(current_user: Annotated[User, Depends(get_current_user)]) -> UserResponse:
-    """現在のユーザー情報を返す"""
+    """Return current user info."""
     return UserResponse.model_validate(current_user)
 
 
@@ -35,7 +35,7 @@ def update_me(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> UserResponse:
-    """現在のユーザー情報を更新"""
+    """Update current user info."""
     updated = update_user(db, current_user, body.name)
     return UserResponse.model_validate(updated)
 
@@ -45,7 +45,7 @@ def export_me(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> UserExportResponse:
-    """現在のユーザーの全データをエクスポート"""
+    """Export all data of the current user."""
     user_uuid = str(current_user.uuid)
     categories = get_all_categories(db, user_uuid)
     expenses = get_all_expenses(db, user_uuid, include_deleted=True)
@@ -62,10 +62,10 @@ def import_me(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> UserImportResponse:
-    """エクスポートしたJSONデータをインポート"""
+    """Import exported JSON data."""
     user_uuid = str(current_user.uuid)
 
-    # 既存データを削除(FK制約を考慮した順序)
+    # Delete existing data (ordered by FK constraints)
     db.query(ExpenseCategoryAssociation).filter(
         ExpenseCategoryAssociation.expense_uuid.in_(
             db.query(Expense.uuid).filter(Expense.user_uuid == user_uuid),
@@ -75,7 +75,7 @@ def import_me(
     db.query(Expense).filter(Expense.user_uuid == user_uuid).delete(synchronize_session=False)
     db.query(Category).filter(Category.user_uuid == user_uuid).delete(synchronize_session=False)
 
-    # カテゴリをインポート(旧UUID -> 新UUIDのマッピング)
+    # Import categories (old UUID -> new UUID mapping)
     category_uuid_map: dict[str, str] = {}
     for cat in body.categories:
         new_category = Category(user_uuid=user_uuid, name=cat.name)
@@ -83,7 +83,7 @@ def import_me(
         db.flush()
         category_uuid_map[cat.uuid] = str(new_category.uuid)
 
-    # 支出をインポート
+    # Import expenses
     for exp in body.expenses:
         expense = Expense(
             user_uuid=user_uuid,
@@ -116,5 +116,5 @@ def delete_me(
     current_user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> None:
-    """現在のユーザーを削除"""
+    """Delete the current user."""
     delete_user(db, current_user)

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -6,7 +6,7 @@ _JWT_SECRET_MIN_LENGTH = 32
 
 
 def get_jwt_secret_key() -> str:
-    """JWT署名用の秘密鍵を取得"""
+    """Get the JWT signing secret key."""
     value = os.getenv("JWT_SECRET_KEY")
     if value is None:
         raise ValueError("JWT_SECRET_KEY environment variable is not set.")
@@ -17,15 +17,15 @@ def get_jwt_secret_key() -> str:
 
 
 def get_webauthn_rp_id() -> str:
-    """WebAuthn Relying Party IDを取得"""
+    """Get the WebAuthn Relying Party ID."""
     return os.getenv("WEBAUTHN_RP_ID", "localhost")
 
 
 def get_webauthn_rp_name() -> str:
-    """WebAuthn Relying Party名を取得"""
+    """Get the WebAuthn Relying Party name."""
     return os.getenv("WEBAUTHN_RP_NAME", "BurnStyle")
 
 
 def get_frontend_origin() -> str:
-    """フロントエンドのオリジンを取得"""
+    """Get the frontend origin URL."""
     return os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -17,7 +17,7 @@ from src.middleware import TokenRefreshMiddleware
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """セキュリティヘッダーを付与するミドルウェア"""
+    """Middleware that adds security headers."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
@@ -28,8 +28,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 app = FastAPI(title="BurnStyle API", version="1.0.0")
 
-# ミドルウェア(後から追加したものが外側になる)
-# リクエスト順: CORS → SecurityHeaders → TokenRefresh → ルーター
+# Middleware (later additions wrap outer layers)
+# Request order: CORS -> SecurityHeaders -> TokenRefresh -> Router
 app.add_middleware(TokenRefreshMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(
@@ -41,7 +41,7 @@ app.add_middleware(
     expose_headers=["X-New-Token"],
 )
 
-# ルーターを登録
+# Register routers
 app.include_router(health_router)
 app.include_router(auth_router)
 app.include_router(category_router)

--- a/backend/src/middleware/token_refresh.py
+++ b/backend/src/middleware/token_refresh.py
@@ -8,7 +8,7 @@ from src.service.jwt_service import create_access_token, decode_access_token
 
 
 class TokenRefreshMiddleware(BaseHTTPMiddleware):
-    """認証済みリクエスト毎にJWTを再発行してレスポンスヘッダーに付与"""
+    """Reissue JWT on each authenticated request and set it in the response header."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)

--- a/backend/src/model/category.py
+++ b/backend/src/model/category.py
@@ -16,7 +16,7 @@ class Category(Base):
 
     user = relationship("User")
 
-    # 多対多の関係
+    # Many-to-many relationship
     expenses = relationship(
         "Expense",
         secondary="expense_category_association",

--- a/backend/src/model/expense.py
+++ b/backend/src/model/expense.py
@@ -28,7 +28,7 @@ class Expense(Base):
 
     user = relationship("User")
 
-    # 多対多の関係
+    # Many-to-many relationship
     categories = relationship(
         "Category",
         secondary="expense_category_association",

--- a/backend/src/model/expense_category_association.py
+++ b/backend/src/model/expense_category_association.py
@@ -7,7 +7,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, String
 from src.repository.database import Base
 
 
-# 多対多の関係を表す中間テーブル
+# Association table for many-to-many relationship
 class ExpenseCategoryAssociation(Base):
     __tablename__ = "expense_category_association"
 

--- a/backend/src/model/utils.py
+++ b/backend/src/model/utils.py
@@ -2,6 +2,6 @@ import uuid6
 
 
 def generate_uuid_string() -> str:
-    """UUID v7をハイフンなしの32文字の文字列として生成"""
+    """Generate a UUID v7 as a 32-character hex string without hyphens."""
     return uuid6.uuid7().hex
 

--- a/backend/src/repository/category_repository.py
+++ b/backend/src/repository/category_repository.py
@@ -7,17 +7,17 @@ from src.model.expense_category_association import ExpenseCategoryAssociation
 
 
 def get_all_categories(db: Session, user_uuid: str) -> list[Category]:
-    """すべてのカテゴリを取得する"""
+    """Get all categories."""
     return db.query(Category).filter(Category.user_uuid == user_uuid).all()
 
 
 def get_category_by_uuid(db: Session, uuid: str, user_uuid: str) -> Category | None:
-    """UUIDでカテゴリを取得する"""
+    """Get a category by UUID."""
     return db.query(Category).filter(Category.uuid == uuid, Category.user_uuid == user_uuid).first()
 
 
 def create_category(db: Session, user_uuid: str, name: str) -> Category:
-    """新しいカテゴリを作成する"""
+    """Create a new category."""
     category = Category(user_uuid=user_uuid, name=name)
     db.add(category)
     db.commit()
@@ -26,13 +26,13 @@ def create_category(db: Session, user_uuid: str, name: str) -> Category:
 
 
 def delete_all_categories(db: Session) -> None:
-    """すべてのカテゴリを削除する(関連する中間テーブルも削除)"""
+    """Delete all categories (including association table records)."""
     db.query(ExpenseCategoryAssociation).delete()
     db.query(Category).delete()
 
 
 def bulk_create_categories(db: Session, user_uuid: str, names: list[str]) -> list[Category]:
-    """カテゴリを一括作成する"""
+    """Bulk-create categories."""
     categories = [Category(user_uuid=user_uuid, name=name) for name in names]
     db.add_all(categories)
     db.commit()
@@ -42,7 +42,7 @@ def bulk_create_categories(db: Session, user_uuid: str, names: list[str]) -> lis
 
 
 def update_category(db: Session, category: Category, name: str) -> Category:
-    """カテゴリ名を更新する"""
+    """Update a category name."""
     category.name = name  # type: ignore[assignment]
     db.commit()
     db.refresh(category)
@@ -50,6 +50,6 @@ def update_category(db: Session, category: Category, name: str) -> Category:
 
 
 def delete_category(db: Session, category: Category) -> None:
-    """カテゴリを物理削除する"""
+    """Hard-delete a category."""
     db.delete(category)
     db.commit()

--- a/backend/src/repository/database.py
+++ b/backend/src/repository/database.py
@@ -9,13 +9,13 @@ from dotenv import load_dotenv
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
-# .envファイルから環境変数を読み込む
+# Load environment variables from .env file
 load_dotenv()
 
 
 def get_database_url() -> str:
-    """環境変数からDATABASE_URLを取得し、ホスト名を適切に変換する"""
-    # Vercel production環境ではPOSTGRES_URLを使用
+    """Get DATABASE_URL from environment variables and resolve the hostname."""
+    # Use POSTGRES_URL in Vercel production environment
     vercel_env = os.getenv("VERCEL_ENV")
     if vercel_env == "production":
         postgres_url = os.getenv("POSTGRES_URL")
@@ -26,7 +26,7 @@ def get_database_url() -> str:
             )
         return postgres_url
 
-    # ローカル環境ではDATABASE_URLを使用
+    # Use DATABASE_URL in local environment
     database_url = os.getenv("DATABASE_URL")
     if database_url is None:
         raise ValueError(
@@ -34,12 +34,12 @@ def get_database_url() -> str:
             "Please set it in your .env file or environment.",
         )
 
-    # Dockerコンテナ内で実行されているかどうかを判断
-    # /appディレクトリが存在し、かつ/.dockerenvファイルが存在する場合はDockerコンテナ内
+    # Detect if running inside a Docker container
+    # True if /app directory or /.dockerenv file exists
     is_docker = Path("/.dockerenv").exists() or Path("/app").exists()
 
-    # ホストマシンから実行する場合のみ、ホスト名をlocalhostに変更
-    # Dockerコンテナ内では"db"、ホストマシンからは"localhost"を使用
+    # Replace hostname with localhost only when running on the host machine
+    # Use "db" inside Docker containers, "localhost" on the host
     if not is_docker and "://" in database_url and ("@db/" in database_url or "@db:" in database_url):
         database_url = database_url.replace("@db/", "@localhost/").replace("@db:", "@localhost:")
 
@@ -52,18 +52,18 @@ class Base(DeclarativeBase):
 
 @lru_cache(maxsize=1)
 def get_engine() -> Engine:
-    """エンジンを遅延生成"""
+    """Lazily create the database engine."""
     return create_engine(get_database_url())
 
 
 @lru_cache(maxsize=1)
 def get_session_local() -> sessionmaker[Session]:
-    """セッションファクトリを遅延生成"""
+    """Lazily create the session factory."""
     return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
 
 
 def get_db() -> Generator[Session]:
-    """データベースセッションを取得する依存性注入用の関数"""
+    """Dependency injection function that yields a database session."""
     db = get_session_local()()
     try:
         yield db

--- a/backend/src/repository/expense_repository.py
+++ b/backend/src/repository/expense_repository.py
@@ -18,7 +18,7 @@ def get_all_expenses(
     month: int | None = None,
     include_deleted: bool = False,
 ) -> list[Expense]:
-    """すべての支出を取得する(削除されていないもののみ)"""
+    """Get all expenses (non-deleted only by default)."""
     query = db.query(Expense).options(selectinload(Expense.categories)).filter(Expense.user_uuid == user_uuid)
     if not include_deleted:
         query = query.filter(Expense.deleted_at.is_(None))
@@ -39,7 +39,7 @@ def get_all_expenses(
 
 
 def get_expense_by_uuid(db: Session, uuid: str, user_uuid: str) -> Expense | None:
-    """UUIDで支出を取得する"""
+    """Get an expense by UUID."""
     return db.query(Expense).options(selectinload(Expense.categories)).filter(
         Expense.uuid == uuid,
         Expense.user_uuid == user_uuid,
@@ -56,7 +56,7 @@ def create_expense(  # noqa: PLR0913
     *,
     category_uuids: list[str] | None = None,
 ) -> Expense:
-    """新しい支出を作成する"""
+    """Create a new expense."""
     expense = Expense(user_uuid=user_uuid, name=name, amount=amount, expensed_at=expensed_at)
 
     if category_uuids:
@@ -73,7 +73,7 @@ def create_expense(  # noqa: PLR0913
 
 
 def update_expense_categories(db: Session, expense: Expense, user_uuid: str, category_uuids: list[str]) -> None:
-    """支出のカテゴリを更新する"""
+    """Update categories of an expense."""
     categories = db.query(Category).filter(
         Category.uuid.in_(category_uuids),
         Category.user_uuid == user_uuid,
@@ -82,6 +82,6 @@ def update_expense_categories(db: Session, expense: Expense, user_uuid: str, cat
 
 
 def soft_delete_expense(db: Session, expense: Expense) -> None:
-    """支出を論理削除する"""
+    """Soft-delete an expense."""
     expense.deleted_at = dt.datetime.now(dt.UTC)  # type: ignore[assignment]
     db.commit()

--- a/backend/src/repository/user_repository.py
+++ b/backend/src/repository/user_repository.py
@@ -6,17 +6,17 @@ from src.model.user import User
 
 
 def get_user_by_name(db: Session, name: str) -> User | None:
-    """ユーザー名でユーザーを取得"""
+    """Get a user by name."""
     return db.query(User).filter(User.name == name).first()
 
 
 def get_user_by_uuid(db: Session, uuid: str) -> User | None:
-    """UUIDでユーザーを取得"""
+    """Get a user by UUID."""
     return db.query(User).filter(User.uuid == uuid).first()
 
 
 def create_user(db: Session, name: str) -> User:
-    """新しいユーザーを作成"""
+    """Create a new user."""
     user = User(name=name)
     db.add(user)
     db.commit()
@@ -25,7 +25,7 @@ def create_user(db: Session, name: str) -> User:
 
 
 def update_user(db: Session, user: User, name: str) -> User:
-    """ユーザー名を更新"""
+    """Update a user's name."""
     user.name = name  # type: ignore[assignment]
     db.commit()
     db.refresh(user)
@@ -33,6 +33,6 @@ def update_user(db: Session, user: User, name: str) -> User:
 
 
 def delete_user(db: Session, user: User) -> None:
-    """ユーザーを削除"""
+    """Delete a user."""
     db.delete(user)
     db.commit()

--- a/backend/src/repository/webauthn_repository.py
+++ b/backend/src/repository/webauthn_repository.py
@@ -6,12 +6,12 @@ from src.model.webauthn_credential import WebAuthnCredential
 
 
 def get_credentials_by_user_uuid(db: Session, user_uuid: str) -> list[WebAuthnCredential]:
-    """ユーザーUUIDで全WebAuthnクレデンシャルを取得"""
+    """Get all WebAuthn credentials by user UUID."""
     return db.query(WebAuthnCredential).filter(WebAuthnCredential.user_uuid == user_uuid).all()
 
 
 def get_credential_by_credential_id(db: Session, credential_id: bytes) -> WebAuthnCredential | None:
-    """クレデンシャルIDでWebAuthnクレデンシャルを取得"""
+    """Get a WebAuthn credential by credential ID."""
     return db.query(WebAuthnCredential).filter(WebAuthnCredential.credential_id == credential_id).first()
 
 
@@ -24,7 +24,7 @@ def create_credential(  # noqa: PLR0913
     sign_count: int,
     transports: str | None,
 ) -> WebAuthnCredential:
-    """新しいWebAuthnクレデンシャルを作成"""
+    """Create a new WebAuthn credential."""
     credential = WebAuthnCredential(
         user_uuid=user_uuid,
         credential_id=credential_id,
@@ -39,6 +39,6 @@ def create_credential(  # noqa: PLR0913
 
 
 def update_sign_count(db: Session, credential: WebAuthnCredential, new_sign_count: int) -> None:
-    """クレデンシャルの署名カウントを更新"""
+    """Update the sign count of a credential."""
     credential.sign_count = new_sign_count  # type: ignore[assignment]
     db.commit()

--- a/backend/src/schema/expense.py
+++ b/backend/src/schema/expense.py
@@ -21,14 +21,14 @@ class ExpenseResponse(BaseModel):
 
 class ExpenseCreate(BaseModel):
     name: str
-    amount: int = Field(gt=0, description="正の整数のみ許可")
+    amount: int = Field(gt=0, description="Must be a positive integer")
     expensed_at: JstInputDatetime
     category_uuid: str | None = None
 
 
 class ExpenseUpdate(BaseModel):
     name: str | None = None
-    amount: int | None = Field(default=None, gt=0, description="正の整数のみ許可")
+    amount: int | None = Field(default=None, gt=0, description="Must be a positive integer")
     expensed_at: JstInputDatetime | None = None
     category_uuid: str | None = None
 

--- a/backend/src/schema/expense_template.py
+++ b/backend/src/schema/expense_template.py
@@ -19,13 +19,13 @@ class ExpenseTemplateResponse(BaseModel):
 
 class ExpenseTemplateCreate(BaseModel):
     name: str
-    amount: int = Field(gt=0, description="正の整数のみ許可")
+    amount: int = Field(gt=0, description="Must be a positive integer")
     category_uuid: str
 
 
 class ExpenseTemplateUpdate(BaseModel):
     name: str | None = None
-    amount: int | None = Field(default=None, gt=0, description="正の整数のみ許可")
+    amount: int | None = Field(default=None, gt=0, description="Must be a positive integer")
     category_uuid: str | None = None
 
 

--- a/backend/src/schema/types.py
+++ b/backend/src/schema/types.py
@@ -10,12 +10,12 @@ JST = timezone(timedelta(hours=9))
 
 
 def _to_jst(v: datetime) -> datetime:
-    """naive datetimeをUTCとみなしJSTに変換"""
+    """Convert naive datetime (assumed UTC) to JST."""
     return v.replace(tzinfo=UTC).astimezone(JST)
 
 
 def _jst_to_utc(v: datetime) -> datetime:
-    """JSTとみなしてUTCに変換(naive->JST->UTC->naive)"""
+    """Convert JST input to naive UTC (naive->JST->UTC->naive)."""
     if v.tzinfo is None:
         v = v.replace(tzinfo=JST)
     return v.astimezone(UTC).replace(tzinfo=None)

--- a/backend/src/service/challenge_store.py
+++ b/backend/src/service/challenge_store.py
@@ -4,19 +4,19 @@ import time
 
 
 class ChallengeStore:
-    """WebAuthnチャレンジの一時保存(インメモリ, TTL 5分)"""
+    """In-memory store for WebAuthn challenges (TTL 5 min)."""
 
     def __init__(self, ttl_seconds: int = 300) -> None:
         self._store: dict[str, tuple[bytes, float]] = {}
         self._ttl = ttl_seconds
 
     def save(self, name: str, challenge: bytes) -> None:
-        """チャレンジを保存"""
+        """Save a challenge."""
         self._cleanup()
         self._store[name] = (challenge, time.monotonic())
 
     def get(self, name: str) -> bytes | None:
-        """チャレンジを取得して削除"""
+        """Retrieve and remove a challenge."""
         self._cleanup()
         entry = self._store.pop(name, None)
         if entry is None:
@@ -25,7 +25,7 @@ class ChallengeStore:
         return challenge
 
     def _cleanup(self) -> None:
-        """期限切れエントリを削除"""
+        """Remove expired entries."""
         now = time.monotonic()
         expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
         for k in expired:

--- a/backend/src/service/jwt_service.py
+++ b/backend/src/service/jwt_service.py
@@ -11,13 +11,13 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 15
 
 
 def create_access_token(user_uuid: str) -> str:
-    """JWTアクセストークンを生成"""
+    """Generate a JWT access token."""
     expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {"sub": user_uuid, "exp": expire}
     return jwt.encode(payload, get_jwt_secret_key(), algorithm=ALGORITHM)
 
 
 def decode_access_token(token: str) -> dict[str, object]:
-    """JWTアクセストークンを検証・デコード"""
+    """Verify and decode a JWT access token."""
     result: dict[str, object] = jwt.decode(token, get_jwt_secret_key(), algorithms=[ALGORITHM])
     return result

--- a/frontend/src/components/AnnualAreaChart.tsx
+++ b/frontend/src/components/AnnualAreaChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts"
 
 import { CHART_COLORS } from "../lib/colors"
+import { MONTH_LABELS } from "../lib/constants"
 import type { ExpenseResponse } from "../lib/types"
 
 interface AnnualAreaChartProps {
@@ -23,7 +24,7 @@ export const AnnualAreaChart = ({ expenses }: AnnualAreaChartProps) => {
     const catSet = new Set<string>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        catSet.add("未分類")
+        catSet.add("Uncategorized")
       } else {
         for (const c of e.categories) {
           catSet.add(c.name)
@@ -33,7 +34,7 @@ export const AnnualAreaChart = ({ expenses }: AnnualAreaChartProps) => {
     const cats = [...catSet]
 
     const months = Array.from({ length: 12 }, (_, i) => {
-      const row: Record<string, string | number> = { label: `${i + 1}月` }
+      const row: Record<string, string | number> = { label: MONTH_LABELS[i] }
       for (const cat of cats) {
         row[cat] = 0
       }
@@ -43,7 +44,7 @@ export const AnnualAreaChart = ({ expenses }: AnnualAreaChartProps) => {
     for (const e of expenses) {
       const m = new Date(e.expensed_at).getMonth()
       if (e.categories.length === 0) {
-        ;(months[m].未分類 as number) += e.amount
+        ;(months[m].Uncategorized as number) += e.amount
       } else {
         for (const c of e.categories) {
           ;(months[m][c.name] as number) += e.amount

--- a/frontend/src/components/AnnualLineChart.tsx
+++ b/frontend/src/components/AnnualLineChart.tsx
@@ -10,6 +10,7 @@ import {
 } from "recharts"
 
 import { CHART_COLORS } from "../lib/colors"
+import { MONTH_LABELS } from "../lib/constants"
 import type { ExpenseResponse } from "../lib/types"
 
 interface AnnualLineChartProps {
@@ -23,7 +24,7 @@ export const AnnualLineChart = ({ expenses }: AnnualLineChartProps) => {
     const catSet = new Set<string>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        catSet.add("未分類")
+        catSet.add("Uncategorized")
       } else {
         for (const c of e.categories) {
           catSet.add(c.name)
@@ -33,7 +34,7 @@ export const AnnualLineChart = ({ expenses }: AnnualLineChartProps) => {
     const cats = [...catSet]
 
     const months = Array.from({ length: 12 }, (_, i) => {
-      const row: Record<string, string | number> = { label: `${i + 1}月` }
+      const row: Record<string, string | number> = { label: MONTH_LABELS[i] }
       for (const cat of cats) {
         row[cat] = 0
       }
@@ -43,7 +44,7 @@ export const AnnualLineChart = ({ expenses }: AnnualLineChartProps) => {
     for (const e of expenses) {
       const m = new Date(e.expensed_at).getMonth()
       if (e.categories.length === 0) {
-        ;(months[m].未分類 as number) += e.amount
+        ;(months[m].Uncategorized as number) += e.amount
       } else {
         for (const c of e.categories) {
           ;(months[m][c.name] as number) += e.amount

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -37,7 +37,7 @@ export const AppLayout = () => {
     try {
       setUser(await api.getMe())
     } catch {
-      // 認証切れ時はclient.tsでリダイレクト済み
+      // Redirect handled by client.ts on auth expiry
     }
   }, [])
 

--- a/frontend/src/components/CategoryBubbleChart.tsx
+++ b/frontend/src/components/CategoryBubbleChart.tsx
@@ -41,7 +41,7 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
     const catSet = new Set<string>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        catSet.add("未分類")
+        catSet.add("Uncategorized")
       } else {
         for (const c of e.categories) catSet.add(c.name)
       }
@@ -52,7 +52,7 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
   const filteredExpenses = useMemo(() => {
     if (hidden.size === 0) return expenses
     return expenses.filter((e) => {
-      if (e.categories.length === 0) return !hidden.has("未分類")
+      if (e.categories.length === 0) return !hidden.has("Uncategorized")
       return e.categories.some((c) => !hidden.has(c.name))
     })
   }, [expenses, hidden])
@@ -107,12 +107,12 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
           <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" />
           <XAxis
             dataKey="frequency"
-            name="頻度"
+            name="Frequency"
             type="number"
             tick={{ fontSize: 11, fill: "var(--chart-label)" }}
             stroke="var(--chart-grid)"
             label={{
-              value: "頻度（回）",
+              value: "Frequency",
               position: "bottom",
               fontSize: 11,
               fill: "var(--chart-label)",
@@ -121,7 +121,7 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
           />
           <YAxis
             dataKey="rangeIndex"
-            name="金額帯"
+            name="Amount range"
             type="number"
             domain={[-0.5, AMOUNT_RANGES.length - 0.5]}
             ticks={AMOUNT_RANGES.map((_, i) => i)}
@@ -130,7 +130,7 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
             stroke="var(--chart-grid)"
             width={80}
           />
-          <ZAxis dataKey="total" range={[60, 500]} name="合計" type="number" />
+          <ZAxis dataKey="total" range={[60, 500]} name="Total" type="number" />
           <Tooltip
             content={({ payload }) => {
               if (!payload?.[0]) return null
@@ -144,8 +144,8 @@ export const CategoryBubbleChart = ({ expenses }: CategoryBubbleChartProps) => {
                   }}
                 >
                   <p className="font-medium">{d.label}</p>
-                  <p>回数: {d.frequency}</p>
-                  <p>合計: ¥{d.total.toLocaleString()}</p>
+                  <p>Count: {d.frequency}</p>
+                  <p>Total: ¥{d.total.toLocaleString()}</p>
                 </div>
               )
             }}

--- a/frontend/src/components/ExpenseHeatmap.tsx
+++ b/frontend/src/components/ExpenseHeatmap.tsx
@@ -28,7 +28,7 @@ export const ExpenseHeatmap = ({ year, month, expenses }: ExpenseHeatmapProps) =
     const catSet = new Set<string>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        catSet.add("未分類")
+        catSet.add("Uncategorized")
       } else {
         for (const c of e.categories) catSet.add(c.name)
       }
@@ -39,7 +39,7 @@ export const ExpenseHeatmap = ({ year, month, expenses }: ExpenseHeatmapProps) =
   const filteredExpenses = useMemo(() => {
     if (hidden.size === 0) return expenses
     return expenses.filter((e) => {
-      if (e.categories.length === 0) return !hidden.has("未分類")
+      if (e.categories.length === 0) return !hidden.has("Uncategorized")
       return e.categories.some((c) => !hidden.has(c.name))
     })
   }, [expenses, hidden])

--- a/frontend/src/components/ExpenseList.tsx
+++ b/frontend/src/components/ExpenseList.tsx
@@ -56,7 +56,7 @@ export const ExpenseList = ({ expenses }: ExpenseListProps) => {
 
       {expenses.length === 0 && (
         <p className="text-center text-sm text-gray-400 dark:text-gray-500">
-          この月の支出はありません
+          No expenses this month
         </p>
       )}
     </div>

--- a/frontend/src/components/MonthlyTrendChart.tsx
+++ b/frontend/src/components/MonthlyTrendChart.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
 
 import { api } from "../lib/api"
+import { MONTH_LABELS } from "../lib/constants"
 import type { ExpenseResponse } from "../lib/types"
 
 const getLast12Months = (year: number, month: number) => {
@@ -13,7 +14,7 @@ const getLast12Months = (year: number, month: number) => {
       m += 12
       y -= 1
     }
-    months.push({ year: y, month: m, label: `${m}月` })
+    months.push({ year: y, month: m, label: MONTH_LABELS[m - 1] })
   }
   return months
 }
@@ -36,7 +37,7 @@ export const MonthlyTrendChart = ({ year, month }: MonthlyTrendChartProps) => {
       setThisYearExpenses(results[0])
       setLastYearExpenses(results[1])
     } catch {
-      // エラーは親で表示済み
+      // Error already displayed by parent
     }
   }, [year, month])
 
@@ -76,8 +77,7 @@ export const MonthlyTrendChart = ({ year, month }: MonthlyTrendChartProps) => {
           axisLine={false}
           tickLine={false}
           tick={{ fontSize: 10, fill: "var(--chart-label)" }}
-          tickFormatter={(v: number) => `${(v / 10000).toFixed(0)}`}
-          unit="万"
+          tickFormatter={(v: number) => `${(v / 1000).toFixed(0)}k`}
           width={40}
         />
         <Tooltip

--- a/frontend/src/components/PieWithStep.tsx
+++ b/frontend/src/components/PieWithStep.tsx
@@ -24,7 +24,7 @@ export const PieWithStep = ({ expenses }: PieWithStepProps) => {
     const map = new Map<string, number>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        map.set("未分類", (map.get("未分類") ?? 0) + e.amount)
+        map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
       } else {
         for (const c of e.categories) {
           map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
@@ -40,8 +40,8 @@ export const PieWithStep = ({ expenses }: PieWithStepProps) => {
     const map = new Map<string, number>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        if (!hidden.has("未分類")) {
-          map.set("未分類", (map.get("未分類") ?? 0) + e.amount)
+        if (!hidden.has("Uncategorized")) {
+          map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
         }
       } else {
         for (const c of e.categories) {

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -35,16 +35,16 @@ export const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
       .getMe()
       .then(() => setVerified(true))
       .catch(() => {
-        // 401 → client.ts が /signin にリダイレクト
+        // 401 -> client.ts redirects to /signin
       })
   }, [])
 
-  // 初回マウント時
+  // On initial mount
   useEffect(() => {
     verify()
   }, [verify])
 
-  // バックグラウンド復帰時
+  // On returning from background
   useEffect(() => {
     const onVisibilityChange = () => {
       if (document.visibilityState === "visible") {

--- a/frontend/src/components/SimplePieChart.tsx
+++ b/frontend/src/components/SimplePieChart.tsx
@@ -15,7 +15,7 @@ export const SimplePieChart = ({ expenses }: SimplePieChartProps) => {
   const map = new Map<string, number>()
   for (const e of expenses) {
     if (e.categories.length === 0) {
-      map.set("未分類", (map.get("未分類") ?? 0) + e.amount)
+      map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
     } else {
       for (const c of e.categories) {
         map.set(c.name, (map.get(c.name) ?? 0) + e.amount)

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -30,7 +30,7 @@ export const UserMenu = ({ userName, onLogout }: UserMenuProps) => {
             className="flex w-full items-center gap-2 rounded px-3 py-2 text-left text-sm text-red-600 hover:bg-gray-50 dark:text-red-400 dark:hover:bg-gray-700"
           >
             <ExitIcon className="size-4 shrink-0" />
-            ログアウト
+            Logout
           </button>
         </Popover.Content>
       </Popover.Portal>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,7 @@ import type {
   UserResponse,
 } from "./types"
 
-// --- 認証 ---
+// --- Auth ---
 
 const register = async (username: string): Promise<RegisterVerifyResponse> => {
   const { options } = await client.post<RegisterOptionsResponse>("/auth/register/options", {
@@ -28,7 +28,7 @@ const register = async (username: string): Promise<RegisterVerifyResponse> => {
     publicKey: PublicKeyCredential.parseCreationOptionsFromJSON(options),
   })
   if (!credential) {
-    throw new Error("パスキーの登録がキャンセルされました")
+    throw new Error("Passkey registration was cancelled")
   }
 
   const credentialJson = (credential as PublicKeyCredential).toJSON()
@@ -48,7 +48,7 @@ const signIn = async (username: string): Promise<SignInVerifyResponse> => {
     publicKey: PublicKeyCredential.parseRequestOptionsFromJSON(options),
   })
   if (!credential) {
-    throw new Error("認証がキャンセルされました")
+    throw new Error("Authentication was cancelled")
   }
 
   const credentialJson = (credential as PublicKeyCredential).toJSON()
@@ -59,7 +59,7 @@ const signIn = async (username: string): Promise<SignInVerifyResponse> => {
   })
 }
 
-// --- ユーザー ---
+// --- User ---
 
 const getMe = (): Promise<UserResponse> => client.get<UserResponse>("/me")
 
@@ -73,7 +73,7 @@ const exportMe = (): Promise<unknown> => client.get<unknown>("/me/export")
 const importMe = (data: unknown): Promise<ImportResponse> =>
   client.post<ImportResponse>("/me/import", data)
 
-// --- カテゴリ ---
+// --- Category ---
 
 const getCategories = (): Promise<CategoryResponse[]> =>
   client.get<CategoryResponse[]>("/categories")
@@ -86,7 +86,7 @@ const updateCategory = (uuid: string, data: CategoryUpdate): Promise<CategoryRes
 
 const deleteCategory = (uuid: string): Promise<void> => client.delete<void>(`/categories/${uuid}`)
 
-// --- 支出 ---
+// --- Expense ---
 
 const getExpense = (uuid: string): Promise<ExpenseResponse> =>
   client.get<ExpenseResponse>(`/expenses/${uuid}`)
@@ -107,7 +107,7 @@ const updateExpense = (uuid: string, data: ExpenseUpdate): Promise<ExpenseRespon
 
 const deleteExpense = (uuid: string): Promise<void> => client.delete<void>(`/expenses/${uuid}`)
 
-// --- 支出テンプレート ---
+// --- Expense Template ---
 
 const getExpenseTemplates = (): Promise<ExpenseTemplateResponse[]> =>
   client.get<ExpenseTemplateResponse[]>("/expense-templates")

--- a/frontend/src/lib/client.ts
+++ b/frontend/src/lib/client.ts
@@ -6,12 +6,12 @@ export interface ApiError {
 }
 
 const STATUS_MESSAGES: Record<number, string> = {
-  400: "リクエストが不正です",
-  403: "アクセス権限がありません",
-  404: "リソースが見つかりません",
-  409: "データが競合しています",
-  422: "入力内容に誤りがあります",
-  500: "サーバーエラーが発生しました",
+  400: "Bad request",
+  403: "Access denied",
+  404: "Resource not found",
+  409: "Data conflict",
+  422: "Invalid input",
+  500: "Server error",
 }
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "http://localhost:9999"
@@ -42,7 +42,7 @@ const request = async <T>(method: string, path: string, body?: unknown): Promise
   if (response.status === 401) {
     localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
     window.location.href = "/signin"
-    const apiError: ApiError = { status: 401, message: "認証が切れました" }
+    const apiError: ApiError = { status: 401, message: "Session expired" }
     throw apiError
   }
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -3,3 +3,18 @@ export const STORAGE_KEYS = {
   THEME: "theme",
   LAST_USERNAME: "last_username",
 } as const
+
+export const MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -19,7 +19,7 @@ export const CategoriesPage = () => {
     try {
       setCategories(await api.getCategories())
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     }
   }, [])
 
@@ -35,7 +35,7 @@ export const CategoriesPage = () => {
       setName("")
       await fetchData()
     } catch (err) {
-      setError(getErrorMessage(err, "作成に失敗"))
+      setError(getErrorMessage(err, "Failed to create"))
     }
   }
 
@@ -70,7 +70,7 @@ export const CategoriesPage = () => {
       setEditing(null)
       await fetchData()
     } catch (err) {
-      setError(getErrorMessage(err, "更新に失敗"))
+      setError(getErrorMessage(err, "Failed to update"))
     }
   }
 
@@ -78,7 +78,7 @@ export const CategoriesPage = () => {
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
       {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
-      {/* 作成フォーム */}
+      {/* Create form */}
       <form
         onSubmit={handleCreate}
         className="flex items-center gap-2 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-800"
@@ -101,7 +101,7 @@ export const CategoriesPage = () => {
         </button>
       </form>
 
-      {/* カテゴリ一覧 */}
+      {/* Category list */}
       {categories.length > 0 ? (
         <div className="divide-y divide-gray-100 overflow-hidden rounded-2xl bg-white shadow-sm dark:divide-gray-700 dark:bg-gray-800">
           {categories.map((c) => (

--- a/frontend/src/pages/ExpenseAnnualPage.tsx
+++ b/frontend/src/pages/ExpenseAnnualPage.tsx
@@ -13,6 +13,7 @@ import { AnnualLineChart } from "../components/AnnualLineChart"
 import { useSwipe } from "../hooks/useSwipe"
 import { api } from "../lib/api"
 import { getErrorMessage } from "../lib/client"
+import { MONTH_LABELS } from "../lib/constants"
 import type { ExpenseResponse } from "../lib/types"
 
 type Tab = "list" | "area" | "line"
@@ -56,7 +57,7 @@ export const ExpenseAnnualPage = () => {
       setExpenses(await api.getExpenses(year))
     } catch (err) {
       setExpenses([])
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     }
   }, [year])
 
@@ -87,7 +88,7 @@ export const ExpenseAnnualPage = () => {
           <DoubleArrowLeftIcon className="size-4" />
         </button>
         <div className="text-center">
-          <p className="text-sm text-gray-500 dark:text-gray-400">{year}年の支出</p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{year} Expenses</p>
           <p className="text-4xl font-extrabold">¥{total.toLocaleString()}</p>
         </div>
         <button
@@ -132,7 +133,7 @@ export const ExpenseAnnualPage = () => {
               key={`month-${String(i)}`}
               className="flex items-center justify-between rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-gray-800"
             >
-              <span className="text-sm">{i + 1}月</span>
+              <span className="text-sm">{MONTH_LABELS[i]}</span>
               <span className="text-sm font-mono">¥{amount.toLocaleString()}</span>
             </div>
           ))}

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -56,7 +56,7 @@ export const ExpenseMonthlyPage = () => {
     try {
       setExpenses(await api.getExpenses(year, month))
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     }
   }, [year, month])
 
@@ -68,7 +68,7 @@ export const ExpenseMonthlyPage = () => {
     const map = new Map<string, number>()
     for (const e of expenses) {
       if (e.categories.length === 0) {
-        map.set("未分類", (map.get("未分類") ?? 0) + e.amount)
+        map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
       } else {
         for (const c of e.categories) {
           map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
@@ -87,7 +87,7 @@ export const ExpenseMonthlyPage = () => {
   const filteredExpenses = useMemo(() => {
     if (!selectedCategory) return expenses
     return expenses.filter((e) => {
-      if (selectedCategory === "未分類") return e.categories.length === 0
+      if (selectedCategory === "Uncategorized") return e.categories.length === 0
       return e.categories.some((c) => c.name === selectedCategory)
     })
   }, [expenses, selectedCategory])
@@ -131,7 +131,7 @@ export const ExpenseMonthlyPage = () => {
         </button>
         <div className="text-center">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            {year}/{month}の支出
+            {year}/{month} Expenses
           </p>
           <p className="text-4xl font-extrabold">¥{total.toLocaleString()}</p>
         </div>

--- a/frontend/src/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/pages/ExpenseTemplatePage.tsx
@@ -40,7 +40,7 @@ export const ExpenseTemplatePage = () => {
       setTemplates(t)
       setCategories(c)
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     }
   }, [])
 
@@ -60,7 +60,7 @@ export const ExpenseTemplatePage = () => {
       setForm({ name: "", amount: "", categoryUuid: "" })
       await fetchData()
     } catch (err) {
-      setError(getErrorMessage(err, "作成に失敗"))
+      setError(getErrorMessage(err, "Failed to create"))
     }
   }
 
@@ -81,7 +81,7 @@ export const ExpenseTemplatePage = () => {
       dialogRef.current?.close()
       await fetchData()
     } catch (err) {
-      setError(getErrorMessage(err, "削除に失敗"))
+      setError(getErrorMessage(err, "Failed to delete"))
     }
   }
 
@@ -107,7 +107,7 @@ export const ExpenseTemplatePage = () => {
       setEditing(null)
       await fetchData()
     } catch (err) {
-      setError(getErrorMessage(err, "更新に失敗"))
+      setError(getErrorMessage(err, "Failed to update"))
     }
   }
 
@@ -115,7 +115,7 @@ export const ExpenseTemplatePage = () => {
     <div className="mx-auto flex h-full max-w-2xl flex-col gap-6 px-6 pb-6">
       {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
-      {/* 作成フォーム */}
+      {/* Create form */}
       <form
         onSubmit={handleCreate}
         className="flex shrink-0 flex-col gap-3 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-800"
@@ -170,17 +170,17 @@ export const ExpenseTemplatePage = () => {
         </div>
       </form>
 
-      {/* 合計金額 */}
+      {/* Total amount */}
       {templates.length > 0 && (
         <div className="flex items-center justify-between rounded-2xl bg-white px-5 py-3.5 shadow-sm dark:bg-gray-800">
-          <span className="text-sm text-gray-500 dark:text-gray-400">合計</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Total</span>
           <span className="min-w-0 truncate text-sm font-semibold tabular-nums">
             ¥{totalAmount.toLocaleString()}
           </span>
         </div>
       )}
 
-      {/* テンプレート一覧 */}
+      {/* Template list */}
       {templates.length > 0 ? (
         <div className="min-h-0 flex-1 divide-y divide-gray-100 overflow-y-auto rounded-2xl bg-white shadow-sm dark:divide-gray-700 dark:bg-gray-800">
           {templates.map((t) => (

--- a/frontend/src/pages/ExpenseTemplateRecordPage.tsx
+++ b/frontend/src/pages/ExpenseTemplateRecordPage.tsx
@@ -36,7 +36,7 @@ export const ExpenseTemplateRecordPage = () => {
         })),
       )
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     } finally {
       setLoading(false)
     }
@@ -75,7 +75,7 @@ export const ExpenseTemplateRecordPage = () => {
       )
       navigate("/expense/monthly")
     } catch (err) {
-      setError(getErrorMessage(err, "記帳に失敗"))
+      setError(getErrorMessage(err, "Failed to record"))
     } finally {
       setSubmitting(false)
     }

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -17,7 +17,7 @@ export const ExpensesPage = () => {
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
 
-  // 作成フォーム
+  // Create form
   const now = new Date()
   const today = toLocalDatetime(now)
   const [form, setForm] = useState({
@@ -31,7 +31,7 @@ export const ExpensesPage = () => {
     try {
       setCategories(await api.getCategories())
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     }
   }, [])
 
@@ -59,7 +59,7 @@ export const ExpensesPage = () => {
       })
       navigate("/expense/monthly")
     } catch (err) {
-      setError(getErrorMessage(err, "作成に失敗"))
+      setError(getErrorMessage(err, "Failed to create"))
     }
   }
 

--- a/frontend/src/pages/TopPage.tsx
+++ b/frontend/src/pages/TopPage.tsx
@@ -43,7 +43,7 @@ export const TopPage = () => {
     try {
       setExpenses(await api.getExpenses(year, month))
     } catch (err) {
-      setError(getErrorMessage(err, "データ取得に失敗"))
+      setError(getErrorMessage(err, "Failed to fetch data"))
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- All `.claude/CLAUDE.md` and `.claude/rules/` docs translated to English
- Backend docstrings, comments, and Field descriptions translated to English
- Frontend error messages, comments, and UI text translated to English
- Commit message convention updated from Japanese to English
- Added Language Policy section to CLAUDE.md

closes #52

## Test plan
- [x] `make lint` passes (mypy + ruff + tsc + oxlint + oxfmt)
- [x] `make test-backend` passes (27 tests)
- [ ] Verify no Japanese text remains in source code
- [ ] Verify chart labels display correctly in English (month names, "Uncategorized", "Total")

🤖 Generated with [Claude Code](https://claude.com/claude-code)