### PR TITLE
chore: ローカル起動のポート番号を変更

### DIFF
--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -19,9 +19,9 @@
 
 | Service | Image | Port |
 |---------|-------|------|
-| backend | Python 3.14-slim + uvicorn | 9999 |
-| frontend | Node 22-slim + Vite | 5173 |
-| db | PostgreSQL 18 | 5432 |
+| backend | Python 3.14-slim + uvicorn | 13000 |
+| frontend | Node 22-slim + Vite | 15173 |
+| db | PostgreSQL 18 | 15432 |
 
 ### Hot Reload
 
@@ -69,11 +69,11 @@ deploy.yml (unified)
 
 | Variable | Purpose |
 |----------|---------|
-| `API_PORT` | Backend port (9999) |
+| `API_PORT` | Backend port (13000) |
 | `POSTGRES_USER` / `PASSWORD` / `DB` | DB connection info |
-| `POSTGRES_PORT` | DB port (5432) |
+| `POSTGRES_PORT` | DB port (15432) |
 | `DATABASE_URL` | DB connection URL |
-| `FRONTEND_PORT` | Frontend port (5173) |
+| `FRONTEND_PORT` | Frontend port (15173) |
 
 ### Local + Production
 

--- a/.env.template
+++ b/.env.template
@@ -1,14 +1,14 @@
 # =========================
 # Local only
 # =========================
-API_PORT=9999
+API_PORT=13000
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
-POSTGRES_PORT=5432
+POSTGRES_PORT=15432
 PYTHONDONTWRITEBYTECODE=1
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:${POSTGRES_PORT}/${POSTGRES_DB}
-FRONTEND_PORT=5173
+FRONTEND_PORT=15173
 
 # =========================
 # Local + Vercel（本番では適切な値に変更）
@@ -21,5 +21,5 @@ FRONTEND_ORIGIN=http://localhost:${FRONTEND_PORT}
 # =========================
 # Vercel only
 # =========================
-VITE_API_URL=http://localhost:9999
+VITE_API_URL=http://localhost:13000
 POSTGRES_URL=

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -28,4 +28,4 @@ def get_webauthn_rp_name() -> str:
 
 def get_frontend_origin() -> str:
     """Get the frontend origin URL."""
-    return os.getenv("FRONTEND_ORIGIN", "http://localhost:5173")
+    return os.getenv("FRONTEND_ORIGIN", "http://localhost:15173")

--- a/frontend/src/lib/client.ts
+++ b/frontend/src/lib/client.ts
@@ -14,7 +14,7 @@ const STATUS_MESSAGES: Record<number, string> = {
   500: "Server error",
 }
 
-const baseUrl = import.meta.env.VITE_API_URL ?? "http://localhost:9999"
+const baseUrl = import.meta.env.VITE_API_URL ?? "http://localhost:13000"
 
 const getHeaders = (): HeadersInit => {
   const headers: Record<string, string> = {


### PR DESCRIPTION
#67

## 概要
他プロジェクトとのポート競合を避けるため、ローカル起動時のポート番号を変更。

## 変更内容
| サービス | 変更前 | 変更後 |
|---------|-------|-------|
| API (backend) | 9999 | 13000 |
| Frontend | 5173 | 15173 |
| DB (PostgreSQL) | 5432 | 15432 |

## 修正ファイル
- `.env.template` - 各 `*_PORT` および `VITE_API_URL`
- `frontend/src/lib/client.ts` - `baseUrl` フォールバック値
- `backend/src/config.py` - `FRONTEND_ORIGIN` フォールバック値
- `.claude/rules/infra.md` - ドキュメントのポート記載

## 補足
各開発者のローカル `.env` ファイルもmerge後に要更新。