### PR TITLE
feat: signin画面でAPI/DBをwarm-up

### DIFF
--- a/backend/src/api/health.py
+++ b/backend/src/api/health.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from src.repository.database import get_db
 
 health_router = APIRouter()
 
@@ -11,5 +17,6 @@ async def root() -> dict[str, str]:
 
 
 @health_router.get("/health")
-async def health_check() -> dict[str, str]:
+def health_check(db: Annotated[Session, Depends(get_db)]) -> dict[str, str]:
+    db.execute(text("SELECT 1"))
     return {"status": "healthy"}

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -9,7 +9,7 @@ def test_root(client: TestClient) -> None:
     assert res.json() == {"message": "BurnStyle API is running"}
 
 
-def test_health_check(client: TestClient) -> None:
-    res = client.get("/health")
+def test_health_check(auth_client: TestClient) -> None:
+    res = auth_client.get("/health")
     assert res.status_code == 200
     assert res.json() == {"status": "healthy"}

--- a/frontend/src/auth/pages/SignInPage.tsx
+++ b/frontend/src/auth/pages/SignInPage.tsx
@@ -1,9 +1,9 @@
 import { Cross2Icon } from "@radix-ui/react-icons"
-import { type SubmitEvent, useState } from "react"
+import { type SubmitEvent, useEffect, useState } from "react"
 import { Link, useNavigate } from "react-router"
 
 import { api } from "../../common/libs/api"
-import { getErrorMessage } from "../../common/libs/client"
+import { client, getErrorMessage } from "../../common/libs/client"
 import { STORAGE_KEYS } from "../../common/libs/constants"
 
 export const SignInPage = () => {
@@ -13,6 +13,10 @@ export const SignInPage = () => {
   )
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    client.get("/health").catch(() => {})
+  }, [])
 
   const clearUsername = () => {
     setUsername("")

--- a/frontend/src/auth/pages/SignInPage.tsx
+++ b/frontend/src/auth/pages/SignInPage.tsx
@@ -14,6 +14,7 @@ export const SignInPage = () => {
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
 
+  // cold start対策: ユーザーが入力している間にAPI/DBを起こしておく
   useEffect(() => {
     client.get("/health").catch(() => {})
   }, [])


### PR DESCRIPTION
## 概要

Vercel本番環境でログインボタン押下後の cold start (約2〜5s) が体感を悪化させているのを軽減。
signin画面表示中に裏で warm-up リクエストを発火させ、ユーザーがusernameを入力している間に Vercel function 起動 + Neon wake-up を消化する。

## 変更点

### backend

- `/health` で `SELECT 1` を実行してDB疎通も検証する形に変更
  - 単なるアプリ生存確認ではなく、Neon wake-upも兼ねる
  - DB障害時には500を返すので死活監視としてもより正確になる

### frontend

- `SignInPage` の `useEffect` で `/health` を fire-and-forget 呼び出し
  - エラーは握りつぶす (ログインフロー本体には影響させない)

## 期待効果

- 従来: `Sign In` ボタン押下 → cold start発火 → 2〜5s待ち
- 改善後: 画面表示と同時にwarm-up → 入力中にcold start消化 → ボタン押下後はほぼ即応

## Test plan

- [ ] `make test-backend` Pass
- [ ] `make lint` Pass
- [ ] 本番にデプロイ後、suspend状態から signin 画面を開いて DevTools の Network で `/health` が走り、その後の signin が速いことを確認