### PR TITLE
feat: 定期支払のフロントエンド (3/3)

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -21,6 +21,8 @@ const PAGE_TITLES: Record<string, string> = {
   "/expense/annual": "Annual",
   "/expense/template": "Template",
   "/expense/template/new": "Record",
+  "/expense/recurring": "Recurring",
+  "/expense/recurring/new": "New ritual",
   "/category": "Category",
   "/setting": "Setting",
 }

--- a/frontend/src/common/libs/api.ts
+++ b/frontend/src/common/libs/api.ts
@@ -11,6 +11,11 @@ import type {
   ExpenseTemplateUpdate,
   ExpenseUpdate,
   ImportResponse,
+  RecurringExpenseCreate,
+  RecurringExpenseDueResponse,
+  RecurringExpenseRecordRequest,
+  RecurringExpenseResponse,
+  RecurringExpenseUpdate,
   RegisterOptionsResponse,
   RegisterVerifyResponse,
   SignInOptionsResponse,
@@ -128,6 +133,35 @@ const updateExpenseTemplate = (
 const deleteExpenseTemplate = (uuid: string): Promise<void> =>
   client.delete<void>(`/expense-templates/${uuid}`)
 
+// --- Recurring Expense ---
+
+const getRecurringExpenses = (): Promise<RecurringExpenseResponse[]> =>
+  client.get<RecurringExpenseResponse[]>("/recurring-expenses")
+
+const getRecurringExpenseDue = (): Promise<RecurringExpenseDueResponse[]> =>
+  client.get<RecurringExpenseDueResponse[]>("/recurring-expenses/due")
+
+const getRecurringExpense = (uuid: string): Promise<RecurringExpenseResponse> =>
+  client.get<RecurringExpenseResponse>(`/recurring-expenses/${uuid}`)
+
+const createRecurringExpense = (data: RecurringExpenseCreate): Promise<RecurringExpenseResponse> =>
+  client.post<RecurringExpenseResponse>("/recurring-expenses", data)
+
+const updateRecurringExpense = (
+  uuid: string,
+  data: RecurringExpenseUpdate,
+): Promise<RecurringExpenseResponse> =>
+  client.patch<RecurringExpenseResponse>(`/recurring-expenses/${uuid}`, data)
+
+const deleteRecurringExpense = (uuid: string): Promise<void> =>
+  client.delete<void>(`/recurring-expenses/${uuid}`)
+
+const recordRecurringExpense = (
+  uuid: string,
+  data: RecurringExpenseRecordRequest = {},
+): Promise<{ recorded_count: number }> =>
+  client.post<{ recorded_count: number }>(`/recurring-expenses/${uuid}/record`, data)
+
 export const api = {
   register,
   signIn,
@@ -150,4 +184,11 @@ export const api = {
   createExpenseTemplate,
   updateExpenseTemplate,
   deleteExpenseTemplate,
+  getRecurringExpenses,
+  getRecurringExpenseDue,
+  getRecurringExpense,
+  createRecurringExpense,
+  updateRecurringExpense,
+  deleteRecurringExpense,
+  recordRecurringExpense,
 }

--- a/frontend/src/common/libs/types.ts
+++ b/frontend/src/common/libs/types.ts
@@ -88,3 +88,52 @@ export interface ImportResponse {
   expenses_count: number
   message: string
 }
+
+export type IntervalUnit = "WEEK" | "MONTH"
+
+export interface RecurringExpenseResponse {
+  uuid: string
+  name: string
+  amount: number
+  category: CategoryResponse
+  interval_unit: IntervalUnit
+  interval_count: number
+  start_date: string
+  end_date: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface RecurringExpenseCreate {
+  name: string
+  amount: number
+  category_uuid: string
+  interval_unit: IntervalUnit
+  interval_count: number
+  start_date: string
+  end_date?: string | null
+}
+
+export interface RecurringExpenseUpdate {
+  name?: string
+  amount?: number
+  category_uuid?: string
+  interval_unit?: IntervalUnit
+  interval_count?: number
+  start_date?: string
+  end_date?: string | null
+}
+
+export interface RecurringExpenseDueResponse {
+  uuid: string
+  name: string
+  amount: number
+  category: CategoryResponse
+  missed_count: number
+  missed_dates: string[]
+}
+
+export interface RecurringExpenseRecordRequest {
+  count?: number
+  expensed_at?: string
+}

--- a/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
@@ -1,0 +1,285 @@
+import { type SubmitEvent, useCallback, useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router"
+
+import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type {
+  CategoryResponse,
+  IntervalUnit,
+  RecurringExpenseCreate,
+  RecurringExpenseUpdate,
+} from "../../common/libs/types"
+
+interface FrequencyOption {
+  key: string
+  label: string
+  unit: IntervalUnit
+  count: number
+}
+
+const FREQUENCY_OPTIONS: FrequencyOption[] = [
+  { key: "weekly", label: "Weekly", unit: "WEEK", count: 1 },
+  { key: "biweekly", label: "Every 2 wk", unit: "WEEK", count: 2 },
+  { key: "monthly", label: "Monthly", unit: "MONTH", count: 1 },
+  { key: "quarterly", label: "Quarterly", unit: "MONTH", count: 3 },
+  { key: "yearly", label: "Yearly", unit: "MONTH", count: 12 },
+]
+
+const matchFrequency = (unit: IntervalUnit, count: number): string =>
+  FREQUENCY_OPTIONS.find((f) => f.unit === unit && f.count === count)?.key ?? "monthly"
+
+const todayJst = (): string => {
+  const now = new Date()
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
+  return jst.toISOString().slice(0, 10)
+}
+
+export const RecurringExpenseEditPage = () => {
+  const navigate = useNavigate()
+  const { uuid } = useParams<{ uuid: string }>()
+  const isEdit = Boolean(uuid)
+
+  const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+  const { dialogRef, open: openDialog } = useConfirmDialog()
+
+  const [name, setName] = useState("")
+  const [amount, setAmount] = useState("")
+  const [frequencyKey, setFrequencyKey] = useState("monthly")
+  const [startDate, setStartDate] = useState(todayJst)
+  const [endDate, setEndDate] = useState("")
+  const [categoryUuid, setCategoryUuid] = useState("")
+
+  const fetchData = useCallback(async () => {
+    try {
+      const cats = await api.getCategories()
+      setCategories(cats)
+      if (uuid) {
+        const r = await api.getRecurringExpense(uuid)
+        setName(r.name)
+        setAmount(String(r.amount))
+        setFrequencyKey(matchFrequency(r.interval_unit, r.interval_count))
+        setStartDate(r.start_date)
+        setEndDate(r.end_date ?? "")
+        setCategoryUuid(r.category.uuid)
+      } else if (cats.length > 0) {
+        setCategoryUuid(cats[0].uuid)
+      }
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [uuid])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+    const freq = FREQUENCY_OPTIONS.find((f) => f.key === frequencyKey)
+    if (!freq) {
+      setError("Invalid frequency")
+      setLoading(false)
+      return
+    }
+    try {
+      if (isEdit && uuid) {
+        const data: RecurringExpenseUpdate = {
+          name,
+          amount: Number(amount),
+          interval_unit: freq.unit,
+          interval_count: freq.count,
+          start_date: startDate,
+          end_date: endDate || null,
+          category_uuid: categoryUuid,
+        }
+        await api.updateRecurringExpense(uuid, data)
+      } else {
+        const data: RecurringExpenseCreate = {
+          name,
+          amount: Number(amount),
+          interval_unit: freq.unit,
+          interval_count: freq.count,
+          start_date: startDate,
+          end_date: endDate || null,
+          category_uuid: categoryUuid,
+        }
+        await api.createRecurringExpense(data)
+      }
+      navigate("/expense/recurring")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!uuid) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.deleteRecurringExpense(uuid)
+      dialogRef.current?.close()
+      navigate("/expense/recurring")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to delete"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
+      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+      {/* Name + amount card */}
+      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+        <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-name">
+          Name this ritual
+        </label>
+        <input
+          id="recurring-name"
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          maxLength={50}
+          placeholder="House cleaner"
+          className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-lg outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+        />
+        <div className="mt-4 flex items-baseline gap-1">
+          <span className="text-2xl text-gray-400">¥</span>
+          <input
+            id="recurring-amount"
+            type="number"
+            inputMode="numeric"
+            min={1}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            required
+            placeholder="0"
+            className="flex-1 border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-2xl outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+          />
+        </div>
+      </div>
+
+      {/* Frequency */}
+      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+        <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">How often</div>
+        <div className="flex flex-wrap gap-2">
+          {FREQUENCY_OPTIONS.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFrequencyKey(f.key)}
+              className={`rounded-full px-4 py-2 text-sm transition-colors ${
+                frequencyKey === f.key
+                  ? "bg-primary text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Dates */}
+      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+        <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-start">
+          Start date
+        </label>
+        <input
+          id="recurring-start"
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          required
+          className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+        />
+
+        <label
+          className="mt-4 block text-xs text-gray-500 dark:text-gray-400"
+          htmlFor="recurring-end"
+        >
+          End date (optional)
+        </label>
+        <input
+          id="recurring-end"
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+        />
+      </div>
+
+      {/* Category */}
+      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+        <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">Category</div>
+        <div className="flex flex-wrap gap-2">
+          {categories.map((c) => (
+            <button
+              key={c.uuid}
+              type="button"
+              onClick={() => setCategoryUuid(c.uuid)}
+              className={`rounded-full px-4 py-2 text-sm transition-colors ${
+                categoryUuid === c.uuid
+                  ? "bg-primary text-white"
+                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+              }`}
+            >
+              {c.name}
+            </button>
+          ))}
+        </div>
+        {categories.length === 0 && (
+          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+            Create a category first from /category
+          </p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col gap-3">
+        <button
+          type="submit"
+          disabled={loading || !categoryUuid}
+          className="rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover disabled:opacity-50"
+        >
+          {loading ? "Saving..." : isEdit ? "Save" : "Create"}
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate("/expense/recurring")}
+          disabled={loading}
+          className="rounded-2xl border border-gray-200 py-3 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Cancel
+        </button>
+        {isEdit && (
+          <button
+            type="button"
+            onClick={openDialog}
+            disabled={loading}
+            className="mt-4 rounded-2xl py-3 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+          >
+            Stop this ritual
+          </button>
+        )}
+      </div>
+
+      <ConfirmDialog
+        message={`Stop "${name}"? Past records remain unchanged.`}
+        onConfirm={handleDelete}
+        confirmText="Stop"
+        loading={loading}
+        dialogRef={dialogRef}
+      />
+    </form>
+  )
+}

--- a/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
@@ -1,0 +1,235 @@
+import { ChevronRightIcon, PlusIcon } from "@radix-ui/react-icons"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Link, useNavigate } from "react-router"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type {
+  IntervalUnit,
+  RecurringExpenseDueResponse,
+  RecurringExpenseResponse,
+} from "../../common/libs/types"
+
+interface FrequencyGroup {
+  key: string
+  label: string
+  unit: IntervalUnit
+  count: number
+}
+
+const FREQUENCY_GROUPS: FrequencyGroup[] = [
+  { key: "weekly", label: "Weekly", unit: "WEEK", count: 1 },
+  { key: "biweekly", label: "Every 2 wk", unit: "WEEK", count: 2 },
+  { key: "monthly", label: "Monthly", unit: "MONTH", count: 1 },
+  { key: "quarterly", label: "Quarterly", unit: "MONTH", count: 3 },
+  { key: "yearly", label: "Yearly", unit: "MONTH", count: 12 },
+]
+
+const PERIOD_LABEL: Record<string, string> = {
+  weekly: "/ wk",
+  biweekly: "/ 2wk",
+  monthly: "/ mo",
+  quarterly: "/ 3mo",
+  yearly: "/ yr",
+}
+
+/** 月次概算合計を算出 (週次は約4.345倍、年次は1/12) */
+const monthlyEquivalent = (r: RecurringExpenseResponse): number => {
+  if (r.interval_unit === "WEEK") {
+    return Math.round((r.amount * 4.345) / r.interval_count)
+  }
+  return Math.round(r.amount / r.interval_count)
+}
+
+const formatAmount = (n: number): string => n.toLocaleString("en-US")
+
+const formatDate = (iso: string): string => {
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+const groupOf = (r: RecurringExpenseResponse): FrequencyGroup | null =>
+  FREQUENCY_GROUPS.find((g) => g.unit === r.interval_unit && g.count === r.interval_count) ?? null
+
+/** 次回予定日を派生算出 (recorded_count はサーバ側のみ把握なので簡易表示として start_date 起点) */
+const nextDueOf = (
+  r: RecurringExpenseResponse,
+  due: RecurringExpenseDueResponse[],
+): string | null => {
+  const d = due.find((x) => x.uuid === r.uuid)
+  if (d && d.missed_dates.length > 0) {
+    return d.missed_dates[0]
+  }
+  return null
+}
+
+export const RecurringExpenseListPage = () => {
+  const navigate = useNavigate()
+  const [items, setItems] = useState<RecurringExpenseResponse[]>([])
+  const [due, setDue] = useState<RecurringExpenseDueResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [list, dueList] = await Promise.all([
+        api.getRecurringExpenses(),
+        api.getRecurringExpenseDue(),
+      ])
+      setItems(list)
+      setDue(dueList)
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const totalMonthly = useMemo(
+    () => items.reduce((sum, r) => sum + monthlyEquivalent(r), 0),
+    [items],
+  )
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, RecurringExpenseResponse[]>()
+    for (const g of FREQUENCY_GROUPS) {
+      map.set(g.key, [])
+    }
+    for (const r of items) {
+      const g = groupOf(r)
+      if (g) {
+        map.get(g.key)?.push(r)
+      }
+    }
+    return map
+  }, [items])
+
+  const handleRecord = async (uuid: string, missedCount: number) => {
+    setError("")
+    setLoading(true)
+    try {
+      await api.recordRecurringExpense(uuid, { count: missedCount })
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to record"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
+      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+      {/* Summary */}
+      <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-gray-800">
+        <div className="text-xs text-gray-500 dark:text-gray-400">Every month</div>
+        <div className="mt-1 text-3xl font-light tracking-tight">¥{formatAmount(totalMonthly)}</div>
+        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+          {items.length} {items.length === 1 ? "ritual" : "rituals"}
+        </div>
+      </div>
+
+      {/* Coming up (due payments) */}
+      {due.length > 0 && (
+        <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+          <div className="mb-3 text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+            Coming up
+          </div>
+          <div className="flex flex-col gap-3">
+            {due.map((d) => (
+              <button
+                key={d.uuid}
+                type="button"
+                onClick={() => handleRecord(d.uuid, d.missed_count)}
+                disabled={loading}
+                className="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3 text-left hover:bg-gray-100 disabled:opacity-50 dark:bg-gray-700 dark:hover:bg-gray-600"
+              >
+                <div className="flex flex-1 flex-col">
+                  <div className="text-sm font-medium">{d.name}</div>
+                  <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {d.missed_count > 1
+                      ? `${d.missed_count} unrecorded · oldest ${formatDate(d.missed_dates[0])}`
+                      : `due ${formatDate(d.missed_dates[0])}`}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-sm font-medium">¥{formatAmount(d.amount)}</div>
+                  <div className="mt-0.5 text-xs text-primary">Tap to record</div>
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Add button */}
+      <Link
+        to="/expense/recurring/new"
+        className="flex items-center justify-center gap-2 rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover"
+      >
+        <PlusIcon className="size-4" />
+        Add ritual
+      </Link>
+
+      {/* Grouped list */}
+      {FREQUENCY_GROUPS.map((g) => {
+        const list = grouped.get(g.key) ?? []
+        if (list.length === 0) return null
+        const groupTotal = list.reduce((sum, r) => sum + monthlyEquivalent(r), 0)
+        return (
+          <div
+            key={g.key}
+            className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-gray-800"
+          >
+            <div className="flex items-center justify-between px-5 py-3 text-xs font-medium text-gray-500 dark:text-gray-400">
+              <span>{g.label}</span>
+              <span>
+                {list.length} · ¥{formatAmount(groupTotal)}/mo
+              </span>
+            </div>
+            <div className="divide-y divide-gray-100 dark:divide-gray-700">
+              {list.map((r) => {
+                const next = nextDueOf(r, due)
+                return (
+                  <button
+                    key={r.uuid}
+                    type="button"
+                    onClick={() => navigate(`/expense/recurring/${r.uuid}`)}
+                    className="flex w-full items-center gap-3 px-5 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700"
+                  >
+                    <div className="flex flex-1 flex-col">
+                      <div className="text-sm font-medium">{r.name}</div>
+                      <div className="mt-0.5 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+                        <span>{r.category.name}</span>
+                        {next && (
+                          <>
+                            <span>·</span>
+                            <span>next {formatDate(next)}</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm font-medium">¥{formatAmount(r.amount)}</div>
+                      <div className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                        {PERIOD_LABEL[g.key]}
+                      </div>
+                    </div>
+                    <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )
+      })}
+
+      {items.length === 0 && (
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">No rituals yet</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,6 +5,8 @@ import { SignupPage } from "./auth/pages/SignupPage"
 import { CategoriesPage } from "./category/pages/CategoriesPage"
 import { AppLayout } from "./common/components/AppLayout"
 import { ProtectedRoute } from "./common/components/ProtectedRoute"
+import { RecurringExpenseEditPage } from "./expense-recurring/pages/RecurringExpenseEditPage"
+import { RecurringExpenseListPage } from "./expense-recurring/pages/RecurringExpenseListPage"
 import { ExpenseTemplatePage } from "./expense-template/pages/ExpenseTemplatePage"
 import { ExpenseTemplateRecordPage } from "./expense-template/pages/ExpenseTemplateRecordPage"
 import { ExpenseAnnualPage } from "./expense/pages/ExpenseAnnualPage"
@@ -33,6 +35,9 @@ export const router = createBrowserRouter([
           { path: "new", element: <ExpensesPage /> },
           { path: "template", element: <ExpenseTemplatePage /> },
           { path: "template/new", element: <ExpenseTemplateRecordPage /> },
+          { path: "recurring", element: <RecurringExpenseListPage /> },
+          { path: "recurring/new", element: <RecurringExpenseEditPage /> },
+          { path: "recurring/:uuid", element: <RecurringExpenseEditPage /> },
           { path: ":uuid", element: <ExpenseDetailPage /> },
         ],
       },

--- a/frontend/src/setting/pages/SettingsPage.tsx
+++ b/frontend/src/setting/pages/SettingsPage.tsx
@@ -1,9 +1,10 @@
 import {
+  BookmarkIcon,
   CheckIcon,
   ChevronRightIcon,
+  CounterClockwiseClockIcon,
   DownloadIcon,
   ExitIcon,
-  BookmarkIcon,
   FileTextIcon,
   Pencil1Icon,
   ResetIcon,
@@ -213,6 +214,15 @@ export const SettingsPage = () => {
         >
           <FileTextIcon className="size-4 text-gray-400 dark:text-gray-500" />
           <span className="flex-1">Template</span>
+          <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate("/expense/recurring")}
+          className="flex w-full items-center gap-3 px-5 py-4 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          <CounterClockwiseClockIcon className="size-4 text-gray-400 dark:text-gray-500" />
+          <span className="flex-1">Recurring</span>
           <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
         </button>
         <button


### PR DESCRIPTION
## 概要

#81 の3PR分割の **PR3 (最終)**。
PR2 で実装した定期支払 API のフロントエンド画面を追加。

## 変更点

### 新規ページ

#### `RecurringExpenseListPage` (`/expense/recurring`)
- 月次概算合計 ("Every month ¥X")
- **Coming up** セクション: 期日到来分 (`/recurring-expenses/due`) を一覧
  - タップで `missed_count` 分まとめて記録
  - 未記録が複数ある場合は \"3 unrecorded · oldest May 1\" 表示
- **周期別グルーピング**: Weekly / Every 2 wk / Monthly / Quarterly / Yearly
  - 各グループに件数と月次概算合計を表示
- 各エントリ: 名前 / カテゴリ / 次回予定日 / 金額 / 周期単位ラベル
- 「Add ritual」ボタン → 作成画面

#### `RecurringExpenseEditPage` (`/expense/recurring/new` & `/expense/recurring/:uuid`)
- 名前 + 金額入力
- **周期セレクタ** (ピル形式): Weekly / Every 2 wk / Monthly / Quarterly / Yearly
  - モデル上は \`(WEEK,1)\` \`(WEEK,2)\` \`(MONTH,1)\` \`(MONTH,3)\` \`(MONTH,12)\` にマッピング
- 開始日 / 終了日 (任意)
- カテゴリ選択 (ピル形式)
- 編集モード時のみ \"Stop this ritual\" ボタン (soft delete + 確認ダイアログ)

### その他

- `frontend/src/common/libs/types.ts`: `IntervalUnit` / `RecurringExpense*` 型追加
- `frontend/src/common/libs/api.ts`: 7メソッド追加 (`getRecurringExpenses` / `getRecurringExpenseDue` / `getRecurringExpense` / `createRecurringExpense` / `updateRecurringExpense` / `deleteRecurringExpense` / `recordRecurringExpense`)
- `frontend/src/router.tsx`: ルート追加
- `frontend/src/common/components/AppLayout.tsx`: ページタイトル追加
- `frontend/src/setting/pages/SettingsPage.tsx`: Recurring へのリンク追加 (Setting配下からアクセス)

## UI参照

\`~/Downloads/ritual_list.html\` / \`ritual.html\` のデザインパターンを参考に、本プロジェクトの Tailwind v4 + Radix Icons の様式に合わせて再構築。

## Test plan

- [x] \`make lint\` Pass
- [ ] /setting → Recurring タップで /expense/recurring へ遷移
- [ ] Add ritual → 名前/金額/周期/開始日/カテゴリ入力 → 作成
- [ ] 一覧で周期別にグループ分けされる
- [ ] 期日到来した recurring が Coming up に表示される
- [ ] Coming up タップで Expense として記録され、月次画面に反映される
- [ ] 既存の recurring をタップ → 編集画面 → 編集 / 削除動作
- [ ] iPhone Safari (本番環境) でレイアウト崩れ無し