### PR TITLE
feat: disable buttons while mutation requests are in flight

### DIFF
--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -4,6 +4,7 @@ interface ConfirmDialogProps {
   message: string
   onConfirm: () => void
   confirmText?: string
+  loading?: boolean
 }
 
 export const useConfirmDialog = () => {
@@ -16,6 +17,7 @@ export const ConfirmDialog = ({
   message,
   onConfirm,
   confirmText = "Delete",
+  loading = false,
   dialogRef,
 }: ConfirmDialogProps & {
   dialogRef: React.RefObject<HTMLDialogElement | null>
@@ -30,14 +32,16 @@ export const ConfirmDialog = ({
         <button
           type="button"
           onClick={() => dialogRef.current?.close()}
-          className="rounded-full px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
+          disabled={loading}
+          className="rounded-full px-4 py-2 text-sm text-gray-500 hover:bg-gray-100 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-700"
         >
           Cancel
         </button>
         <button
           type="button"
           onClick={onConfirm}
-          className="rounded-full bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600"
+          disabled={loading}
+          className="rounded-full bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-700 disabled:opacity-50 dark:bg-red-700 dark:hover:bg-red-600"
         >
           {confirmText}
         </button>

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -13,6 +13,7 @@ export const CategoriesPage = () => {
   const [editing, setEditing] = useState<{ uuid: string; name: string } | null>(null)
   const editInputRef = useRef<HTMLInputElement>(null)
   const [deleteTarget, setDeleteTarget] = useState<CategoryResponse | null>(null)
+  const [loading, setLoading] = useState(false)
   const { dialogRef, open: openDialog } = useConfirmDialog()
 
   const fetchData = useCallback(async () => {
@@ -30,12 +31,15 @@ export const CategoriesPage = () => {
   const handleCreate = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError("")
+    setLoading(true)
     try {
       await api.createCategory({ name })
       setName("")
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to create"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -47,6 +51,7 @@ export const CategoriesPage = () => {
   const handleDelete = async () => {
     if (!deleteTarget) return
     setError("")
+    setLoading(true)
     try {
       await api.deleteCategory(deleteTarget.uuid)
       setDeleteTarget(null)
@@ -54,6 +59,8 @@ export const CategoriesPage = () => {
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -65,12 +72,15 @@ export const CategoriesPage = () => {
   const handleUpdate = async () => {
     if (!editing) return
     setError("")
+    setLoading(true)
     try {
       await api.updateCategory(editing.uuid, { name: editing.name })
       setEditing(null)
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to update"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -95,7 +105,8 @@ export const CategoriesPage = () => {
         />
         <button
           type="submit"
-          className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-white hover:bg-primary-hover"
+          disabled={loading}
+          className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-white hover:bg-primary-hover disabled:opacity-50"
         >
           <PlusIcon className="size-4" />
         </button>
@@ -121,14 +132,16 @@ export const CategoriesPage = () => {
                   <button
                     type="button"
                     onClick={handleUpdate}
-                    className="text-primary hover:text-primary-hover"
+                    disabled={loading}
+                    className="text-primary hover:text-primary-hover disabled:opacity-50"
                   >
                     <CheckIcon className="size-4" />
                   </button>
                   <button
                     type="button"
                     onClick={() => setEditing(null)}
-                    className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                    disabled={loading}
+                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
                   >
                     <ResetIcon className="size-4" />
                   </button>
@@ -139,14 +152,16 @@ export const CategoriesPage = () => {
                   <button
                     type="button"
                     onClick={() => startEdit(c)}
-                    className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                    disabled={loading}
+                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
                   >
                     <Pencil1Icon className="size-3.5" />
                   </button>
                   <button
                     type="button"
                     onClick={() => confirmDelete(c)}
-                    className="text-red-400 hover:text-red-600"
+                    disabled={loading}
+                    className="text-red-400 hover:text-red-600 disabled:opacity-50"
                   >
                     <TrashIcon className="size-3.5" />
                   </button>
@@ -162,6 +177,7 @@ export const CategoriesPage = () => {
       <ConfirmDialog
         message={`Delete "${deleteTarget?.name}"?`}
         onConfirm={handleDelete}
+        loading={loading}
         dialogRef={dialogRef}
       />
     </div>

--- a/frontend/src/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/pages/ExpenseDetailPage.tsx
@@ -21,6 +21,7 @@ export const ExpenseDetailPage = () => {
   const [expense, setExpense] = useState<ExpenseResponse | null>(null)
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
 
   const [form, setForm] = useState({
     name: "",
@@ -61,6 +62,7 @@ export const ExpenseDetailPage = () => {
     e.preventDefault()
     if (!uuid) return
     setError("")
+    setLoading(true)
     try {
       await api.updateExpense(uuid, {
         name: form.name,
@@ -71,6 +73,8 @@ export const ExpenseDetailPage = () => {
       navigate(-1)
     } catch (err) {
       setError(getErrorMessage(err, "Update failed"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -78,12 +82,15 @@ export const ExpenseDetailPage = () => {
 
   const handleDelete = async () => {
     if (!uuid) return
+    setLoading(true)
     try {
       await api.deleteExpense(uuid)
       dialogRef.current?.close()
       navigate("/expense/monthly")
     } catch (err) {
       setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -179,15 +186,17 @@ export const ExpenseDetailPage = () => {
       <button
         type="submit"
         form="expense-detail-form"
-        className="rounded-xl bg-primary px-5 py-4 text-white hover:bg-primary-hover"
+        disabled={loading}
+        className="rounded-xl bg-primary px-5 py-4 text-white hover:bg-primary-hover disabled:opacity-50"
       >
-        Update
+        {loading ? "Updating..." : "Update"}
       </button>
 
       <button
         type="button"
         onClick={openDeleteDialog}
-        className="flex items-center justify-center gap-2 text-sm text-red-500 hover:text-red-600 dark:text-red-400 dark:hover:text-red-300"
+        disabled={loading}
+        className="flex items-center justify-center gap-2 text-sm text-red-500 hover:text-red-600 disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300"
       >
         <TrashIcon className="size-3.5" />
         Delete
@@ -196,6 +205,7 @@ export const ExpenseDetailPage = () => {
       <ConfirmDialog
         message="Delete this expense?"
         onConfirm={handleDelete}
+        loading={loading}
         dialogRef={dialogRef}
       />
     </div>

--- a/frontend/src/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/pages/ExpenseTemplatePage.tsx
@@ -17,6 +17,7 @@ export const ExpenseTemplatePage = () => {
   const [templates, setTemplates] = useState<ExpenseTemplateResponse[]>([])
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
 
   const [form, setForm] = useState({
     name: "",
@@ -51,6 +52,7 @@ export const ExpenseTemplatePage = () => {
   const handleCreate = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError("")
+    setLoading(true)
     try {
       await api.createExpenseTemplate({
         name: form.name,
@@ -61,6 +63,8 @@ export const ExpenseTemplatePage = () => {
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to create"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -75,6 +79,7 @@ export const ExpenseTemplatePage = () => {
   const handleDelete = async () => {
     if (!deleteTarget) return
     setError("")
+    setLoading(true)
     try {
       await api.deleteExpenseTemplate(deleteTarget.uuid)
       setDeleteTarget(null)
@@ -82,6 +87,8 @@ export const ExpenseTemplatePage = () => {
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to delete"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -98,6 +105,7 @@ export const ExpenseTemplatePage = () => {
   const handleUpdate = async () => {
     if (!editing) return
     setError("")
+    setLoading(true)
     try {
       await api.updateExpenseTemplate(editing.uuid, {
         name: editing.name,
@@ -108,6 +116,8 @@ export const ExpenseTemplatePage = () => {
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to update"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -163,7 +173,8 @@ export const ExpenseTemplatePage = () => {
           </div>
           <button
             type="submit"
-            className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-white hover:bg-primary-hover"
+            disabled={loading}
+            className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-white hover:bg-primary-hover disabled:opacity-50"
           >
             <PlusIcon className="size-4" />
           </button>
@@ -232,14 +243,16 @@ export const ExpenseTemplatePage = () => {
                     <button
                       type="button"
                       onClick={handleUpdate}
-                      className="text-primary hover:text-primary-hover"
+                      disabled={loading}
+                      className="text-primary hover:text-primary-hover disabled:opacity-50"
                     >
                       <CheckIcon className="size-4" />
                     </button>
                     <button
                       type="button"
                       onClick={() => setEditing(null)}
-                      className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                      disabled={loading}
+                      className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
                     >
                       <ResetIcon className="size-4" />
                     </button>
@@ -259,14 +272,16 @@ export const ExpenseTemplatePage = () => {
                   <button
                     type="button"
                     onClick={() => startEdit(t)}
-                    className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                    disabled={loading}
+                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
                   >
                     <Pencil1Icon className="size-3.5" />
                   </button>
                   <button
                     type="button"
                     onClick={() => confirmDelete(t)}
-                    className="text-red-400 hover:text-red-600"
+                    disabled={loading}
+                    className="text-red-400 hover:text-red-600 disabled:opacity-50"
                   >
                     <TrashIcon className="size-3.5" />
                   </button>
@@ -282,6 +297,7 @@ export const ExpenseTemplatePage = () => {
       <ConfirmDialog
         message={`Delete "${deleteTarget?.name}"?`}
         onConfirm={handleDelete}
+        loading={loading}
         dialogRef={dialogRef}
       />
     </div>

--- a/frontend/src/pages/ExpensesPage.tsx
+++ b/frontend/src/pages/ExpensesPage.tsx
@@ -16,6 +16,7 @@ export const ExpensesPage = () => {
   const nameRef = useRef<HTMLInputElement>(null)
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
 
   // Create form
   const now = new Date()
@@ -50,6 +51,7 @@ export const ExpensesPage = () => {
   const handleCreate = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError("")
+    setLoading(true)
     try {
       await api.createExpense({
         name: form.name,
@@ -60,6 +62,8 @@ export const ExpensesPage = () => {
       navigate("/expense/monthly")
     } catch (err) {
       setError(getErrorMessage(err, "Failed to create"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -146,15 +150,17 @@ export const ExpensesPage = () => {
       <button
         type="submit"
         form="expense-form"
-        className="rounded-xl bg-primary px-5 py-4 text-white hover:bg-primary-hover"
+        disabled={loading}
+        className="rounded-xl bg-primary px-5 py-4 text-white hover:bg-primary-hover disabled:opacity-50"
       >
-        Add
+        {loading ? "Adding..." : "Add"}
       </button>
 
       <button
         type="button"
         onClick={() => navigate("/expense/template/new")}
-        className="rounded-xl border border-gray-200 px-5 py-4 text-sm text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        disabled={loading}
+        className="rounded-xl border border-gray-200 px-5 py-4 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
       >
         Template
       </button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -34,6 +34,7 @@ export const SettingsPage = () => {
   const [name, setName] = useState("")
   const [theme, setTheme] = useState<ThemeMode>(getStoredTheme)
   const [success, setSuccess] = useState("")
+  const [loading, setLoading] = useState(false)
   const { dialogRef, open: openDialog } = useConfirmDialog()
   const { dialogRef: importDialogRef, open: openImportDialog } = useConfirmDialog()
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -51,17 +52,21 @@ export const SettingsPage = () => {
 
   const handleUpdate = async () => {
     setError("")
+    setLoading(true)
     try {
       await api.updateMe({ name })
       setEditing(false)
       await refreshUser()
     } catch (err) {
       setError(getErrorMessage(err, "Update failed"))
+    } finally {
+      setLoading(false)
     }
   }
 
   const handleDelete = async () => {
     setError("")
+    setLoading(true)
     try {
       await api.deleteMe()
       localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
@@ -69,6 +74,8 @@ export const SettingsPage = () => {
       window.location.href = "/auth"
     } catch (err) {
       setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -108,6 +115,7 @@ export const SettingsPage = () => {
   const handleImport = async () => {
     setError("")
     setSuccess("")
+    setLoading(true)
     importDialogRef.current?.close()
     try {
       const result = await api.importMe(importDataRef.current)
@@ -116,6 +124,7 @@ export const SettingsPage = () => {
       setError(getErrorMessage(err, "Import failed"))
     } finally {
       importDataRef.current = null
+      setLoading(false)
     }
   }
 
@@ -139,14 +148,16 @@ export const SettingsPage = () => {
             <button
               type="button"
               onClick={handleUpdate}
-              className="text-primary hover:text-primary-hover"
+              disabled={loading}
+              className="text-primary hover:text-primary-hover disabled:opacity-50"
             >
               <CheckIcon className="size-4" />
             </button>
             <button
               type="button"
               onClick={() => setEditing(false)}
-              className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+              disabled={loading}
+              className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
             >
               <ResetIcon className="size-4" />
             </button>
@@ -216,7 +227,8 @@ export const SettingsPage = () => {
         <button
           type="button"
           onClick={() => fileInputRef.current?.click()}
-          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+          disabled={loading}
+          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-700"
         >
           <UploadIcon className="size-4 text-gray-400 dark:text-gray-500" />
           <span className="flex-1">Import Data</span>
@@ -245,7 +257,8 @@ export const SettingsPage = () => {
         <button
           type="button"
           onClick={openDialog}
-          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950"
+          disabled={loading}
+          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-950"
         >
           <TrashIcon className="size-4" />
           <span className="flex-1">Delete Account</span>
@@ -255,12 +268,14 @@ export const SettingsPage = () => {
       <ConfirmDialog
         message="All your expense data will be permanently deleted. Are you sure?"
         onConfirm={handleDelete}
+        loading={loading}
         dialogRef={dialogRef}
       />
       <ConfirmDialog
         message="All existing categories, expenses, and templates will be deleted and replaced with the imported data. Continue?"
         onConfirm={handleImport}
         confirmText="Import"
+        loading={loading}
         dialogRef={importDialogRef}
       />
     </div>


### PR DESCRIPTION
## Summary

POST / PATCH / DELETE 通信中に、対応するボタンを `disabled` にして二重送信を防ぐ制御を追加しました。

- 各ページにローカルな `loading` ステートを追加し、リクエスト開始で `true`、`finally` で `false` に戻す
- 対象ボタン（送信・更新・削除・編集確定・取消・テンプレート遷移など）に `disabled={loading}` と `disabled:opacity-50` を付与
- `ConfirmDialog` に `loading` プロップを追加し、確認/キャンセルボタンも処理中は無効化

### 変更ファイル

- `frontend/src/components/ConfirmDialog.tsx` — `loading` プロップ追加
- `frontend/src/pages/CategoriesPage.tsx` — 作成 / 更新 / 削除
- `frontend/src/pages/ExpenseDetailPage.tsx` — 更新 / 削除
- `frontend/src/pages/ExpenseTemplatePage.tsx` — 作成 / 更新 / 削除
- `frontend/src/pages/ExpensesPage.tsx` — 作成
- `frontend/src/pages/SettingsPage.tsx` — プロフィール更新 / アカウント削除 / インポート

`SignupPage` / `SignInPage` / `ExpenseTemplateRecordPage` は元から同等のローディング制御が入っていたため変更不要です。

## Test plan

- [ ] `make lint` がパスする（typecheck / oxlint / oxfmt 確認済み）
- [ ] 各フォームの送信中、ボタンが `opacity-50` で押せなくなることを確認
- [ ] 削除確認ダイアログの確認/キャンセルボタンが処理中に無効化されることを確認
- [ ] エラー発生時にもボタンが再度有効に戻ることを確認

https://claude.ai/code/session_01CtZgBXQxUX4Mw4oLSRpRLi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtZgBXQxUX4Mw4oLSRpRLi)_