### PR TITLE
refactor: expenses APIから直接DBアクセスを排除 (2/4)

### DIFF
--- a/backend/src/api/expenses.py
+++ b/backend/src/api/expenses.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from src.api.deps import get_current_user
-from src.model.expense import Expense
 from src.model.user import User
 from src.repository.database import get_db
 from src.repository.expense_repository import (
@@ -14,9 +13,9 @@ from src.repository.expense_repository import (
     get_all_expenses,
     get_expense_by_uuid,
     soft_delete_expense,
-    update_expense_categories,
 )
 from src.schema.expense import ExpenseCreate, ExpenseResponse, ExpenseUpdate
+from src.service import expense_service
 
 expense_router = APIRouter(prefix="/expenses", tags=["expenses"])
 
@@ -64,27 +63,19 @@ def patch_expense(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> ExpenseResponse:
-    expense = (
-        db.query(Expense)
-        .options(joinedload(Expense.categories))
-        .filter(Expense.uuid == uuid, Expense.user_uuid == user.uuid, Expense.deleted_at.is_(None))
-        .first()
-    )
+    expense = get_expense_by_uuid(db, uuid, str(user.uuid))
     if not expense:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Expense not found")
 
     update_data = body.model_dump(exclude_unset=True)
-    category_uuid = update_data.pop("category_uuid", None)
-
-    for key, value in update_data.items():
-        setattr(expense, key, value)
-
+    category_uuids: list[str] | None = None
     if "category_uuid" in body.model_fields_set:
-        uuids = [category_uuid] if category_uuid else []
-        update_expense_categories(db, expense, str(user.uuid), uuids)
+        cat_uuid = update_data.pop("category_uuid")
+        category_uuids = [cat_uuid] if cat_uuid else []
 
-    db.commit()
-    db.refresh(expense)
+    expense = expense_service.update_expense(
+        db, expense, str(user.uuid), update_data, category_uuids,
+    )
     return ExpenseResponse.model_validate(expense)
 
 

--- a/backend/src/service/expense_service.py
+++ b/backend/src/service/expense_service.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.repository import expense_repository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+    from src.model.expense import Expense
+
+
+def update_expense(
+    db: Session,
+    expense: Expense,
+    user_uuid: str,
+    update_data: dict[str, Any],
+    category_uuids: list[str] | None,
+) -> Expense:
+    """フィールド更新とカテゴリ再リンクを1トランザクションで実行。
+
+    category_uuids=None ならカテゴリ未変更、[] ならクリア。
+    """
+    for key, value in update_data.items():
+        setattr(expense, key, value)
+
+    if category_uuids is not None:
+        expense_repository.update_expense_categories(db, expense, user_uuid, category_uuids)
+
+    db.commit()
+    db.refresh(expense)
+    return expense


### PR DESCRIPTION
## 概要

#88 の段階的リファクタの **PR2/4**。
\`backend/src/api/expenses.py\` の \`patch_expense\` から \`db.query/joinedload/commit/refresh\` を排除。

## 変更点

### 新規

- \`backend/src/service/expense_service.py\`
  - \`update_expense(db, expense, user_uuid, update_data, category_uuids)\`
  - フィールド更新 + カテゴリ再リンクを1トランザクションで実行
  - \`category_uuids=None\` で「カテゴリ未変更」、\`[]\` で「クリア」を表現

### 修正

- \`backend/src/api/expenses.py\`
  - \`patch_expense\`: 直接の \`db.query(Expense).options(joinedload).filter().first()\` を撤廃
  - 既存の \`expense_repository.get_expense_by_uuid\` (selectinload で eager load 済み) を流用
  - \`db.commit\` / \`db.refresh\` を排除し service 経由に統一
  - 他エンドポイント (list / get / post / delete) は元から repository 経由でクリーンだったため変更なし

## 不変な挙動

- API仕様 / レスポンス形 / HTTPステータスコードは変更なし
- patch の \`category_uuid\` 省略時はカテゴリ未変更、null/空指定時はクリアの挙動を保持
- 既存テスト無変更で全Pass

## Test plan

- [x] \`make test-backend\` Pass (55件)
- [x] \`make lint\` Pass
- [ ] レビュー後、PR3 (recurring_expenses.py) に進む