### PR TITLE
fix: CORS preflightキャッシュを無効化

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -39,6 +39,7 @@ app.add_middleware(
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization"],
     expose_headers=["X-New-Token"],
+    max_age=0,
 )
 
 # Register routers


### PR DESCRIPTION
## 概要
CORS設定の変更や障害時に、ブラウザがpreflightレスポンスをキャッシュしているため最大10分間古い結果で混乱する問題への対策。

## 原因
\`CORSMiddleware\` のデフォルト \`max_age\` は600秒。一度CORS失敗のpreflightをブラウザがキャッシュすると、サーバー側修正後もしばらくCORSエラーが続く。

## 変更内容
\`backend/src/main.py\` の \`CORSMiddleware\` に \`max_age=0\` を指定。

## トレードオフ
preflightリクエストが毎回サーバーに飛ぶようになるが、本アプリ規模では実質無視できるコスト。

## 確認
- \`make lint\` 通過
- \`make test-backend\` 通過（27 passed）