### PR TITLE
ci: actions/setup-node を v5 に更新

### DIFF
--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 


### PR DESCRIPTION
## 概要
GitHub Actionsで \`actions/setup-node@v4\` がNode.js 20で動作しているため非推奨warningが発生。v5（Node.js 24）に更新。

## 警告内容
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.

## 変更内容
\`.github/workflows/deploy_frontend.yml\` の \`actions/setup-node@v4\` → \`@v5\`（lint・deploy 2箇所）

## 補足
他のactionは既にNode 24対応版（\`actions/checkout@v6\`、\`actions/setup-python@v6\`、\`astral-sh/setup-uv@v7\`）。