### PR TITLE
feat: トップページの円グラフを棒グラフに変更

### DIFF
--- a/frontend/src/components/CategoryBarChart.tsx
+++ b/frontend/src/components/CategoryBarChart.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
-import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import { Bar, BarChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
 
-import { CHART_COLORS } from "../lib/colors"
 import type { ExpenseResponse } from "../lib/types"
 
 interface CategoryBarChartProps {
@@ -61,11 +60,13 @@ export const CategoryBarChart = ({ expenses }: CategoryBarChartProps) => {
           }}
           cursor={{ fill: "var(--chart-cursor)" }}
         />
-        <Bar dataKey="amount" radius={[6, 6, 0, 0]} barSize={32} isAnimationActive={false}>
-          {data.map((_, i) => (
-            <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
-          ))}
-        </Bar>
+        <Bar
+          dataKey="amount"
+          fill="var(--chart-bar)"
+          radius={[6, 6, 0, 0]}
+          barSize={32}
+          isAnimationActive={false}
+        />
       </BarChart>
     </ResponsiveContainer>
   )

--- a/frontend/src/components/MonthlyTrendChart.tsx
+++ b/frontend/src/components/MonthlyTrendChart.tsx
@@ -95,7 +95,7 @@ export const MonthlyTrendChart = ({ year, month }: MonthlyTrendChartProps) => {
         <Bar
           dataKey="amount"
           fill="var(--chart-bar)"
-          radius={[6, 6, 6, 6]}
+          radius={[6, 6, 0, 0]}
           barSize={14}
           isAnimationActive={false}
         />

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react"
 
-import { CHART_COLORS } from "../lib/colors"
 import type { ExpenseResponse } from "../lib/types"
+
+const BAR_COLOR = "var(--chart-bar)"
 
 interface SimpleBarChartProps {
   expenses: ExpenseResponse[]
@@ -29,23 +30,29 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
   const maxAmount = data[0].amount
 
   return (
-    <div className="mt-3 flex flex-col gap-2">
-      {data.map((d, i) => (
-        <div key={d.name} className="flex items-center gap-2">
-          <span className="w-16 shrink-0 truncate text-xs text-gray-500 dark:text-gray-400">
+    <div className="mt-3 flex flex-col gap-1">
+      <div className="flex h-[100px] items-end gap-1.5">
+        {data.map((d) => (
+          <div
+            key={d.name}
+            className="flex-1 rounded-t-md"
+            style={{
+              height: `${(d.amount / maxAmount) * 100}%`,
+              backgroundColor: BAR_COLOR,
+            }}
+          />
+        ))}
+      </div>
+      <div className="flex gap-1.5">
+        {data.map((d) => (
+          <span
+            key={d.name}
+            className="flex-1 truncate text-center text-[9px] text-gray-400 dark:text-gray-500"
+          >
             {d.name}
           </span>
-          <div className="relative h-4 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
-            <div
-              className="h-full rounded-full"
-              style={{
-                width: `${(d.amount / maxAmount) * 100}%`,
-                backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
-              }}
-            />
-          </div>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from "react"
+
+import { CHART_COLORS } from "../lib/colors"
+import type { ExpenseResponse } from "../lib/types"
+
+interface SimpleBarChartProps {
+  expenses: ExpenseResponse[]
+}
+
+export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
+  const data = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const e of expenses) {
+      if (e.categories.length === 0) {
+        map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
+      } else {
+        for (const c of e.categories) {
+          map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
+        }
+      }
+    }
+    return [...map.entries()]
+      .map(([name, amount]) => ({ name, amount }))
+      .toSorted((a, b) => b.amount - a.amount)
+  }, [expenses])
+
+  if (data.length === 0) return null
+
+  const maxAmount = data[0].amount
+
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      {data.map((d, i) => (
+        <div key={d.name} className="flex items-center gap-2">
+          <span className="w-16 shrink-0 truncate text-xs text-gray-500 dark:text-gray-400">
+            {d.name}
+          </span>
+          <div className="relative h-4 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${(d.amount / maxAmount) * 100}%`,
+                backgroundColor: CHART_COLORS[i % CHART_COLORS.length],
+              }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react"
 import type { ExpenseResponse } from "../lib/types"
 
 const BAR_COLOR = "var(--chart-bar)"
+const formatAmount = (v: number) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : `${v}`)
 
 interface SimpleBarChartProps {
   expenses: ExpenseResponse[]
@@ -28,22 +29,34 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
   if (data.length === 0) return null
 
   const maxAmount = data[0].amount
+  const midAmount = Math.round(maxAmount / 2)
 
   return (
     <div className="mt-3 flex items-end gap-4">
-      <div className="flex h-[100px] items-end gap-1.5">
-        {data.map((d) => (
-          <div
-            key={d.name}
-            className="w-3.5 rounded-t-md"
-            style={{
-              height: `${(d.amount / maxAmount) * 100}%`,
-              backgroundColor: BAR_COLOR,
-            }}
-          />
-        ))}
+      <div className="flex items-end gap-1">
+        <div className="flex h-[100px] flex-col justify-between pb-0.5 text-right">
+          <span className="text-[10px] text-gray-400 dark:text-gray-500">
+            {formatAmount(maxAmount)}
+          </span>
+          <span className="text-[10px] text-gray-400 dark:text-gray-500">
+            {formatAmount(midAmount)}
+          </span>
+          <span className="text-[10px] text-gray-400 dark:text-gray-500">0</span>
+        </div>
+        <div className="flex h-[100px] items-end gap-1.5">
+          {data.map((d) => (
+            <div
+              key={d.name}
+              className="w-3.5 rounded-t-md"
+              style={{
+                height: `${(d.amount / maxAmount) * 100}%`,
+                backgroundColor: BAR_COLOR,
+              }}
+            />
+          ))}
+        </div>
       </div>
-      <ul className="flex flex-1 flex-col gap-1.5">
+      <ul className="ml-auto flex flex-col gap-1.5">
         {data.map((d, i) => (
           <li key={d.name} className="flex items-center gap-1.5">
             <span className="text-[10px] text-gray-400 dark:text-gray-500">{i + 1}</span>

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -31,7 +31,7 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
 
   return (
     <div className="mt-3 flex flex-col gap-1">
-      <div className="flex h-[100px] items-end justify-center gap-1.5">
+      <div className="flex h-[100px] items-end gap-1.5">
         {data.map((d) => (
           <div
             key={d.name}
@@ -43,7 +43,7 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
           />
         ))}
       </div>
-      <div className="flex justify-center gap-1.5">
+      <div className="flex gap-1.5">
         {data.map((d) => (
           <span
             key={d.name}

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -30,12 +30,12 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
   const maxAmount = data[0].amount
 
   return (
-    <div className="mt-3 flex flex-col gap-1">
+    <div className="mt-3 flex items-end gap-4">
       <div className="flex h-[100px] items-end gap-1.5">
         {data.map((d) => (
           <div
             key={d.name}
-            className="max-w-3.5 flex-1 rounded-t-md"
+            className="w-3.5 rounded-t-md"
             style={{
               height: `${(d.amount / maxAmount) * 100}%`,
               backgroundColor: BAR_COLOR,
@@ -43,16 +43,14 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
           />
         ))}
       </div>
-      <div className="flex gap-1.5">
-        {data.map((d) => (
-          <span
-            key={d.name}
-            className="max-w-3.5 flex-1 truncate text-center text-[9px] text-gray-400 dark:text-gray-500"
-          >
-            {d.name}
-          </span>
+      <ul className="flex flex-1 flex-col gap-1.5">
+        {data.map((d, i) => (
+          <li key={d.name} className="flex items-center gap-1.5">
+            <span className="text-[10px] text-gray-400 dark:text-gray-500">{i + 1}</span>
+            <span className="truncate text-xs text-gray-500 dark:text-gray-400">{d.name}</span>
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/frontend/src/components/SimpleBarChart.tsx
+++ b/frontend/src/components/SimpleBarChart.tsx
@@ -31,11 +31,11 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
 
   return (
     <div className="mt-3 flex flex-col gap-1">
-      <div className="flex h-[100px] items-end gap-1.5">
+      <div className="flex h-[100px] items-end justify-center gap-1.5">
         {data.map((d) => (
           <div
             key={d.name}
-            className="flex-1 rounded-t-md"
+            className="max-w-3.5 flex-1 rounded-t-md"
             style={{
               height: `${(d.amount / maxAmount) * 100}%`,
               backgroundColor: BAR_COLOR,
@@ -43,11 +43,11 @@ export const SimpleBarChart = ({ expenses }: SimpleBarChartProps) => {
           />
         ))}
       </div>
-      <div className="flex gap-1.5">
+      <div className="flex justify-center gap-1.5">
         {data.map((d) => (
           <span
             key={d.name}
-            className="flex-1 truncate text-center text-[9px] text-gray-400 dark:text-gray-500"
+            className="max-w-3.5 flex-1 truncate text-center text-[9px] text-gray-400 dark:text-gray-500"
           >
             {d.name}
           </span>

--- a/frontend/src/pages/TopPage.tsx
+++ b/frontend/src/pages/TopPage.tsx
@@ -2,19 +2,22 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router"
 
 import { MonthlyTrendChart } from "../components/MonthlyTrendChart"
-import { SimplePieChart } from "../components/SimplePieChart"
+import { SimpleBarChart } from "../components/SimpleBarChart"
 import { api } from "../lib/api"
 import { getErrorMessage } from "../lib/client"
 import type { ExpenseResponse } from "../lib/types"
 
-const SkeletonPieChart = () => (
-  <div className="mt-3 flex items-center gap-5">
-    <div className="size-[120px] shrink-0 rounded-full bg-gray-100 dark:bg-gray-700" />
-    <div className="flex flex-1 flex-col gap-2">
-      <div className="h-3 w-20 rounded bg-gray-100 dark:bg-gray-700" />
-      <div className="h-3 w-16 rounded bg-gray-100 dark:bg-gray-700" />
-      <div className="h-3 w-24 rounded bg-gray-100 dark:bg-gray-700" />
-    </div>
+const SkeletonBarChart2 = () => (
+  <div className="mt-3 flex flex-col gap-2">
+    {Array.from({ length: 3 }, (_, i) => (
+      <div key={`skel-${String(i)}`} className="flex items-center gap-2">
+        <div className="h-3 w-16 shrink-0 rounded bg-gray-100 dark:bg-gray-700" />
+        <div
+          className="h-4 animate-pulse rounded-full bg-gray-100 dark:bg-gray-700"
+          style={{ width: `${80 - i * 20}%` }}
+        />
+      </div>
+    ))}
   </div>
 )
 
@@ -77,7 +80,7 @@ export const TopPage = () => {
         <p className="mb-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
           Monthly
         </p>
-        {loading ? <SkeletonPieChart /> : <SimplePieChart expenses={expenses} />}
+        {loading ? <SkeletonBarChart2 /> : <SimpleBarChart expenses={expenses} />}
       </button>
 
       <button

--- a/frontend/src/pages/TopPage.tsx
+++ b/frontend/src/pages/TopPage.tsx
@@ -8,15 +8,13 @@ import { getErrorMessage } from "../lib/client"
 import type { ExpenseResponse } from "../lib/types"
 
 const SkeletonBarChart2 = () => (
-  <div className="mt-3 flex flex-col gap-2">
-    {Array.from({ length: 3 }, (_, i) => (
-      <div key={`skel-${String(i)}`} className="flex items-center gap-2">
-        <div className="h-3 w-16 shrink-0 rounded bg-gray-100 dark:bg-gray-700" />
-        <div
-          className="h-4 animate-pulse rounded-full bg-gray-100 dark:bg-gray-700"
-          style={{ width: `${80 - i * 20}%` }}
-        />
-      </div>
+  <div className="mt-3 flex h-[100px] items-end gap-1.5">
+    {Array.from({ length: 5 }, (_, i) => (
+      <div
+        key={`skel-${String(i)}`}
+        className="flex-1 animate-pulse rounded-t-md bg-gray-100 dark:bg-gray-700"
+        style={{ height: `${40 + Math.random() * 50}%` }}
+      />
     ))}
   </div>
 )


### PR DESCRIPTION
## Summary
- トップページ（ダッシュボード）のカテゴリ別円グラフを水平棒グラフに変更
- `SimpleBarChart` コンポーネントを新規作成
- スケルトンUIも棒グラフ形状に更新

closes #58

## Test plan
- [ ] トップページで水平棒グラフが表示されること
- [ ] カテゴリ別の金額が正しく反映されること
- [ ] データなしの場合に何も表示されないこと
- [ ] ダークモードで正常に表示されること
- [ ] ローディング中にスケルトンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)