### PR TITLE
docs: READMEを平易で簡潔な表現に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,7 @@
 
 > **Burn** your money, show your **Style**.
 
-How you spend money reveals who you are.
+A simple expense tracker — no budgets, no alerts, no judgement.
 
-Income is shaped by circumstance. But spending is shaped by choice.
-
-Two people with the same income can live entirely different lives — one spends ¥10,000 a month on coffee, another on books. Same amount, different stories.
-
-Spending is the accumulation of small, daily decisions. What you buy and what you don't — that chain of choices reflects values you may never put into words.
-
-Not "saving." Discovery.
-BurnStyle is not a tool for cutting expenses. It's a tool for understanding what you truly value.
-Not finding waste to eliminate, but observing the contours of your own consumption.
-
-You think you know yourself best?
-The story your spending tells — you haven't read it yet.
-
-Your style lives in the way you burn.
+What you buy, and what you don't, tells a story about what you value.
+BurnStyle just helps you see it.


### PR DESCRIPTION
## 概要
冗長で抽象的だった README を、コンセプトの核を残しつつ簡潔に書き直し。

## 変更内容
- タイトル・タグライン \`Burn your money, show your Style.\` はそのまま維持
- 7段落あった本文を 3行に圧縮
- 何のアプリか（シンプルな支出トラッカー）と、何をしないか（予算・通知・判定なし）を明示

## Before
\`\`\`
How you spend money reveals who you are.
Income is shaped by circumstance. But spending is shaped by choice.
（…7段落の哲学的な文章）
\`\`\`

## After
\`\`\`
A simple expense tracker — no budgets, no alerts, no judgement.

What you buy, and what you don't, tells a story about what you value.
BurnStyle just helps you see it.
\`\`\`