### PR TITLE
refactor: expense_templates APIから直接DBアクセスを排除 (1/4)

### DIFF
--- a/backend/src/api/expense_templates.py
+++ b/backend/src/api/expense_templates.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from src.api.deps import get_current_user
-from src.model.category import Category
-from src.model.expense import Expense
-from src.model.expense_category_association import ExpenseCategoryAssociation
-from src.model.expense_template import ExpenseTemplate
 from src.model.user import User
+from src.repository import expense_template_repository
+from src.repository.category_repository import get_category_by_uuid
 from src.repository.database import get_db
 from src.schema.expense_template import (
     BulkRecordRequest,
@@ -20,8 +17,14 @@ from src.schema.expense_template import (
     ExpenseTemplateResponse,
     ExpenseTemplateUpdate,
 )
+from src.service import expense_template_service
 
 expense_template_router = APIRouter(prefix="/expense-templates", tags=["expense-templates"])
+
+
+def _verify_category(db: Session, category_uuid: str, user_uuid: str) -> None:
+    if not get_category_by_uuid(db, category_uuid, user_uuid):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category not found")
 
 
 @expense_template_router.get("")
@@ -29,15 +32,7 @@ def list_templates(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> list[ExpenseTemplateResponse]:
-    templates = (
-        db.query(ExpenseTemplate)
-        .options(joinedload(ExpenseTemplate.category))
-        .filter(
-            ExpenseTemplate.user_uuid == user.uuid,
-            ExpenseTemplate.deleted_at.is_(None),
-        )
-        .all()
-    )
+    templates = expense_template_repository.get_all_active(db, str(user.uuid))
     return [ExpenseTemplateResponse.model_validate(t) for t in templates]
 
 
@@ -47,22 +42,14 @@ def create_template(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ExpenseTemplateResponse:
-    category = db.query(Category).filter(
-        Category.uuid == body.category_uuid,
-        Category.user_uuid == user.uuid,
-    ).first()
-    if not category:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category not found")
-
-    template = ExpenseTemplate(
-        user_uuid=user.uuid,
+    _verify_category(db, body.category_uuid, str(user.uuid))
+    template = expense_template_repository.create(
+        db,
+        user_uuid=str(user.uuid),
         name=body.name,
         amount=body.amount,
         category_uuid=body.category_uuid,
     )
-    db.add(template)
-    db.commit()
-    db.refresh(template)
     return ExpenseTemplateResponse.model_validate(template)
 
 
@@ -73,28 +60,15 @@ def update_template(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ExpenseTemplateResponse:
-    template = db.query(ExpenseTemplate).options(joinedload(ExpenseTemplate.category)).filter(
-        ExpenseTemplate.uuid == uuid,
-        ExpenseTemplate.user_uuid == user.uuid,
-        ExpenseTemplate.deleted_at.is_(None),
-    ).first()
+    template = expense_template_repository.get_by_uuid(db, uuid, str(user.uuid))
     if not template:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
 
     update_data = body.model_dump(exclude_unset=True)
     if "category_uuid" in update_data:
-        category = db.query(Category).filter(
-            Category.uuid == update_data["category_uuid"],
-            Category.user_uuid == user.uuid,
-        ).first()
-        if not category:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Category not found")
+        _verify_category(db, update_data["category_uuid"], str(user.uuid))
 
-    for key, value in update_data.items():
-        setattr(template, key, value)
-
-    db.commit()
-    db.refresh(template)
+    template = expense_template_repository.update(db, template, update_data)
     return ExpenseTemplateResponse.model_validate(template)
 
 
@@ -104,16 +78,10 @@ def delete_template(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> Response:
-    template = db.query(ExpenseTemplate).filter(
-        ExpenseTemplate.uuid == uuid,
-        ExpenseTemplate.user_uuid == user.uuid,
-        ExpenseTemplate.deleted_at.is_(None),
-    ).first()
+    template = expense_template_repository.get_by_uuid(db, uuid, str(user.uuid))
     if not template:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Template not found")
-
-    template.deleted_at = datetime.now(UTC)  # type: ignore[assignment]
-    db.commit()
+    expense_template_repository.soft_delete(db, template)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
@@ -123,26 +91,9 @@ def bulk_record(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> BulkRecordResponse:
-    templates = (
-        db.query(ExpenseTemplate)
-        .filter(
-            ExpenseTemplate.uuid.in_(body.template_uuids),
-            ExpenseTemplate.user_uuid == user.uuid,
-            ExpenseTemplate.deleted_at.is_(None),
-        )
-        .all()
-    )
-
+    templates = expense_template_service.bulk_record(db, body.template_uuids, str(user.uuid))
     if not templates:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No valid templates found")
-
-    for t in templates:
-        expense = Expense(user_uuid=user.uuid, name=t.name, amount=t.amount)
-        db.add(expense)
-        db.flush()
-        association = ExpenseCategoryAssociation(expense_uuid=expense.uuid, category_uuid=t.category_uuid)
-        db.add(association)
-
-    db.commit()
-
-    return BulkRecordResponse(created_count=len(templates), message=f"Recorded {len(templates)} expenses")
+    return BulkRecordResponse(
+        created_count=len(templates), message=f"Recorded {len(templates)} expenses",
+    )

--- a/backend/src/repository/expense_template_repository.py
+++ b/backend/src/repository/expense_template_repository.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy.orm import Session, joinedload
+
+from src.model.expense_template import ExpenseTemplate
+
+
+def get_all_active(db: Session, user_uuid: str) -> list[ExpenseTemplate]:
+    """ユーザーの未削除テンプレート一覧を取得 (categoryをeager load)。"""
+    return (
+        db.query(ExpenseTemplate)
+        .options(joinedload(ExpenseTemplate.category))
+        .filter(
+            ExpenseTemplate.user_uuid == user_uuid,
+            ExpenseTemplate.deleted_at.is_(None),
+        )
+        .all()
+    )
+
+
+def get_by_uuid(db: Session, uuid: str, user_uuid: str) -> ExpenseTemplate | None:
+    """単体取得 (categoryをeager load、未削除のみ)。"""
+    return (
+        db.query(ExpenseTemplate)
+        .options(joinedload(ExpenseTemplate.category))
+        .filter(
+            ExpenseTemplate.uuid == uuid,
+            ExpenseTemplate.user_uuid == user_uuid,
+            ExpenseTemplate.deleted_at.is_(None),
+        )
+        .first()
+    )
+
+
+def get_active_by_uuids(
+    db: Session, uuids: list[str], user_uuid: str,
+) -> list[ExpenseTemplate]:
+    """複数UUIDで一括取得 (bulk-record用)。"""
+    return (
+        db.query(ExpenseTemplate)
+        .filter(
+            ExpenseTemplate.uuid.in_(uuids),
+            ExpenseTemplate.user_uuid == user_uuid,
+            ExpenseTemplate.deleted_at.is_(None),
+        )
+        .all()
+    )
+
+
+def create(db: Session, user_uuid: str, name: str, amount: int, category_uuid: str) -> ExpenseTemplate:
+    """新規作成。"""
+    template = ExpenseTemplate(
+        user_uuid=user_uuid, name=name, amount=amount, category_uuid=category_uuid,
+    )
+    db.add(template)
+    db.commit()
+    db.refresh(template)
+    return template
+
+
+def update(db: Session, template: ExpenseTemplate, fields: dict[str, Any]) -> ExpenseTemplate:
+    """指定フィールドのみ更新。"""
+    for key, value in fields.items():
+        setattr(template, key, value)
+    db.commit()
+    db.refresh(template)
+    return template
+
+
+def soft_delete(db: Session, template: ExpenseTemplate) -> None:
+    """deleted_at を立てて論理削除。"""
+    template.deleted_at = datetime.now(UTC)  # type: ignore[assignment]
+    db.commit()

--- a/backend/src/service/expense_template_service.py
+++ b/backend/src/service/expense_template_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.model.expense import Expense
+from src.model.expense_category_association import ExpenseCategoryAssociation
+from src.repository import expense_template_repository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from src.model.expense_template import ExpenseTemplate
+
+
+def bulk_record(
+    db: Session, template_uuids: list[str], user_uuid: str,
+) -> list[ExpenseTemplate]:
+    """指定テンプレートからExpenseを一括生成。テンプレート一覧を返す。
+
+    呼び元で len() を取れば作成件数になる。
+    """
+    templates = expense_template_repository.get_active_by_uuids(db, template_uuids, user_uuid)
+    if not templates:
+        return []
+
+    for t in templates:
+        expense = Expense(user_uuid=user_uuid, name=t.name, amount=t.amount)
+        db.add(expense)
+        db.flush()
+        db.add(
+            ExpenseCategoryAssociation(
+                expense_uuid=expense.uuid, category_uuid=t.category_uuid,
+            ),
+        )
+    db.commit()
+    return templates


### PR DESCRIPTION
## 概要

#88 の段階的リファクタの **PR1/4**。
\`backend/src/api/expense_templates.py\` から \`db.query/add/commit/flush/refresh\` を排除し、層分離 (api/ → service/ → repository/) を適用。

## 変更点

### 新規

- \`backend/src/repository/expense_template_repository.py\`
  - \`get_all_active\` / \`get_by_uuid\` / \`get_active_by_uuids\` / \`create\` / \`update\` / \`soft_delete\`
  - eager load (joinedload(category)) は repository 側で吸収
- \`backend/src/service/expense_template_service.py\`
  - \`bulk_record\`: 複数テンプレートから Expense + ExpenseCategoryAssociation を生成する複合ロジック

### 修正

- \`backend/src/api/expense_templates.py\`:
  - 直接DBアクセスを全廃
  - 単純CRUDは repository、複合ロジックは service 経由
  - HTTPException変換とPydantic変換のみAPI層に残る
  - \`_verify_category\` は \`category_repository.get_category_by_uuid\` を使う形にリファクタ

## 設計判断

- **commit境界**: repository (単発CRUD) と service (複合) のどちらでも commit する従来パターンを踏襲
  - \`categories.py\` で確立済み
- **eager load配置**: repository 側に閉じ込め (apiは何が読まれるか意識不要)
- **トランザクション**: service の \`bulk_record\` 内で \`flush\` (uuid生成) → \`commit\`、現行挙動を保持

## 不変な挙動

- 既存のAPI仕様 / レスポンス形 / HTTPステータスコードは変更なし
- bulk-record の重複排除等の挙動も変更なし
- 既存テスト (\`tests/api/test_expense_templates.py\` 想定) は変更不要

## Test plan

- [x] \`make test-backend\` Pass (55件)
- [x] \`make lint\` Pass
- [ ] レビュー後、PR2 (expenses.py) に進む