### PR TITLE
fix: dbコンテナのlistenポートをPOSTGRES_PORTに揃える

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       context: ./db
       dockerfile: Dockerfile.db
     container_name: burn-style_db
+    command: -p ${POSTGRES_PORT}
     env_file:
       - .env
     ports:


### PR DESCRIPTION
## 概要
#67 のポート変更後、dbへの接続が `server closed the connection unexpectedly` で失敗する不具合の修正。

## 原因
- 公式 \`postgres\` イメージはコンテナ内部で **5432** をlistenする
- \`docker-compose.yml\` の \`ports: \"\${POSTGRES_PORT}:\${POSTGRES_PORT}\"\` でホスト15432→コンテナ15432にmappingしていたが、コンテナ内部では5432でlisten中
- ホストからの15432宛て接続も、backend→\`db:15432\` の接続も到達不可

## 変更内容
\`docker-compose.yml\` の db サービスに \`command: -p \${POSTGRES_PORT}\` を追加。コンテナ内部でも同ポートでlistenするよう変更。

## 確認
- \`docker compose down db && docker compose up -d db\` 後、ログに \`listening on IPv4 address "0.0.0.0", port 15432\` を確認