### PR TITLE
feat: 月次/年次画面でデータが無い場合の空状態UIを追加

### DIFF
--- a/frontend/src/components/ExpenseEmptyState.tsx
+++ b/frontend/src/components/ExpenseEmptyState.tsx
@@ -1,0 +1,32 @@
+import { FileTextIcon, PlusIcon } from "@radix-ui/react-icons"
+import { useNavigate } from "react-router"
+
+interface ExpenseEmptyStateProps {
+  period: string
+}
+
+export const ExpenseEmptyState = ({ period }: ExpenseEmptyStateProps) => {
+  const navigate = useNavigate()
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 py-12 text-center">
+      <div className="flex size-14 items-center justify-center rounded-full bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-500">
+        <FileTextIcon className="size-6" />
+      </div>
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-medium text-gray-600 dark:text-gray-300">
+          No expenses for {period}
+        </p>
+        <p className="text-xs text-gray-400 dark:text-gray-500">Start tracking your spending</p>
+      </div>
+      <button
+        type="button"
+        onClick={() => navigate("/expense/new")}
+        className="mt-2 inline-flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2.5 text-sm text-white hover:bg-primary-hover"
+      >
+        <PlusIcon />
+        Add expense
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/ExpenseAnnualPage.tsx
+++ b/frontend/src/pages/ExpenseAnnualPage.tsx
@@ -10,6 +10,7 @@ import { useSearchParams } from "react-router"
 
 import { AnnualAreaChart } from "../components/AnnualAreaChart"
 import { AnnualLineChart } from "../components/AnnualLineChart"
+import { ExpenseEmptyState } from "../components/ExpenseEmptyState"
 import { useSwipe } from "../hooks/useSwipe"
 import { api } from "../lib/api"
 import { getErrorMessage } from "../lib/client"
@@ -126,30 +127,36 @@ export const ExpenseAnnualPage = () => {
         ))}
       </div>
 
-      {tab === "list" && (
-        <div className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-2 pt-4">
-          {monthlyTotals.map((amount, i) => (
-            <div
-              key={`month-${String(i)}`}
-              className="flex items-center justify-between rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-gray-800"
-            >
-              <span className="text-sm">{MONTH_LABELS[i]}</span>
-              <span className="text-sm font-mono">¥{amount.toLocaleString()}</span>
+      {expenses.length === 0 ? (
+        <ExpenseEmptyState period={String(year)} />
+      ) : (
+        <>
+          {tab === "list" && (
+            <div className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-2 pt-4">
+              {monthlyTotals.map((amount, i) => (
+                <div
+                  key={`month-${String(i)}`}
+                  className="flex items-center justify-between rounded-xl bg-white px-4 py-3 shadow-sm dark:bg-gray-800"
+                >
+                  <span className="text-sm">{MONTH_LABELS[i]}</span>
+                  <span className="text-sm font-mono">¥{amount.toLocaleString()}</span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      )}
+          )}
 
-      {tab === "area" && (
-        <div className="min-h-0 flex-1 overflow-y-auto pt-4">
-          <AnnualAreaChart expenses={expenses} />
-        </div>
-      )}
+          {tab === "area" && (
+            <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+              <AnnualAreaChart expenses={expenses} />
+            </div>
+          )}
 
-      {tab === "line" && (
-        <div className="min-h-0 flex-1 overflow-y-auto pt-4">
-          <AnnualLineChart expenses={expenses} />
-        </div>
+          {tab === "line" && (
+            <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+              <AnnualLineChart expenses={expenses} />
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -12,6 +12,7 @@ import { useSearchParams } from "react-router"
 
 import { CategoryBarChart } from "../components/CategoryBarChart"
 import { CategoryBubbleChart } from "../components/CategoryBubbleChart"
+import { ExpenseEmptyState } from "../components/ExpenseEmptyState"
 import { ExpenseHeatmap } from "../components/ExpenseHeatmap"
 import { ExpenseList } from "../components/ExpenseList"
 import { PieWithStep } from "../components/PieWithStep"
@@ -190,30 +191,36 @@ export const ExpenseMonthlyPage = () => {
       )}
 
       <div ref={swipeRef} className="flex min-h-0 flex-1 flex-col">
-        {tab === "list" && <ExpenseList expenses={filteredExpenses} />}
+        {expenses.length === 0 ? (
+          <ExpenseEmptyState period={`${year}/${month}`} />
+        ) : (
+          <>
+            {tab === "list" && <ExpenseList expenses={filteredExpenses} />}
 
-        {tab === "pie" && (
-          <div className="min-h-0 flex-1 overflow-y-auto pt-4">
-            <PieWithStep expenses={filteredExpenses} />
-          </div>
-        )}
+            {tab === "pie" && (
+              <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+                <PieWithStep expenses={filteredExpenses} />
+              </div>
+            )}
 
-        {tab === "heatmap" && (
-          <div className="min-h-0 flex-1 overflow-y-auto pt-4">
-            <ExpenseHeatmap year={year} month={month} expenses={filteredExpenses} />
-          </div>
-        )}
+            {tab === "heatmap" && (
+              <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+                <ExpenseHeatmap year={year} month={month} expenses={filteredExpenses} />
+              </div>
+            )}
 
-        {tab === "bubble" && (
-          <div className="min-h-0 flex-1 overflow-y-auto pt-4">
-            <CategoryBubbleChart expenses={filteredExpenses} />
-          </div>
-        )}
+            {tab === "bubble" && (
+              <div className="min-h-0 flex-1 overflow-y-auto pt-4">
+                <CategoryBubbleChart expenses={filteredExpenses} />
+              </div>
+            )}
 
-        {tab === "bar" && (
-          <div className="flex min-h-0 flex-1 flex-col pt-4">
-            <CategoryBarChart expenses={filteredExpenses} />
-          </div>
+            {tab === "bar" && (
+              <div className="flex min-h-0 flex-1 flex-col pt-4">
+                <CategoryBarChart expenses={filteredExpenses} />
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/frontend/src/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/pages/ExpenseMonthlyPage.tsx
@@ -134,7 +134,7 @@ export const ExpenseMonthlyPage = () => {
         </button>
         <div className="text-center">
           <p className="text-sm text-gray-500 dark:text-gray-400">
-            {year}/{month} Expenses
+            {year}/{month}
           </p>
           <p className="text-4xl font-extrabold">¥{total.toLocaleString()}</p>
         </div>

--- a/frontend/src/pages/TopPage.tsx
+++ b/frontend/src/pages/TopPage.tsx
@@ -78,7 +78,15 @@ export const TopPage = () => {
         <p className="mb-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
           Monthly
         </p>
-        {loading ? <SkeletonBarChart2 /> : <SimpleBarChart expenses={expenses} />}
+        {loading ? (
+          <SkeletonBarChart2 />
+        ) : expenses.length === 0 ? (
+          <div className="flex h-[100px] items-center justify-center text-xs text-gray-400 dark:text-gray-500">
+            No expenses this month
+          </div>
+        ) : (
+          <SimpleBarChart expenses={expenses} />
+        )}
       </button>
 
       <button


### PR DESCRIPTION
## 概要
月次・年次の分析画面で、その期間に支出データが無い場合の空状態UIを追加。
従来は空のグラフや ¥0 が並んだ12ヶ月リストが表示され、何をすべきか不明瞭だった。

## 変更内容
- 共通コンポーネント `ExpenseEmptyState` を追加
  - アイコン + 「No expenses for {期間}」 + 「Add expense」ボタン
  - ボタンクリックで `/expense/new` へ遷移
- `ExpenseMonthlyPage`: \`expenses.length === 0\` の場合に各タブ共通で表示
- `ExpenseAnnualPage`: 同上

## 動作確認
- \`make lint\` 通過
- 期間切り替え（前/次月、前/次年）で空状態 ↔ データ表示が切り替わることを確認すること