### PR TITLE
feat: 構造化JSONロギング基盤を追加

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -7,6 +7,11 @@
 - `print()` is only allowed in `scripts/` directory
 - `.env` must not be committed (use `.env.template` instead)
 
+## Logging
+- Use `src.logger.get_logger(name)` — never `print()` in app code
+- Pass structured data via `extra={...}` (e.g. `logger.info("user signed in", extra={"event": "signin"})`)
+- `request_id` and `user_uuid` are auto-injected from contextvars — do not pass them explicitly
+
 ## mypy / ruff
 - mypy strict mode required, type annotations on all functions and variables
 - ruff line length: 120

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -6,6 +6,7 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy.orm import Session
 
+from src.logger import user_uuid_var
 from src.model.user import User
 from src.repository.database import get_db
 from src.repository.user_repository import get_user_by_uuid
@@ -32,4 +33,5 @@ def get_current_user(
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
 
+    user_uuid_var.set(user_uuid)
     return user

--- a/backend/src/logger.py
+++ b/backend/src/logger.py
@@ -16,7 +16,7 @@ class JsonFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         payload: dict[str, Any] = {
-            "ts": datetime.now(UTC).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
             "level": record.levelname,
             "logger": record.name,
             "msg": record.getMessage(),

--- a/backend/src/logger.py
+++ b/backend/src/logger.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from contextvars import ContextVar
+from datetime import UTC, datetime
+from typing import Any
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+user_uuid_var: ContextVar[str | None] = ContextVar("user_uuid", default=None)
+
+
+class JsonFormatter(logging.Formatter):
+    """JSON formatter that auto-includes request_id and user_uuid from contextvars."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if request_id := request_id_var.get():
+            payload["request_id"] = request_id
+        if user_uuid := user_uuid_var.get():
+            payload["user_uuid"] = user_uuid
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        payload.update(
+            {k: v for k, v in record.__dict__.items() if k not in _RESERVED_KEYS},
+        )
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+_RESERVED_KEYS = {
+    "args", "asctime", "created", "exc_info", "exc_text", "filename", "funcName",
+    "levelname", "levelno", "lineno", "message", "module", "msecs", "msg", "name",
+    "pathname", "process", "processName", "relativeCreated", "stack_info", "thread",
+    "threadName", "taskName",
+}
+
+
+def configure_logging() -> None:
+    """Install JsonFormatter on the root logger. Idempotent."""
+    root = logging.getLogger()
+    if any(isinstance(h.formatter, JsonFormatter) for h in root.handlers):
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger under the burnstyle namespace."""
+    configure_logging()
+    return logging.getLogger(f"burnstyle.{name}")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -13,7 +13,10 @@ from src.api import (
     user_router,
 )
 from src.config import get_frontend_origin
-from src.middleware import TokenRefreshMiddleware
+from src.logger import configure_logging
+from src.middleware import RequestLoggingMiddleware, TokenRefreshMiddleware
+
+configure_logging()
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -29,7 +32,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 app = FastAPI(title="BurnStyle API", version="1.0.0")
 
 # Middleware (later additions wrap outer layers)
-# Request order: CORS -> SecurityHeaders -> TokenRefresh -> Router
+# Request order: RequestLogging -> CORS -> SecurityHeaders -> TokenRefresh -> Router
 app.add_middleware(TokenRefreshMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(
@@ -38,9 +41,10 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization"],
-    expose_headers=["X-New-Token"],
+    expose_headers=["X-New-Token", "X-Request-ID"],
     max_age=0,
 )
+app.add_middleware(RequestLoggingMiddleware)
 
 # Register routers
 app.include_router(health_router)

--- a/backend/src/middleware/__init__.py
+++ b/backend/src/middleware/__init__.py
@@ -1,3 +1,4 @@
+from src.middleware.request_logging import RequestLoggingMiddleware
 from src.middleware.token_refresh import TokenRefreshMiddleware
 
-__all__ = ["TokenRefreshMiddleware"]
+__all__ = ["RequestLoggingMiddleware", "TokenRefreshMiddleware"]

--- a/backend/src/middleware/request_logging.py
+++ b/backend/src/middleware/request_logging.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import time
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from src.logger import get_logger, request_id_var
+
+logger = get_logger("request")
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Assign request_id, emit start/end access logs with duration."""
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        request_id = request.headers.get("x-vercel-id") or str(uuid.uuid4())
+        token = request_id_var.set(request_id)
+        start = time.perf_counter()
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+            logger.exception(
+                "request failed",
+                extra={"method": request.method, "path": request.url.path, "duration_ms": duration_ms},
+            )
+            raise
+        finally:
+            request_id_var.reset(token)
+
+        duration_ms = round((time.perf_counter() - start) * 1000, 2)
+        logger.info(
+            "request",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status": response.status_code,
+                "duration_ms": duration_ms,
+            },
+        )
+        response.headers["X-Request-ID"] = request_id
+        return response


### PR DESCRIPTION
## 概要

Vercelの Function Logs を活用しやすいよう構造化JSONログ基盤を導入。
全リクエストに request_id を採番し、認証済みリクエストには user_uuid も自動付与する。

## 構成

### `src/logger.py`
- `JsonFormatter`: 標準 `logging.Formatter` を継承、stdlib `json` で出力 (依存追加なし)
- `request_id_var` / `user_uuid_var`: `contextvars.ContextVar` でリクエスト単位の値を保持
- `get_logger(name)`: 自動で `configure_logging()` を呼び `burnstyle.{name}` のロガーを返す

### `src/middleware/request_logging.py`
- `RequestLoggingMiddleware`:
  - `x-vercel-id` ヘッダがあれば採用 (Vercelダッシュボードと突合可能) / なければ `uuid4`
  - `request_id_var` に格納し、後続のログ呼び出しで自動付与
  - リクエスト終了時に `method` / `path` / `status` / `duration_ms` をINFO出力
  - 例外発生時は `logger.exception` でstack traceを含めERROR出力
  - レスポンスに `X-Request-ID` ヘッダを付与

### `src/api/deps.py`
- `get_current_user` 内で `user_uuid_var.set()` を呼び、認証済みリクエストのログにユーザー情報自動付与

### `src/main.py`
- 起動時に `configure_logging()` を実行
- `RequestLoggingMiddleware` を最外層に登録 (CORSの外)
- CORSの `expose_headers` に `X-Request-ID` 追加

## 出力例

```json
{"ts":"2026-05-09T12:34:56.789012+00:00","level":"INFO","logger":"burnstyle.request","msg":"request","request_id":"iad1::xxx","user_uuid":"abc...","method":"POST","path":"/auth/signin/verify","status":200,"duration_ms":142.3}
```

## 利用方法

```python
from src.logger import get_logger

logger = get_logger("api.auth")
logger.info("user signed in", extra={"event": "signin_success"})
```

`request_id` / `user_uuid` は contextvars から自動で取得されるので呼び出し側で渡す必要なし。

## Test plan

- [ ] `make test-backend` Pass
- [ ] `make lint` Pass
- [ ] ローカルでDocker起動 → リクエスト送信 → ターミナルにJSONログが出力される
- [ ] レスポンスヘッダに `X-Request-ID` が含まれる
- [ ] Vercel本番にデプロイ後、Function Logsで JSON が認識される