### PR TITLE
chore: Node.jsバージョンをLTSの24系に更新

### DIFF
--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -20,7 +20,7 @@
 | Service | Image | Port |
 |---------|-------|------|
 | backend | Python 3.14-slim + uvicorn | 13000 |
-| frontend | Node 22-slim + Vite | 15173 |
+| frontend | Node 24-slim + Vite | 15173 |
 | db | PostgreSQL 18 | 15432 |
 
 ### Hot Reload

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Install dependencies
         run: cd frontend && npm ci
 
@@ -33,6 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
 
       - name: Install Vercel CLI
         run: npm install -g vercel

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
#69

## 概要
Node.jsバージョンをLTSである24系に統一。`@types/node` は既に `^24.10.1` のため、Docker・CI・型定義の整合をとる。

## 変更内容
- `frontend/Dockerfile`: `node:22-slim` → `node:24-slim`
- `.github/workflows/deploy_frontend.yml`: `actions/setup-node@v4` で `node-version: 24` を明示（lint・deploy両jobに追加）
- `.claude/rules/infra.md`: ドキュメントを `Node 24-slim` に更新

## 確認
- `make lint` 通過（typecheck含む）