### PR TITLE
docs: docstring/JSDocを日本語で記載するルールを明記

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Language Policy
 - All text in the repository (code, comments, documentation, commit messages) must be written in English.
+- **Exception**: JSDoc / Python docstrings are written in Japanese (concise, 1–2 lines focusing on WHY).
 
 ## Implementation Policy
 - **Simplicity is the top priority**


### PR DESCRIPTION
## 概要

プロジェクトの「全テキスト英語」ポリシーに対し、**JSDoc / Python docstring は日本語で記載** する例外を明記。

## 変更点

`.claude/CLAUDE.md` の Language Policy セクションに例外を追記:

\`\`\`md
- **Exception**: JSDoc / Python docstrings are written in Japanese (concise, 1–2 lines focusing on WHY).
\`\`\`

## 背景

- グローバルの `~/.claude/CLAUDE.md` で「docstring/JSDocは日本語で簡潔に」のルールを設定済み
- プロジェクトの英語ポリシーと矛盾するため、プロジェクトCLAUDE.mdに例外として明記し整合させる

## Test plan

- [x] CLAUDE.md がmarkdownとして正しく表示される