### PR TITLE
feat: RecurringExpenseモデル追加 (1/3)

### DIFF
--- a/backend/alembic/versions/aec700ae61d2_add_recurring_expenses_and_expenses_.py
+++ b/backend/alembic/versions/aec700ae61d2_add_recurring_expenses_and_expenses_.py
@@ -1,0 +1,71 @@
+"""recurring_expenses追加 + expenses.recurring_expense_uuid追加
+
+Revision ID: aec700ae61d2
+Revises: 9ca611086cef
+Create Date: 2026-05-09 20:47:00.225698
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "aec700ae61d2"
+down_revision: str | Sequence[str] | None = "9ca611086cef"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+FK_NAME = "expenses_recurring_expense_uuid_fkey"
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "recurring_expenses",
+        sa.Column("uuid", sa.String(length=32), nullable=False),
+        sa.Column("user_uuid", sa.String(length=32), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("amount", sa.Integer(), nullable=False),
+        sa.Column("category_uuid", sa.String(length=32), nullable=False),
+        sa.Column(
+            "interval_unit",
+            sa.Enum("WEEK", "MONTH", name="interval_unit"),
+            nullable=False,
+        ),
+        sa.Column("interval_count", sa.Integer(), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint("amount > 0", name="check_recurring_expense_amount_positive"),
+        sa.CheckConstraint(
+            "interval_count > 0", name="check_recurring_expense_interval_count_positive",
+        ),
+        sa.ForeignKeyConstraint(["category_uuid"], ["categories.uuid"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_uuid"], ["users.uuid"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("uuid"),
+    )
+    op.add_column(
+        "expenses",
+        sa.Column("recurring_expense_uuid", sa.String(length=32), nullable=True),
+    )
+    op.create_foreign_key(
+        FK_NAME,
+        "expenses",
+        "recurring_expenses",
+        ["recurring_expense_uuid"],
+        ["uuid"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint(FK_NAME, "expenses", type_="foreignkey")
+    op.drop_column("expenses", "recurring_expense_uuid")
+    op.drop_table("recurring_expenses")
+    op.execute("DROP TYPE IF EXISTS interval_unit")

--- a/backend/src/model/__init__.py
+++ b/backend/src/model/__init__.py
@@ -2,6 +2,7 @@ from src.model.category import Category
 from src.model.expense import Expense
 from src.model.expense_category_association import ExpenseCategoryAssociation
 from src.model.expense_template import ExpenseTemplate
+from src.model.recurring_expense import IntervalUnit, RecurringExpense
 from src.model.user import User
 from src.model.utils import generate_uuid_string
 from src.model.webauthn_credential import WebAuthnCredential
@@ -11,6 +12,8 @@ __all__ = [
     "Expense",
     "ExpenseCategoryAssociation",
     "ExpenseTemplate",
+    "IntervalUnit",
+    "RecurringExpense",
     "User",
     "WebAuthnCredential",
     "generate_uuid_string",

--- a/backend/src/model/expense.py
+++ b/backend/src/model/expense.py
@@ -20,6 +20,11 @@ class Expense(Base):
     name = Column(String, nullable=False)
     amount = Column(Integer, nullable=False)
     expensed_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    recurring_expense_uuid = Column(
+        String(32),
+        ForeignKey("recurring_expenses.uuid", ondelete="SET NULL"),
+        nullable=True,
+    )
     created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
     updated_at = Column(
         DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False,
@@ -27,6 +32,7 @@ class Expense(Base):
     deleted_at = Column(DateTime, nullable=True)
 
     user = relationship("User")
+    recurring_expense = relationship("RecurringExpense")
 
     # Many-to-many relationship
     categories = relationship(

--- a/backend/src/model/recurring_expense.py
+++ b/backend/src/model/recurring_expense.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import enum
+from datetime import UTC, datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Integer,
+    String,
+)
+from sqlalchemy.orm import relationship
+
+from src.model.utils import generate_uuid_string
+from src.repository.database import Base
+
+
+class IntervalUnit(str, enum.Enum):
+    WEEK = "WEEK"
+    MONTH = "MONTH"
+
+
+class RecurringExpense(Base):
+    __tablename__ = "recurring_expenses"
+    __table_args__ = (
+        CheckConstraint("amount > 0", name="check_recurring_expense_amount_positive"),
+        CheckConstraint("interval_count > 0", name="check_recurring_expense_interval_count_positive"),
+    )
+
+    uuid = Column(String(32), primary_key=True, default=generate_uuid_string)
+    user_uuid = Column(String(32), ForeignKey("users.uuid", ondelete="CASCADE"), nullable=False)
+    name = Column(String, nullable=False)
+    amount = Column(Integer, nullable=False)
+    category_uuid = Column(String(32), ForeignKey("categories.uuid", ondelete="CASCADE"), nullable=False)
+    interval_unit: Column[IntervalUnit] = Column(
+        Enum(IntervalUnit, name="interval_unit"), nullable=False,
+    )
+    interval_count = Column(Integer, nullable=False)
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=True)
+    created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
+    updated_at = Column(
+        DateTime, default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC), nullable=False,
+    )
+    deleted_at = Column(DateTime, nullable=True)
+
+    user = relationship("User")
+    category = relationship("Category")


### PR DESCRIPTION
## 概要

#81 の3PR分割の **PR1**。
モデル定義とマイグレーションのみで、APIや業務ロジックは PR2 で対応。

## 変更点

### 新規モデル `RecurringExpense`

```
recurring_expenses
- uuid               String(32)  PK, uuid7
- user_uuid          String(32)  FK -> users, CASCADE
- name               String      NOT NULL
- amount             Integer     CHECK > 0
- category_uuid      String(32)  FK -> categories, CASCADE
- interval_unit      Enum        WEEK | MONTH
- interval_count     Integer     CHECK > 0
- start_date         Date        JST naive date
- end_date           Date        nullable
- created_at, updated_at  DateTime UTC
- deleted_at         DateTime    nullable (soft delete)
```

### 既存 `expenses` 拡張

```
+ recurring_expense_uuid  String(32)  FK -> recurring_expenses.uuid, ON DELETE SET NULL, nullable
```

### マイグレーション

`alembic/versions/aec700ae61d2_add_recurring_expenses_and_expenses_.py`
- `recurring_expenses` テーブル作成
- `expenses.recurring_expense_uuid` 列追加 + FK制約
- downgrade で interval_unit ENUM 型もクリーンアップ
- 命名・コードスタイルを既存の `9ca611086cef` に合わせて整備

## 設計判断

このPRでは以下を **意図的に含めない** (PR2/3 で対応):

- `next_due_at` 物理列を持たない設計 (派生値として算出)
- `recorded_count` は `expenses.recurring_expense_uuid` の COUNT で都度算出
- 詳細は #81 参照

## Test plan

- [x] `make test-backend` Pass (既存35件、新機能テストはPR2で追加)
- [x] `make lint` Pass (mypy strict / ruff / typecheck / oxlint / oxfmt)
- [x] `make upgrade` で本マイグレーション適用成功
- [x] `alembic downgrade -1 && alembic upgrade head` のラウンドトリップ成功