### PR TITLE
feat: add category bar chart tab to monthly analysis page

### DIFF
--- a/frontend/src/components/CategoryBarChart.tsx
+++ b/frontend/src/components/CategoryBarChart.tsx
@@ -30,22 +30,24 @@ export const CategoryBarChart = ({ expenses }: CategoryBarChartProps) => {
   }
 
   return (
-    <ResponsiveContainer width="100%" height={Math.max(200, data.length * 48)}>
-      <BarChart data={data} layout="vertical" barCategoryGap="20%">
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} barCategoryGap="20%">
         <XAxis
-          type="number"
+          dataKey="name"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fontSize: 10, fill: "var(--chart-label)" }}
+          interval={0}
+          angle={-30}
+          textAnchor="end"
+          height={60}
+        />
+        <YAxis
           axisLine={false}
           tickLine={false}
           tick={{ fontSize: 10, fill: "var(--chart-label)" }}
           tickFormatter={(v: number) => `¥${(v / 1000).toFixed(0)}k`}
-        />
-        <YAxis
-          type="category"
-          dataKey="name"
-          axisLine={false}
-          tickLine={false}
-          tick={{ fontSize: 12, fill: "var(--chart-label)" }}
-          width={100}
+          width={50}
         />
         <Tooltip
           formatter={(value) => [`¥${Number(value).toLocaleString()}`]}
@@ -59,7 +61,7 @@ export const CategoryBarChart = ({ expenses }: CategoryBarChartProps) => {
           }}
           cursor={{ fill: "var(--chart-cursor)" }}
         />
-        <Bar dataKey="amount" radius={[0, 6, 6, 0]} barSize={24} isAnimationActive={false}>
+        <Bar dataKey="amount" radius={[6, 6, 0, 0]} barSize={32} isAnimationActive={false}>
           {data.map((_, i) => (
             <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
           ))}

--- a/frontend/src/components/CategoryBarChart.tsx
+++ b/frontend/src/components/CategoryBarChart.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from "react"
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+
+import { CHART_COLORS } from "../lib/colors"
+import type { ExpenseResponse } from "../lib/types"
+
+interface CategoryBarChartProps {
+  expenses: ExpenseResponse[]
+}
+
+export const CategoryBarChart = ({ expenses }: CategoryBarChartProps) => {
+  const data = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const e of expenses) {
+      if (e.categories.length === 0) {
+        map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
+      } else {
+        for (const c of e.categories) {
+          map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
+        }
+      }
+    }
+    return [...map.entries()]
+      .map(([name, amount]) => ({ name, amount }))
+      .toSorted((a, b) => b.amount - a.amount)
+  }, [expenses])
+
+  if (data.length === 0) {
+    return <p className="mt-8 text-center text-sm text-gray-400">No data</p>
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.max(200, data.length * 48)}>
+      <BarChart data={data} layout="vertical" barCategoryGap="20%">
+        <XAxis
+          type="number"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fontSize: 10, fill: "var(--chart-label)" }}
+          tickFormatter={(v: number) => `¥${(v / 1000).toFixed(0)}k`}
+        />
+        <YAxis
+          type="category"
+          dataKey="name"
+          axisLine={false}
+          tickLine={false}
+          tick={{ fontSize: 12, fill: "var(--chart-label)" }}
+          width={100}
+        />
+        <Tooltip
+          formatter={(value) => [`¥${Number(value).toLocaleString()}`]}
+          contentStyle={{
+            borderRadius: "12px",
+            border: "none",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+            fontSize: "12px",
+            backgroundColor: "var(--chart-tooltip-bg)",
+            color: "var(--chart-tooltip-text)",
+          }}
+          cursor={{ fill: "var(--chart-cursor)" }}
+        />
+        <Bar dataKey="amount" radius={[0, 6, 6, 0]} barSize={24} isAnimationActive={false}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -149,10 +149,10 @@ export const ExpenseMonthlyPage = () => {
       <div className="flex shrink-0 gap-4 overflow-x-auto border-b border-gray-100 dark:border-gray-700">
         {[
           { key: "list" as const, label: "list", icon: ListBulletIcon },
+          { key: "bar" as const, label: "bar", icon: BarChartIcon },
           { key: "pie" as const, label: "pie", icon: PieChartIcon },
           { key: "heatmap" as const, label: "heat map", icon: CalendarIcon },
           { key: "bubble" as const, label: "bubble", icon: MixIcon },
-          { key: "bar" as const, label: "bar", icon: BarChartIcon },
         ].map(({ key, label, icon: Icon }) => (
           <button
             key={key}

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -146,7 +146,7 @@ export const ExpenseMonthlyPage = () => {
         </button>
       </div>
 
-      <div className="flex shrink-0 gap-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="flex shrink-0 gap-4 overflow-x-auto border-b border-gray-100 dark:border-gray-700">
         {[
           { key: "list" as const, label: "list", icon: ListBulletIcon },
           { key: "pie" as const, label: "pie", icon: PieChartIcon },
@@ -158,7 +158,7 @@ export const ExpenseMonthlyPage = () => {
             key={key}
             type="button"
             onClick={() => setTab(key)}
-            className={`flex items-center gap-1.5 border-b-2 px-1 py-2 text-sm ${
+            className={`flex shrink-0 items-center gap-1.5 border-b-2 px-1 py-2 text-sm ${
               tab === key
                 ? "border-primary text-primary"
                 : "border-transparent text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -1,4 +1,5 @@
 import {
+  BarChartIcon,
   CalendarIcon,
   DoubleArrowLeftIcon,
   DoubleArrowRightIcon,
@@ -9,6 +10,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "react-router"
 
+import { CategoryBarChart } from "../components/CategoryBarChart"
 import { CategoryBubbleChart } from "../components/CategoryBubbleChart"
 import { ExpenseHeatmap } from "../components/ExpenseHeatmap"
 import { ExpenseList } from "../components/ExpenseList"
@@ -18,8 +20,8 @@ import { api } from "../lib/api"
 import { getErrorMessage } from "../lib/client"
 import type { ExpenseResponse } from "../lib/types"
 
-type Tab = "list" | "pie" | "heatmap" | "bubble"
-const VALID_TABS: Tab[] = ["list", "pie", "heatmap", "bubble"]
+type Tab = "list" | "pie" | "heatmap" | "bubble" | "bar"
+const VALID_TABS: Tab[] = ["list", "pie", "heatmap", "bubble", "bar"]
 
 export const ExpenseMonthlyPage = () => {
   const now = new Date()
@@ -150,6 +152,7 @@ export const ExpenseMonthlyPage = () => {
           { key: "pie" as const, label: "pie", icon: PieChartIcon },
           { key: "heatmap" as const, label: "heat map", icon: CalendarIcon },
           { key: "bubble" as const, label: "bubble", icon: MixIcon },
+          { key: "bar" as const, label: "bar", icon: BarChartIcon },
         ].map(({ key, label, icon: Icon }) => (
           <button
             key={key}
@@ -204,6 +207,12 @@ export const ExpenseMonthlyPage = () => {
         {tab === "bubble" && (
           <div className="min-h-0 flex-1 overflow-y-auto pt-4">
             <CategoryBubbleChart expenses={filteredExpenses} />
+          </div>
+        )}
+
+        {tab === "bar" && (
+          <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+            <CategoryBarChart expenses={filteredExpenses} />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add "Bar" tab to monthly analysis page (`/expense/monthly`) showing category-wise spending as a horizontal bar chart
- Categories sorted by amount in descending order with color-coded bars
- Closes #56

## Changes
- New `CategoryBarChart` component using recharts `BarChart` with horizontal layout
- Updated `ExpenseMonthlyPage` to include the new "bar" tab

## Test plan
- [ ] Open monthly analysis page and verify "bar" tab appears
- [ ] Confirm bar chart displays category totals sorted by amount
- [ ] Verify tooltip shows formatted yen amounts
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)