### PR TITLE
feat: 定期支払のAPI実装 (2/3)

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -15,3 +15,8 @@
 ## mypy / ruff
 - mypy strict mode required, type annotations on all functions and variables
 - ruff line length: 120
+
+## Date / Time
+- For "JST today", use `datetime.now(JST).date()` — `date.today()` is OS-tz dependent and forbidden
+- `python-dateutil` is allowed only for `relativedelta` (month arithmetic). `dateutil.parser` is forbidden
+- For recurring schedules, compute dates from `start_date + n × interval` to avoid drift on month-end edges (do not chain from "last + interval")

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -19,6 +19,7 @@
 | `WEBAUTHN_RP_ID` | WebAuthn RP ID |
 | `WEBAUTHN_RP_NAME` | WebAuthn RP name |
 | `FRONTEND_ORIGIN` | CORS origin |
+| `CRON_SECRET` | Bearer token for `/cron/*` endpoints (32+ chars recommended) |
 
 ### Production Only
 | Variable | Purpose |

--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,7 @@ JWT_SECRET_KEY=
 WEBAUTHN_RP_ID=localhost
 WEBAUTHN_RP_NAME="BurnStyle"
 FRONTEND_ORIGIN=http://localhost:${FRONTEND_PORT}
+CRON_SECRET=
 
 # =========================
 # Vercel only

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "sqlalchemy>=2.0.44",
     "uuid6>=2024.5.1",
     "uvicorn[standard]==0.32.0",
+    "python-dateutil>=2.9",
 ]
 
 [dependency-groups]
@@ -22,6 +23,7 @@ dev = [
     "mypy>=1.19.1",
     "pytest>=9.0.2",
     "ruff>=0.14.8",
+    "types-python-dateutil>=2.9",
 ]
 
 [tool.uv]

--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -3,13 +3,16 @@ from src.api.categories import category_router
 from src.api.expense_templates import expense_template_router
 from src.api.expenses import expense_router
 from src.api.health import health_router
+from src.api.recurring_expenses import cron_router, recurring_expense_router
 from src.api.users import user_router
 
 __all__ = [
     "auth_router",
     "category_router",
+    "cron_router",
     "expense_router",
     "expense_template_router",
     "health_router",
+    "recurring_expense_router",
     "user_router",
 ]

--- a/backend/src/api/recurring_expenses.py
+++ b/backend/src/api/recurring_expenses.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Response, status
+from sqlalchemy.orm import Session, joinedload
+
+from src.api.deps import get_current_user
+from src.config import get_cron_secret
+from src.model.category import Category
+from src.model.recurring_expense import RecurringExpense
+from src.model.user import User
+from src.repository import recurring_expense_repository
+from src.repository.database import get_db
+from src.schema.recurring_expense import (
+    CronRecordResponse,
+    RecordRequest,
+    RecurringExpenseCreate,
+    RecurringExpenseDueResponse,
+    RecurringExpenseResponse,
+    RecurringExpenseUpdate,
+)
+from src.service import recurring_expense_service
+
+recurring_expense_router = APIRouter(prefix="/recurring-expenses", tags=["recurring-expenses"])
+
+
+def _verify_user_category(db: Session, category_uuid: str, user_uuid: str) -> None:
+    category = (
+        db.query(Category)
+        .filter(Category.uuid == category_uuid, Category.user_uuid == user_uuid)
+        .first()
+    )
+    if not category:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category not found")
+
+
+@recurring_expense_router.get("")
+def list_recurring(
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RecurringExpenseResponse]:
+    items = recurring_expense_repository.get_all_active(db, str(user.uuid))
+    return [RecurringExpenseResponse.model_validate(r) for r in items]
+
+
+@recurring_expense_router.get("/due")
+def list_due(
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[RecurringExpenseDueResponse]:
+    today = recurring_expense_service.jst_today()
+    items = recurring_expense_repository.get_all_active(db, str(user.uuid))
+    result: list[RecurringExpenseDueResponse] = []
+    for r in items:
+        recorded = recurring_expense_repository.count_recorded(db, str(r.uuid))
+        dates = recurring_expense_service.missed_dates(r, recorded, today)
+        if not dates:
+            continue
+        result.append(
+            RecurringExpenseDueResponse(
+                uuid=str(r.uuid),
+                name=str(r.name),
+                amount=int(r.amount),
+                category=r.category,
+                missed_count=len(dates),
+                missed_dates=dates,
+            ),
+        )
+    return result
+
+
+@recurring_expense_router.post("", status_code=status.HTTP_201_CREATED)
+def create_recurring(
+    body: RecurringExpenseCreate,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> RecurringExpenseResponse:
+    _verify_user_category(db, body.category_uuid, str(user.uuid))
+
+    if body.end_date is not None and body.end_date < body.start_date:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="end_date must be on or after start_date",
+        )
+
+    recurring = RecurringExpense(
+        user_uuid=user.uuid,
+        name=body.name,
+        amount=body.amount,
+        category_uuid=body.category_uuid,
+        interval_unit=body.interval_unit,
+        interval_count=body.interval_count,
+        start_date=body.start_date,
+        end_date=body.end_date,
+    )
+    db.add(recurring)
+    db.commit()
+    db.refresh(recurring)
+    # Re-load with category eagerly
+    loaded = (
+        db.query(RecurringExpense)
+        .options(joinedload(RecurringExpense.category))
+        .filter(RecurringExpense.uuid == recurring.uuid)
+        .one()
+    )
+    return RecurringExpenseResponse.model_validate(loaded)
+
+
+@recurring_expense_router.get("/{uuid}")
+def get_recurring(
+    uuid: str,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> RecurringExpenseResponse:
+    recurring = recurring_expense_repository.get_by_uuid(db, uuid, str(user.uuid))
+    if not recurring:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring expense not found")
+    return RecurringExpenseResponse.model_validate(recurring)
+
+
+@recurring_expense_router.patch("/{uuid}")
+def update_recurring(
+    uuid: str,
+    body: RecurringExpenseUpdate,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> RecurringExpenseResponse:
+    recurring = recurring_expense_repository.get_by_uuid(db, uuid, str(user.uuid))
+    if not recurring:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring expense not found")
+
+    update_data = body.model_dump(exclude_unset=True)
+    if "category_uuid" in update_data:
+        _verify_user_category(db, update_data["category_uuid"], str(user.uuid))
+
+    new_start = update_data.get("start_date", recurring.start_date)
+    new_end = update_data.get("end_date", recurring.end_date)
+    if new_end is not None and new_end < new_start:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="end_date must be on or after start_date",
+        )
+
+    for key, value in update_data.items():
+        setattr(recurring, key, value)
+    db.commit()
+    db.refresh(recurring)
+    return RecurringExpenseResponse.model_validate(recurring)
+
+
+@recurring_expense_router.delete("/{uuid}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_recurring(
+    uuid: str,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> Response:
+    recurring = recurring_expense_repository.get_by_uuid(db, uuid, str(user.uuid))
+    if not recurring:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring expense not found")
+    recurring_expense_repository.soft_delete(db, recurring)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@recurring_expense_router.post("/{uuid}/record")
+def record_recurring(
+    uuid: str,
+    body: RecordRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> dict[str, int]:
+    recurring = recurring_expense_repository.get_by_uuid(db, uuid, str(user.uuid))
+    if not recurring:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recurring expense not found")
+
+    created = recurring_expense_service.record_occurrences(
+        db, recurring, count=body.count, expensed_at_override=body.expensed_at,
+    )
+    return {"recorded_count": created}
+
+
+cron_router = APIRouter(prefix="/cron/recurring-expenses", tags=["cron"])
+
+
+def _verify_cron_secret(authorization: Annotated[str | None, Header()] = None) -> None:
+    expected = f"Bearer {get_cron_secret()}"
+    if authorization != expected:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid cron secret")
+
+
+@cron_router.api_route("/record-due", methods=["GET", "POST"])
+def cron_record_due(
+    db: Annotated[Session, Depends(get_db)],
+    _: Annotated[None, Depends(_verify_cron_secret)],
+) -> CronRecordResponse:
+    recorded, processed = recurring_expense_service.record_all_due_for_cron(db)
+    return CronRecordResponse(
+        recorded_count=recorded, processed_recurring_count=processed,
+    )

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -29,3 +29,11 @@ def get_webauthn_rp_name() -> str:
 def get_frontend_origin() -> str:
     """Get the frontend origin URL."""
     return os.getenv("FRONTEND_ORIGIN", "http://localhost:15173")
+
+
+def get_cron_secret() -> str:
+    """Get the cron Bearer token. Required for /cron endpoints."""
+    value = os.getenv("CRON_SECRET")
+    if value is None:
+        raise ValueError("CRON_SECRET environment variable is not set.")
+    return value

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -7,9 +7,11 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from src.api import (
     auth_router,
     category_router,
+    cron_router,
     expense_router,
     expense_template_router,
     health_router,
+    recurring_expense_router,
     user_router,
 )
 from src.config import get_frontend_origin
@@ -52,4 +54,6 @@ app.include_router(auth_router)
 app.include_router(category_router)
 app.include_router(expense_router)
 app.include_router(expense_template_router)
+app.include_router(recurring_expense_router)
+app.include_router(cron_router)
 app.include_router(user_router)

--- a/backend/src/repository/recurring_expense_repository.py
+++ b/backend/src/repository/recurring_expense_repository.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from src.model.expense import Expense
+from src.model.recurring_expense import RecurringExpense
+
+
+def get_all_active(db: Session, user_uuid: str) -> list[RecurringExpense]:
+    """List all active recurring expenses for the user."""
+    return (
+        db.query(RecurringExpense)
+        .options(joinedload(RecurringExpense.category))
+        .filter(
+            RecurringExpense.user_uuid == user_uuid,
+            RecurringExpense.deleted_at.is_(None),
+        )
+        .all()
+    )
+
+
+def get_all_active_for_cron(db: Session) -> list[RecurringExpense]:
+    """List all active recurring expenses across users (for cron)."""
+    return (
+        db.query(RecurringExpense)
+        .options(joinedload(RecurringExpense.category))
+        .filter(RecurringExpense.deleted_at.is_(None))
+        .all()
+    )
+
+
+def get_by_uuid(db: Session, uuid: str, user_uuid: str) -> RecurringExpense | None:
+    """Fetch a single recurring expense for the user."""
+    return (
+        db.query(RecurringExpense)
+        .options(joinedload(RecurringExpense.category))
+        .filter(
+            RecurringExpense.uuid == uuid,
+            RecurringExpense.user_uuid == user_uuid,
+            RecurringExpense.deleted_at.is_(None),
+        )
+        .first()
+    )
+
+
+def count_recorded(db: Session, recurring_uuid: str) -> int:
+    """Count expenses linked to this recurring expense (excluding soft-deleted)."""
+    result = (
+        db.query(func.count(Expense.uuid))
+        .filter(
+            Expense.recurring_expense_uuid == recurring_uuid,
+            Expense.deleted_at.is_(None),
+        )
+        .scalar()
+    )
+    return int(result or 0)
+
+
+def soft_delete(db: Session, recurring: RecurringExpense) -> None:
+    """Soft-delete a recurring expense."""
+    recurring.deleted_at = datetime.now(UTC)  # type: ignore[assignment]
+    db.commit()

--- a/backend/src/schema/recurring_expense.py
+++ b/backend/src/schema/recurring_expense.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import date
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.model.recurring_expense import IntervalUnit
+from src.schema.category import CategoryResponse
+from src.schema.types import JstDatetime
+
+
+class RecurringExpenseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uuid: str
+    name: str
+    amount: int
+    category: CategoryResponse
+    interval_unit: IntervalUnit
+    interval_count: int
+    start_date: date
+    end_date: date | None
+    created_at: JstDatetime
+    updated_at: JstDatetime
+
+
+class RecurringExpenseCreate(BaseModel):
+    name: str
+    amount: int = Field(gt=0, description="Must be a positive integer")
+    category_uuid: str
+    interval_unit: IntervalUnit
+    interval_count: int = Field(gt=0, description="Must be a positive integer")
+    start_date: date
+    end_date: date | None = None
+
+
+class RecurringExpenseUpdate(BaseModel):
+    name: str | None = None
+    amount: int | None = Field(default=None, gt=0)
+    category_uuid: str | None = None
+    interval_unit: IntervalUnit | None = None
+    interval_count: int | None = Field(default=None, gt=0)
+    start_date: date | None = None
+    end_date: date | None = None
+
+
+class RecurringExpenseDueResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uuid: str
+    name: str
+    amount: int
+    category: CategoryResponse
+    missed_count: int
+    missed_dates: list[date]
+
+
+class RecordRequest(BaseModel):
+    count: int = Field(default=1, gt=0, description="Number of occurrences to record")
+    expensed_at: date | None = None
+
+
+class CronRecordResponse(BaseModel):
+    recorded_count: int
+    processed_recurring_count: int

--- a/backend/src/service/recurring_expense_service.py
+++ b/backend/src/service/recurring_expense_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from dateutil.relativedelta import relativedelta
+
+from src.model.expense import Expense
+from src.model.expense_category_association import ExpenseCategoryAssociation
+from src.model.recurring_expense import IntervalUnit
+from src.repository import recurring_expense_repository
+from src.schema.types import JST
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from src.model.recurring_expense import RecurringExpense
+
+
+def jst_today() -> date:
+    """Return today's date in JST. Avoid date.today() (OS-tz dependent)."""
+    return datetime.now(JST).date()
+
+
+def offset_from_start(unit: IntervalUnit, count: int, n: int) -> relativedelta | timedelta:
+    """Compute the offset to add to start_date for the n-th occurrence (0-indexed)."""
+    if unit is IntervalUnit.WEEK:
+        return timedelta(weeks=count * n)
+    return relativedelta(months=count * n)
+
+
+def occurrence_date(start: date, unit: IntervalUnit, count: int, n: int) -> date:
+    """Return the date of the n-th occurrence (0-indexed) starting from start_date."""
+    return start + offset_from_start(unit, count, n)
+
+
+def missed_dates(
+    recurring: RecurringExpense, recorded_count: int, today: date,
+) -> list[date]:
+    """Return dates that are due but not yet recorded.
+
+    Iterates from the (recorded_count)-th occurrence forward, collecting dates
+    that are <= today and (if end_date is set) <= end_date.
+    """
+    result: list[date] = []
+    n = recorded_count
+    while True:
+        d = occurrence_date(
+            recurring.start_date,  # type: ignore[arg-type]
+            recurring.interval_unit,  # type: ignore[arg-type]
+            recurring.interval_count,  # type: ignore[arg-type]
+            n,
+        )
+        if d > today:
+            break
+        if recurring.end_date is not None and d > recurring.end_date:
+            break
+        result.append(d)
+        n += 1
+    return result
+
+
+def record_occurrences(
+    db: Session,
+    recurring: RecurringExpense,
+    count: int,
+    expensed_at_override: date | None = None,
+) -> int:
+    """Create `count` Expense rows linked to this recurring expense.
+
+    Uses computed occurrence dates as `expensed_at` unless overridden.
+    Returns the number of records created.
+    """
+    recorded = recurring_expense_repository.count_recorded(db, str(recurring.uuid))
+    created = 0
+    for i in range(count):
+        if expensed_at_override is not None:
+            expensed_at = datetime.combine(expensed_at_override, datetime.min.time())
+        else:
+            occurrence = occurrence_date(
+                recurring.start_date,  # type: ignore[arg-type]
+                recurring.interval_unit,  # type: ignore[arg-type]
+                recurring.interval_count,  # type: ignore[arg-type]
+                recorded + i,
+            )
+            expensed_at = datetime.combine(occurrence, datetime.min.time())
+
+        expense = Expense(
+            user_uuid=recurring.user_uuid,
+            name=recurring.name,
+            amount=recurring.amount,
+            expensed_at=expensed_at,
+            recurring_expense_uuid=recurring.uuid,
+        )
+        db.add(expense)
+        db.flush()
+        db.add(
+            ExpenseCategoryAssociation(
+                expense_uuid=expense.uuid,
+                category_uuid=recurring.category_uuid,
+            ),
+        )
+        created += 1
+
+    db.commit()
+    return created
+
+
+def record_all_due_for_cron(db: Session) -> tuple[int, int]:
+    """Process all active recurring expenses across users.
+
+    Returns (recorded_count, processed_recurring_count).
+    """
+    today = jst_today()
+    recurrings = recurring_expense_repository.get_all_active_for_cron(db)
+    total_recorded = 0
+    processed = 0
+    for r in recurrings:
+        recorded = recurring_expense_repository.count_recorded(db, str(r.uuid))
+        dates = missed_dates(r, recorded, today)
+        if not dates:
+            continue
+        total_recorded += record_occurrences(db, r, count=len(dates))
+        processed += 1
+    return total_recorded, processed

--- a/backend/tests/api/test_recurring_expenses.py
+++ b/backend/tests/api/test_recurring_expenses.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.main import app
+from src.model.category import Category
+from src.model.expense import Expense
+from src.model.recurring_expense import IntervalUnit, RecurringExpense
+from src.model.user import User
+from src.repository.database import get_db
+from src.service import recurring_expense_service
+
+_TEST_CRON_SECRET = "test-cron-secret"  # noqa: S105
+
+
+@pytest.fixture(autouse=True)
+def cron_secret() -> Generator[str]:
+    """Set CRON_SECRET for tests using the cron endpoint."""
+    os.environ["CRON_SECRET"] = _TEST_CRON_SECRET
+    yield _TEST_CRON_SECRET
+    os.environ.pop("CRON_SECRET", None)
+
+
+@pytest.fixture
+def category(db: Session, test_user: User) -> Category:
+    cat = Category(user_uuid=str(test_user.uuid), name="住居費")
+    db.add(cat)
+    db.commit()
+    db.refresh(cat)
+    return cat
+
+
+def _make_payload(category_uuid: str, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "家賃",
+        "amount": 80000,
+        "category_uuid": category_uuid,
+        "interval_unit": "MONTH",
+        "interval_count": 1,
+        "start_date": "2026-01-01",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestCreate:
+    def test_creates_recurring(self, auth_client: TestClient, category: Category) -> None:
+        res = auth_client.post("/recurring-expenses", json=_make_payload(str(category.uuid)))
+        assert res.status_code == 201
+        data = res.json()
+        assert data["name"] == "家賃"
+        assert data["amount"] == 80000
+        assert data["interval_unit"] == "MONTH"
+        assert data["interval_count"] == 1
+        assert data["start_date"] == "2026-01-01"
+        assert data["end_date"] is None
+        assert data["category"]["uuid"] == category.uuid
+
+    def test_rejects_zero_amount(self, auth_client: TestClient, category: Category) -> None:
+        res = auth_client.post(
+            "/recurring-expenses", json=_make_payload(str(category.uuid), amount=0),
+        )
+        assert res.status_code == 422
+
+    def test_rejects_zero_interval_count(self, auth_client: TestClient, category: Category) -> None:
+        res = auth_client.post(
+            "/recurring-expenses", json=_make_payload(str(category.uuid), interval_count=0),
+        )
+        assert res.status_code == 422
+
+    def test_rejects_unknown_category(self, auth_client: TestClient) -> None:
+        res = auth_client.post("/recurring-expenses", json=_make_payload("nonexistent"))
+        assert res.status_code == 400
+
+    def test_rejects_end_before_start(self, auth_client: TestClient, category: Category) -> None:
+        res = auth_client.post(
+            "/recurring-expenses",
+            json=_make_payload(str(category.uuid), end_date="2025-12-01"),
+        )
+        assert res.status_code == 400
+
+
+class TestList:
+    def test_excludes_soft_deleted(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        active = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="active",
+            amount=1000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        deleted = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="deleted",
+            amount=2000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add_all([active, deleted])
+        db.commit()
+        db.refresh(deleted)
+        auth_client.delete(f"/recurring-expenses/{deleted.uuid}")
+
+        res = auth_client.get("/recurring-expenses")
+        assert res.status_code == 200
+        names = [item["name"] for item in res.json()]
+        assert names == ["active"]
+
+
+class TestUpdate:
+    def test_updates_amount(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        res = auth_client.patch(f"/recurring-expenses/{r.uuid}", json={"amount": 85000})
+        assert res.status_code == 200
+        assert res.json()["amount"] == 85000
+
+    def test_returns_404_for_other_user(
+        self, auth_client: TestClient, db: Session,
+    ) -> None:
+        other = User(uuid="otheruser0000000000000000000000", name="other")
+        db.add(other)
+        db.commit()
+        cat = Category(user_uuid="otheruser0000000000000000000000", name="食費")
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+        r = RecurringExpense(
+            user_uuid="otheruser0000000000000000000000",
+            name="x",
+            amount=1000,
+            category_uuid=cat.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        res = auth_client.patch(f"/recurring-expenses/{r.uuid}", json={"amount": 1})
+        assert res.status_code == 404
+
+
+class TestDue:
+    def test_returns_missed_dates_for_monthly(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        # Force "today" via patching jst_today
+
+        original = recurring_expense_service.jst_today
+        recurring_expense_service.jst_today = lambda: date(2026, 3, 15)
+        try:
+            res = auth_client.get("/recurring-expenses/due")
+        finally:
+            recurring_expense_service.jst_today = original
+
+        assert res.status_code == 200
+        data = res.json()
+        assert len(data) == 1
+        assert data[0]["missed_count"] == 3
+        assert data[0]["missed_dates"] == ["2026-01-01", "2026-02-01", "2026-03-01"]
+
+    def test_excludes_dates_after_end_date(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 2, 1),
+        )
+        db.add(r)
+        db.commit()
+
+
+        original = recurring_expense_service.jst_today
+        recurring_expense_service.jst_today = lambda: date(2026, 5, 1)
+        try:
+            res = auth_client.get("/recurring-expenses/due")
+        finally:
+            recurring_expense_service.jst_today = original
+
+        assert res.json()[0]["missed_dates"] == ["2026-01-01", "2026-02-01"]
+
+    def test_excludes_future_start_date(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="future",
+            amount=1000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2099, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+
+        res = auth_client.get("/recurring-expenses/due")
+        assert res.json() == []
+
+
+class TestRecord:
+    def test_creates_expense_with_computed_date(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        res = auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 1})
+        assert res.status_code == 200
+        assert res.json()["recorded_count"] == 1
+
+        expense = db.query(Expense).filter(Expense.recurring_expense_uuid == r.uuid).first()
+        assert expense is not None
+        assert expense.expensed_at.date() == date(2026, 1, 1)
+        assert expense.amount == 80000
+
+    def test_creates_multiple_with_count(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        res = auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 3})
+        assert res.status_code == 200
+        assert res.json()["recorded_count"] == 3
+
+        expenses = (
+            db.query(Expense)
+            .filter(Expense.recurring_expense_uuid == r.uuid)
+            .order_by(Expense.expensed_at)
+            .all()
+        )
+        assert [e.expensed_at.date() for e in expenses] == [
+            date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1),
+        ]
+
+    def test_month_end_does_not_drift(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        """1/31 monthly should yield 2/28 then 3/31 (start-anchored, no drift)."""
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="rent",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 31),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 3})
+
+        expenses = (
+            db.query(Expense)
+            .filter(Expense.recurring_expense_uuid == r.uuid)
+            .order_by(Expense.expensed_at)
+            .all()
+        )
+        # 2026 is not a leap year → Feb 28
+        assert [e.expensed_at.date() for e in expenses] == [
+            date(2026, 1, 31), date(2026, 2, 28), date(2026, 3, 31),
+        ]
+
+    def test_biweekly_advances_14_days(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="invest",
+            amount=10000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.WEEK,
+            interval_count=2,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 3})
+
+        expenses = (
+            db.query(Expense)
+            .filter(Expense.recurring_expense_uuid == r.uuid)
+            .order_by(Expense.expensed_at)
+            .all()
+        )
+        assert [e.expensed_at.date() for e in expenses] == [
+            date(2026, 1, 1), date(2026, 1, 15), date(2026, 1, 29),
+        ]
+
+    def test_recorded_count_excludes_soft_deleted(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        """Soft-deleting the latest record allows re-recording to refill that occurrence."""
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 2})
+        latest = (
+            db.query(Expense)
+            .filter(Expense.recurring_expense_uuid == r.uuid)
+            .order_by(Expense.expensed_at.desc())
+            .first()
+        )
+        assert latest is not None
+        auth_client.delete(f"/expenses/{latest.uuid}")
+
+        auth_client.post(f"/recurring-expenses/{r.uuid}/record", json={"count": 1})
+        active_dates = sorted(
+            e.expensed_at.date()
+            for e in db.query(Expense)
+            .filter(Expense.recurring_expense_uuid == r.uuid, Expense.deleted_at.is_(None))
+            .all()
+        )
+        assert active_dates == [date(2026, 1, 1), date(2026, 2, 1)]
+
+
+class TestDelete:
+    def test_soft_deletes(
+        self, auth_client: TestClient, category: Category, db: Session, test_user: User,
+    ) -> None:
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=category.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+        db.refresh(r)
+
+        res = auth_client.delete(f"/recurring-expenses/{r.uuid}")
+        assert res.status_code == 204
+        assert auth_client.get("/recurring-expenses").json() == []
+
+
+class TestCron:
+    def _override_db(self, db: Session) -> None:
+        def _gen() -> Generator[Session]:
+            yield db
+        app.dependency_overrides[get_db] = _gen
+
+    def test_unauthenticated(self, db: Session) -> None:
+        self._override_db(db)
+        try:
+            client = TestClient(app)
+            res = client.post("/cron/recurring-expenses/record-due")
+            assert res.status_code == 401
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_records_all_due_across_users(
+        self, db: Session, test_user: User,
+    ) -> None:
+        cat = Category(user_uuid=str(test_user.uuid), name="住居費")
+        other_user = User(uuid="otheruser0000000000000000000000", name="other")
+        db.add_all([cat, other_user])
+        db.commit()
+        other_cat = Category(user_uuid=str(other_user.uuid), name="食費")
+        db.add(other_cat)
+        db.commit()
+        db.refresh(cat)
+        db.refresh(other_cat)
+
+        a = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=cat.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        b = RecurringExpense(
+            user_uuid=str(other_user.uuid),
+            name="食材",
+            amount=5000,
+            category_uuid=other_cat.uuid,
+            interval_unit=IntervalUnit.WEEK,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add_all([a, b])
+        db.commit()
+
+
+        original = recurring_expense_service.jst_today
+        recurring_expense_service.jst_today = lambda: date(2026, 1, 15)
+        self._override_db(db)
+        try:
+            client = TestClient(app)
+            res = client.post(
+                "/cron/recurring-expenses/record-due",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        finally:
+            recurring_expense_service.jst_today = original
+            app.dependency_overrides.clear()
+
+        assert res.status_code == 200
+        body = res.json()
+        # a: 1/1 (monthly) - 1 occurrence by 1/15
+        # b: 1/1, 1/8, 1/15 (weekly) - 3 occurrences
+        assert body["recorded_count"] == 4
+        assert body["processed_recurring_count"] == 2
+
+    def test_idempotent_when_called_twice(
+        self, db: Session, test_user: User,
+    ) -> None:
+        cat = Category(user_uuid=str(test_user.uuid), name="住居費")
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+        r = RecurringExpense(
+            user_uuid=str(test_user.uuid),
+            name="家賃",
+            amount=80000,
+            category_uuid=cat.uuid,
+            interval_unit=IntervalUnit.MONTH,
+            interval_count=1,
+            start_date=date(2026, 1, 1),
+        )
+        db.add(r)
+        db.commit()
+
+
+        original = recurring_expense_service.jst_today
+        recurring_expense_service.jst_today = lambda: date(2026, 3, 15)
+        self._override_db(db)
+        try:
+            client = TestClient(app)
+            first = client.post(
+                "/cron/recurring-expenses/record-due",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+            second = client.post(
+                "/cron/recurring-expenses/record-due",
+                headers={"Authorization": "Bearer test-cron-secret"},
+            )
+        finally:
+            recurring_expense_service.jst_today = original
+            app.dependency_overrides.clear()
+
+        assert first.json()["recorded_count"] == 3
+        assert second.json()["recorded_count"] == 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -54,6 +54,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "psycopg2-binary" },
     { name = "pyjwt" },
+    { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "sqlalchemy" },
     { name = "uuid6" },
@@ -68,6 +69,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "types-python-dateutil" },
 ]
 
 [package.metadata]
@@ -75,6 +77,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.123.5" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pyjwt", specifier = ">=2.10.0" },
+    { name = "python-dateutil", specifier = ">=2.9" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "sqlalchemy", specifier = ">=2.0.44" },
     { name = "uuid6", specifier = ">=2024.5.1" },
@@ -89,6 +92,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.14.8" },
+    { name = "types-python-dateutil", specifier = ">=2.9" },
 ]
 
 [[package]]
@@ -600,6 +604,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -661,6 +677,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.44"
 source = { registry = "https://pypi.org/simple" }
@@ -683,6 +708,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/9b/ee1674cbe9ec50bb824f35a5dc0ce5fd1f1b6196ba1213e3fe6f33b4ce32/types_python_dateutil-2.9.0.20260508.tar.gz", hash = "sha256:596a6d63d81f587bf04c8254fb78df9d2344e915ce67948d7400512e3a6206d5", size = 17033, upload-time = "2026-05-08T04:47:08.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/7c/1788ff10edf56031d74ad3fba40947e0e8b82e3a529b30e6b7d71c191dec/types_python_dateutil-2.9.0.20260508-py3-none-any.whl", hash = "sha256:bfc6fd2d81aa86e5ac97206a64304f6bd247426eedbca9b98619bbc48c6a1c10", size = 18425, upload-time = "2026-05-08T04:47:07.207Z" },
 ]
 
 [[package]]

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,4 +1,7 @@
 {
+  "crons": [
+    { "path": "/cron/recurring-expenses/record-due", "schedule": "0 15 * * *" }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 概要

#81 の3PR分割の **PR2**。
PR1で追加した `RecurringExpense` モデルに対する schema/repository/service/API 実装と、cron 経由の自動記録エンドポイントを追加。

## 変更点

### スキーマ層 (`schema/recurring_expense.py`)
- `RecurringExpenseCreate` / `Update` / `Response`
- `RecurringExpenseDueResponse` (`missed_count` + `missed_dates` 同梱)
- `RecordRequest` (`count`, `expensed_at` 任意)
- `CronRecordResponse` (`recorded_count`, `processed_recurring_count`)

### リポジトリ層 (`repository/recurring_expense_repository.py`)
- `get_all_active` / `get_all_active_for_cron` / `get_by_uuid`
- `count_recorded`: `expenses.recurring_expense_uuid` の COUNT (soft-delete除外)
- `soft_delete`

### サービス層 (`service/recurring_expense_service.py`)
- `jst_today`: `datetime.now(JST).date()` (OS-tz依存の `date.today()` を回避)
- `occurrence_date`: `start_date + relativedelta(unit × count × n)` で **start起点・都度算出**
- `missed_dates`: 未記録の期日列を計算 (今日・end_date超過は除外)
- `record_occurrences`: count回 Expense 生成 + ExpenseCategoryAssociation 付与
- `record_all_due_for_cron`: 全 active recurring を横断処理

### API層 (`api/recurring_expenses.py`)
- ユーザー操作 (JWT): GET一覧/due, POST作成, GET/PATCH/DELETE/{uuid}, POST/{uuid}/record
- cron (CRON_SECRET): `POST/GET /cron/recurring-expenses/record-due`

### インフラ
- `backend/vercel.json` に cron 設定 (`schedule: "0 15 * * *"` = 翌日 00:00 JST)
- `python-dateutil>=2.9` を依存追加 (`relativedelta` 用、`parser` は禁則)
- `CRON_SECRET` 環境変数追加
- `.env.template` / `infra.md` / `backend.md` 反映

### テスト

20件追加 (合計 55 passing):

- 作成/更新/一覧/取得/削除のCRUD
- バリデーション (amount/interval_count > 0, end_date >= start_date, 不在カテゴリ)
- 他ユーザーのリソース 404
- 月次の `missed_dates` 算出
- end_date 超過は due に出ない
- 未来 start_date は due に出ない
- `/record` での Expense 生成 (count/expensed_at_override)
- **月末日問題**: 1/31 月次 → 2/28 → 3/31 ドリフトなし
- **隔週**: (WEEK, 2) で14日刻み
- soft-delete された Expense は `recorded_count` から除外
- cron 認証 (401)
- cron 全ユーザー横断記録
- cron 同日2回叩いても2回目は0件 (冪等性)

## Test plan

- [x] `make test-backend` Pass (55件)
- [x] `make lint` Pass
- [ ] 本番環境変数に `CRON_SECRET` 設定 (32文字以上)
- [ ] Vercel Cron が `0 15 * * *` で起動するか確認 (デプロイ後)

## 注意

- `CRON_SECRET` を Vercel ダッシュボードで設定する必要あり
- cron 用の `.env.template` の値は **空欄** (本番値の漏洩防止)