### PR TITLE
feat: include expense_templates in export/import

### DIFF
--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from src.api.deps import get_current_user
 from src.model.category import Category
@@ -18,7 +18,7 @@ from src.repository.user_repository import delete_user, update_user
 from src.schema.auth import UserResponse, UserUpdateRequest
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
-from src.schema.user import UserExportResponse, UserImportRequest, UserImportResponse
+from src.schema.user import ExportExpenseTemplateResponse, UserExportResponse, UserImportRequest, UserImportResponse
 
 user_router = APIRouter(tags=["users"])
 
@@ -49,10 +49,17 @@ def export_me(
     user_uuid = str(current_user.uuid)
     categories = get_all_categories(db, user_uuid)
     expenses = get_all_expenses(db, user_uuid, include_deleted=True)
+    templates = (
+        db.query(ExpenseTemplate)
+        .options(joinedload(ExpenseTemplate.category))
+        .filter(ExpenseTemplate.user_uuid == user_uuid)
+        .all()
+    )
     return UserExportResponse(
         name=str(current_user.name),
         categories=[CategoryResponse.model_validate(c) for c in categories],
         expenses=[ExpenseResponse.model_validate(e) for e in expenses],
+        expense_templates=[ExportExpenseTemplateResponse.model_validate(t) for t in templates],
     )
 
 
@@ -102,12 +109,28 @@ def import_me(
             if new_category_uuid:
                 db.add(ExpenseCategoryAssociation(expense_uuid=expense.uuid, category_uuid=new_category_uuid))
 
+    # Import expense templates
+    for tmpl in body.expense_templates:
+        new_category_uuid = category_uuid_map.get(tmpl.category.uuid)
+        if new_category_uuid:
+            db.add(ExpenseTemplate(
+                user_uuid=user_uuid,
+                name=tmpl.name,
+                amount=tmpl.amount,
+                category_uuid=new_category_uuid,
+                created_at=tmpl.created_at,
+                updated_at=tmpl.updated_at,
+                deleted_at=tmpl.deleted_at,
+            ))
+
     db.commit()
 
     return UserImportResponse(
         categories_count=len(body.categories),
         expenses_count=len(body.expenses),
-        message=f"Imported {len(body.categories)} categories and {len(body.expenses)} expenses",
+        expense_templates_count=len(body.expense_templates),
+        message=f"Imported {len(body.categories)} categories, {len(body.expenses)} expenses,"
+        f" and {len(body.expense_templates)} templates",
     )
 
 

--- a/backend/src/schema/user.py
+++ b/backend/src/schema/user.py
@@ -1,16 +1,29 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
-from src.schema.types import JstInputDatetime
+from src.schema.types import JstDatetime, JstInputDatetime
+
+
+class ExportExpenseTemplateResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uuid: str
+    name: str
+    amount: int
+    category: CategoryResponse
+    created_at: JstDatetime
+    updated_at: JstDatetime
+    deleted_at: JstDatetime | None
 
 
 class UserExportResponse(BaseModel):
     name: str
     categories: list[CategoryResponse]
     expenses: list[ExpenseResponse]
+    expense_templates: list[ExportExpenseTemplateResponse]
 
 
 class ImportCategory(BaseModel):
@@ -28,12 +41,23 @@ class ImportExpense(BaseModel):
     categories: list[ImportCategory]
 
 
+class ImportExpenseTemplate(BaseModel):
+    name: str
+    amount: int
+    category: ImportCategory
+    created_at: JstInputDatetime
+    updated_at: JstInputDatetime
+    deleted_at: JstInputDatetime | None = None
+
+
 class UserImportRequest(BaseModel):
     categories: list[ImportCategory]
     expenses: list[ImportExpense]
+    expense_templates: list[ImportExpenseTemplate] = []
 
 
 class UserImportResponse(BaseModel):
     categories_count: int
     expenses_count: int
+    expense_templates_count: int
     message: str


### PR DESCRIPTION
## Summary
- Export (`GET /me/export`) now includes `expense_templates` with `deleted_at` field
- Import (`POST /me/import`) accepts `expense_templates` and restores them with correct category UUID mapping
- `expense_templates` field is optional in import request for backward compatibility with existing export files

closes #48

## Test plan
- [ ] Export includes expense_templates (including soft-deleted ones)
- [ ] Import restores expense_templates with correct category associations
- [ ] Import of old format JSON (without expense_templates) still works
- [ ] Category UUID mapping is correctly applied to templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)