### PR TITLE
chore: backend全docstringを日本語に統一

### DIFF
--- a/backend/src/api/auth.py
+++ b/backend/src/api/auth.py
@@ -44,7 +44,7 @@ def register_options(
     body: RegisterOptionsRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> RegisterOptionsResponse:
-    """Generate registration options."""
+    """登録オプションを生成。"""
     existing = get_user_by_name(db, body.name)
     if existing is not None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Registration failed")
@@ -66,7 +66,7 @@ def register_verify(
     body: RegisterVerifyRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> RegisterVerifyResponse:
-    """Verify registration and create user + credential."""
+    """登録を検証しユーザーと資格情報を作成。"""
     challenge = challenge_store.get(body.name)
     if challenge is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Challenge not found or expired")
@@ -104,7 +104,7 @@ def sign_in_options(
     body: SignInOptionsRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> SignInOptionsResponse:
-    """Generate authentication options."""
+    """認証オプションを生成。"""
     user = get_user_by_name(db, body.name)
     if user is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Authentication failed")
@@ -137,7 +137,7 @@ def sign_in_verify(
     body: SignInVerifyRequest,
     db: Annotated[Session, Depends(get_db)],
 ) -> SignInVerifyResponse:
-    """Verify authentication and return JWT token."""
+    """認証を検証しJWTを返却。"""
     challenge = challenge_store.get(body.name)
     if challenge is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Challenge not found or expired")

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -19,7 +19,7 @@ def get_current_user(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     db: Annotated[Session, Depends(get_db)],
 ) -> User:
-    """Retrieve the current user from the JWT token."""
+    """JWTトークンから現在のユーザーを取得。"""
     try:
         payload = decode_access_token(credentials.credentials)
     except Exception:

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -6,7 +6,7 @@ _JWT_SECRET_MIN_LENGTH = 32
 
 
 def get_jwt_secret_key() -> str:
-    """Get the JWT signing secret key."""
+    """JWT署名用シークレットキーを取得。"""
     value = os.getenv("JWT_SECRET_KEY")
     if value is None:
         raise ValueError("JWT_SECRET_KEY environment variable is not set.")
@@ -17,22 +17,22 @@ def get_jwt_secret_key() -> str:
 
 
 def get_webauthn_rp_id() -> str:
-    """Get the WebAuthn Relying Party ID."""
+    """WebAuthn Relying Party IDを取得。"""
     return os.getenv("WEBAUTHN_RP_ID", "localhost")
 
 
 def get_webauthn_rp_name() -> str:
-    """Get the WebAuthn Relying Party name."""
+    """WebAuthn Relying Party名を取得。"""
     return os.getenv("WEBAUTHN_RP_NAME", "BurnStyle")
 
 
 def get_frontend_origin() -> str:
-    """Get the frontend origin URL."""
+    """フロントエンドのoriginURLを取得。"""
     return os.getenv("FRONTEND_ORIGIN", "http://localhost:15173")
 
 
 def get_cron_secret() -> str:
-    """Get the cron Bearer token. Required for /cron endpoints."""
+    """cron用のBearerトークンを取得 (/cronエンドポイント認証で必須)。"""
     value = os.getenv("CRON_SECRET")
     if value is None:
         raise ValueError("CRON_SECRET environment variable is not set.")

--- a/backend/src/logger.py
+++ b/backend/src/logger.py
@@ -12,7 +12,7 @@ user_uuid_var: ContextVar[str | None] = ContextVar("user_uuid", default=None)
 
 
 class JsonFormatter(logging.Formatter):
-    """JSON formatter that auto-includes request_id and user_uuid from contextvars."""
+    """contextvarsのrequest_id/user_uuidを自動付与するJSONフォーマッタ。"""
 
     def format(self, record: logging.LogRecord) -> str:
         payload: dict[str, Any] = {
@@ -42,7 +42,7 @@ _RESERVED_KEYS = {
 
 
 def configure_logging() -> None:
-    """Install JsonFormatter on the root logger. Idempotent."""
+    """ルートロガーにJsonFormatterをインストール。冪等。"""
     root = logging.getLogger()
     if any(isinstance(h.formatter, JsonFormatter) for h in root.handlers):
         return
@@ -54,6 +54,6 @@ def configure_logging() -> None:
 
 
 def get_logger(name: str) -> logging.Logger:
-    """Return a configured logger under the burnstyle namespace."""
+    """burnstyle名前空間のロガーを取得。"""
     configure_logging()
     return logging.getLogger(f"burnstyle.{name}")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -22,7 +22,7 @@ configure_logging()
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """Middleware that adds security headers."""
+    """セキュリティヘッダを付与するミドルウェア。"""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)

--- a/backend/src/middleware/request_logging.py
+++ b/backend/src/middleware/request_logging.py
@@ -13,7 +13,7 @@ logger = get_logger("request")
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
-    """Assign request_id, emit start/end access logs with duration."""
+    """request_idを採番し、開始/終了アクセスログを出力。"""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         request_id = request.headers.get("x-vercel-id") or str(uuid.uuid4())

--- a/backend/src/middleware/token_refresh.py
+++ b/backend/src/middleware/token_refresh.py
@@ -8,7 +8,7 @@ from src.service.jwt_service import create_access_token, decode_access_token
 
 
 class TokenRefreshMiddleware(BaseHTTPMiddleware):
-    """Reissue JWT on each authenticated request and set it in the response header."""
+    """認証付きリクエストで毎回JWTを再発行しレスポンスヘッダに付与。"""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)

--- a/backend/src/model/utils.py
+++ b/backend/src/model/utils.py
@@ -2,6 +2,6 @@ import uuid6
 
 
 def generate_uuid_string() -> str:
-    """Generate a UUID v7 as a 32-character hex string without hyphens."""
+    """UUID v7を32文字のhex文字列で生成 (ハイフンなし)。"""
     return uuid6.uuid7().hex
 

--- a/backend/src/repository/category_repository.py
+++ b/backend/src/repository/category_repository.py
@@ -8,17 +8,17 @@ from src.model.expense_template import ExpenseTemplate
 
 
 def get_all_categories(db: Session, user_uuid: str) -> list[Category]:
-    """Get all categories."""
+    """カテゴリ一覧を取得。"""
     return db.query(Category).filter(Category.user_uuid == user_uuid).all()
 
 
 def get_category_by_uuid(db: Session, uuid: str, user_uuid: str) -> Category | None:
-    """Get a category by UUID."""
+    """UUIDでカテゴリを取得。"""
     return db.query(Category).filter(Category.uuid == uuid, Category.user_uuid == user_uuid).first()
 
 
 def create_category(db: Session, user_uuid: str, name: str) -> Category:
-    """Create a new category."""
+    """カテゴリを新規作成。"""
     category = Category(user_uuid=user_uuid, name=name)
     db.add(category)
     db.commit()
@@ -27,7 +27,7 @@ def create_category(db: Session, user_uuid: str, name: str) -> Category:
 
 
 def delete_all_categories(db: Session) -> None:
-    """Delete all categories (including association table records)."""
+    """全カテゴリを削除 (association表のレコードも含む)。"""
     db.query(ExpenseCategoryAssociation).delete()
     db.query(Category).delete()
 
@@ -38,7 +38,7 @@ def delete_all_for_user(db: Session, user_uuid: str) -> None:
 
 
 def bulk_create_categories(db: Session, user_uuid: str, names: list[str]) -> list[Category]:
-    """Bulk-create categories."""
+    """カテゴリを一括作成。"""
     categories = [Category(user_uuid=user_uuid, name=name) for name in names]
     db.add_all(categories)
     db.commit()
@@ -48,7 +48,7 @@ def bulk_create_categories(db: Session, user_uuid: str, names: list[str]) -> lis
 
 
 def update_category(db: Session, category: Category, name: str) -> Category:
-    """Update a category name."""
+    """カテゴリ名を更新。"""
     category.name = name  # type: ignore[assignment]
     db.commit()
     db.refresh(category)
@@ -56,17 +56,13 @@ def update_category(db: Session, category: Category, name: str) -> Category:
 
 
 def delete_category(db: Session, category: Category) -> None:
-    """Hard-delete a category."""
+    """カテゴリを物理削除。"""
     db.delete(category)
     db.commit()
 
 
 def merge_categories(db: Session, source: Category, target: Category) -> Category:
-    """Merge the source category into the target.
-
-    Re-link expense associations and templates from source to target,
-    then delete source. Duplicate expense links are deduplicated.
-    """
+    """sourceカテゴリをtargetに統合。expense関連付けとtemplateを付け替えてsourceを削除。重複は排除。"""
     target_expense_uuids = {
         row[0]
         for row in db.query(ExpenseCategoryAssociation.expense_uuid)

--- a/backend/src/repository/database.py
+++ b/backend/src/repository/database.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 
 def get_database_url() -> str:
-    """Get DATABASE_URL from environment variables and resolve the hostname."""
+    """環境変数からDATABASE_URLを取得しホスト名を解決。"""
     # Use POSTGRES_URL in Vercel production environment
     vercel_env = os.getenv("VERCEL_ENV")
     if vercel_env == "production":
@@ -52,18 +52,18 @@ class Base(DeclarativeBase):
 
 @lru_cache(maxsize=1)
 def get_engine() -> Engine:
-    """Lazily create the database engine."""
+    """DBエンジンを遅延生成。"""
     return create_engine(get_database_url())
 
 
 @lru_cache(maxsize=1)
 def get_session_local() -> sessionmaker[Session]:
-    """Lazily create the session factory."""
+    """セッションファクトリを遅延生成。"""
     return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
 
 
 def get_db() -> Generator[Session]:
-    """Dependency injection function that yields a database session."""
+    """DBセッションをyieldするDI関数。"""
     db = get_session_local()()
     try:
         yield db

--- a/backend/src/repository/expense_repository.py
+++ b/backend/src/repository/expense_repository.py
@@ -18,7 +18,7 @@ def get_all_expenses(
     month: int | None = None,
     include_deleted: bool = False,
 ) -> list[Expense]:
-    """Get all expenses (non-deleted only by default)."""
+    """支出一覧を取得 (デフォルトは未削除のみ)。"""
     query = db.query(Expense).options(selectinload(Expense.categories)).filter(Expense.user_uuid == user_uuid)
     if not include_deleted:
         query = query.filter(Expense.deleted_at.is_(None))
@@ -39,7 +39,7 @@ def get_all_expenses(
 
 
 def get_expense_by_uuid(db: Session, uuid: str, user_uuid: str) -> Expense | None:
-    """Get an expense by UUID."""
+    """UUIDで支出を取得 (categoryをeager load)。"""
     return db.query(Expense).options(selectinload(Expense.categories)).filter(
         Expense.uuid == uuid,
         Expense.user_uuid == user_uuid,
@@ -56,7 +56,7 @@ def create_expense(  # noqa: PLR0913
     *,
     category_uuids: list[str] | None = None,
 ) -> Expense:
-    """Create a new expense."""
+    """支出を新規作成。"""
     expense = Expense(user_uuid=user_uuid, name=name, amount=amount, expensed_at=expensed_at)
 
     if category_uuids:
@@ -73,7 +73,7 @@ def create_expense(  # noqa: PLR0913
 
 
 def update_expense_categories(db: Session, expense: Expense, user_uuid: str, category_uuids: list[str]) -> None:
-    """Update categories of an expense."""
+    """支出のカテゴリを再リンク。"""
     categories = db.query(Category).filter(
         Category.uuid.in_(category_uuids),
         Category.user_uuid == user_uuid,
@@ -82,7 +82,7 @@ def update_expense_categories(db: Session, expense: Expense, user_uuid: str, cat
 
 
 def soft_delete_expense(db: Session, expense: Expense) -> None:
-    """Soft-delete an expense."""
+    """支出を論理削除。"""
     expense.deleted_at = dt.datetime.now(dt.UTC)  # type: ignore[assignment]
     db.commit()
 

--- a/backend/src/repository/recurring_expense_repository.py
+++ b/backend/src/repository/recurring_expense_repository.py
@@ -11,7 +11,7 @@ from src.model.recurring_expense import RecurringExpense
 
 
 def get_all_active(db: Session, user_uuid: str) -> list[RecurringExpense]:
-    """List all active recurring expenses for the user."""
+    """ユーザーの未削除定期支払一覧を取得 (categoryをeager load)。"""
     return (
         db.query(RecurringExpense)
         .options(joinedload(RecurringExpense.category))
@@ -24,7 +24,7 @@ def get_all_active(db: Session, user_uuid: str) -> list[RecurringExpense]:
 
 
 def get_all_active_for_cron(db: Session) -> list[RecurringExpense]:
-    """List all active recurring expenses across users (for cron)."""
+    """全ユーザーの未削除定期支払を取得 (cron用)。"""
     return (
         db.query(RecurringExpense)
         .options(joinedload(RecurringExpense.category))
@@ -34,7 +34,7 @@ def get_all_active_for_cron(db: Session) -> list[RecurringExpense]:
 
 
 def get_by_uuid(db: Session, uuid: str, user_uuid: str) -> RecurringExpense | None:
-    """Fetch a single recurring expense for the user."""
+    """UUIDで定期支払を単体取得 (未削除のみ)。"""
     return (
         db.query(RecurringExpense)
         .options(joinedload(RecurringExpense.category))
@@ -48,7 +48,7 @@ def get_by_uuid(db: Session, uuid: str, user_uuid: str) -> RecurringExpense | No
 
 
 def count_recorded(db: Session, recurring_uuid: str) -> int:
-    """Count expenses linked to this recurring expense (excluding soft-deleted)."""
+    """定期支払に紐づくExpense件数を取得 (soft-delete除外)。"""
     result = (
         db.query(func.count(Expense.uuid))
         .filter(
@@ -84,6 +84,6 @@ def update(db: Session, recurring: RecurringExpense, fields: dict[str, Any]) -> 
 
 
 def soft_delete(db: Session, recurring: RecurringExpense) -> None:
-    """Soft-delete a recurring expense."""
+    """定期支払を論理削除。"""
     recurring.deleted_at = datetime.now(UTC)  # type: ignore[assignment]
     db.commit()

--- a/backend/src/repository/user_repository.py
+++ b/backend/src/repository/user_repository.py
@@ -6,17 +6,17 @@ from src.model.user import User
 
 
 def get_user_by_name(db: Session, name: str) -> User | None:
-    """Get a user by name."""
+    """ユーザー名でユーザーを取得。"""
     return db.query(User).filter(User.name == name).first()
 
 
 def get_user_by_uuid(db: Session, uuid: str) -> User | None:
-    """Get a user by UUID."""
+    """UUIDでユーザーを取得。"""
     return db.query(User).filter(User.uuid == uuid).first()
 
 
 def create_user(db: Session, name: str) -> User:
-    """Create a new user."""
+    """ユーザーを新規作成。"""
     user = User(name=name)
     db.add(user)
     db.commit()
@@ -25,7 +25,7 @@ def create_user(db: Session, name: str) -> User:
 
 
 def update_user(db: Session, user: User, name: str) -> User:
-    """Update a user's name."""
+    """ユーザー名を更新。"""
     user.name = name  # type: ignore[assignment]
     db.commit()
     db.refresh(user)
@@ -33,6 +33,6 @@ def update_user(db: Session, user: User, name: str) -> User:
 
 
 def delete_user(db: Session, user: User) -> None:
-    """Delete a user."""
+    """ユーザーを削除。"""
     db.delete(user)
     db.commit()

--- a/backend/src/repository/webauthn_repository.py
+++ b/backend/src/repository/webauthn_repository.py
@@ -6,12 +6,12 @@ from src.model.webauthn_credential import WebAuthnCredential
 
 
 def get_credentials_by_user_uuid(db: Session, user_uuid: str) -> list[WebAuthnCredential]:
-    """Get all WebAuthn credentials by user UUID."""
+    """ユーザーUUIDで全WebAuthn資格情報を取得。"""
     return db.query(WebAuthnCredential).filter(WebAuthnCredential.user_uuid == user_uuid).all()
 
 
 def get_credential_by_credential_id(db: Session, credential_id: bytes) -> WebAuthnCredential | None:
-    """Get a WebAuthn credential by credential ID."""
+    """credential IDから資格情報を取得。"""
     return db.query(WebAuthnCredential).filter(WebAuthnCredential.credential_id == credential_id).first()
 
 
@@ -24,7 +24,7 @@ def create_credential(  # noqa: PLR0913
     sign_count: int,
     transports: str | None,
 ) -> WebAuthnCredential:
-    """Create a new WebAuthn credential."""
+    """WebAuthn資格情報を新規作成。"""
     credential = WebAuthnCredential(
         user_uuid=user_uuid,
         credential_id=credential_id,
@@ -39,6 +39,6 @@ def create_credential(  # noqa: PLR0913
 
 
 def update_sign_count(db: Session, credential: WebAuthnCredential, new_sign_count: int) -> None:
-    """Update the sign count of a credential."""
+    """資格情報のsign_countを更新。"""
     credential.sign_count = new_sign_count  # type: ignore[assignment]
     db.commit()

--- a/backend/src/schema/types.py
+++ b/backend/src/schema/types.py
@@ -10,12 +10,12 @@ JST = timezone(timedelta(hours=9))
 
 
 def _to_jst(v: datetime) -> datetime:
-    """Convert naive datetime (assumed UTC) to JST."""
+    """naive datetime (UTC想定) をJSTに変換。"""
     return v.replace(tzinfo=UTC).astimezone(JST)
 
 
 def _jst_to_utc(v: datetime) -> datetime:
-    """Convert JST input to naive UTC (naive->JST->UTC->naive)."""
+    """JST入力をnaive UTCに変換 (naive→JST→UTC→naive)。"""
     if v.tzinfo is None:
         v = v.replace(tzinfo=JST)
     return v.astimezone(UTC).replace(tzinfo=None)

--- a/backend/src/service/challenge_store.py
+++ b/backend/src/service/challenge_store.py
@@ -4,19 +4,19 @@ import time
 
 
 class ChallengeStore:
-    """In-memory store for WebAuthn challenges (TTL 5 min)."""
+    """WebAuthnチャレンジをメモリに保持するストア (TTL 5分)。"""
 
     def __init__(self, ttl_seconds: int = 300) -> None:
         self._store: dict[str, tuple[bytes, float]] = {}
         self._ttl = ttl_seconds
 
     def save(self, name: str, challenge: bytes) -> None:
-        """Save a challenge."""
+        """チャレンジを保存。"""
         self._cleanup()
         self._store[name] = (challenge, time.monotonic())
 
     def get(self, name: str) -> bytes | None:
-        """Retrieve and remove a challenge."""
+        """チャレンジを取り出して削除。"""
         self._cleanup()
         entry = self._store.pop(name, None)
         if entry is None:
@@ -25,7 +25,7 @@ class ChallengeStore:
         return challenge
 
     def _cleanup(self) -> None:
-        """Remove expired entries."""
+        """期限切れエントリを削除。"""
         now = time.monotonic()
         expired = [k for k, (_, ts) in self._store.items() if now - ts > self._ttl]
         for k in expired:

--- a/backend/src/service/jwt_service.py
+++ b/backend/src/service/jwt_service.py
@@ -11,13 +11,13 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 15
 
 
 def create_access_token(user_uuid: str) -> str:
-    """Generate a JWT access token."""
+    """JWTアクセストークンを生成。"""
     expire = datetime.now(UTC) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     payload = {"sub": user_uuid, "exp": expire}
     return jwt.encode(payload, get_jwt_secret_key(), algorithm=ALGORITHM)
 
 
 def decode_access_token(token: str) -> dict[str, object]:
-    """Verify and decode a JWT access token."""
+    """JWTアクセストークンを検証してデコード。"""
     result: dict[str, object] = jwt.decode(token, get_jwt_secret_key(), algorithms=[ALGORITHM])
     return result

--- a/backend/src/service/recurring_expense_service.py
+++ b/backend/src/service/recurring_expense_service.py
@@ -18,30 +18,26 @@ if TYPE_CHECKING:
 
 
 def jst_today() -> date:
-    """Return today's date in JST. Avoid date.today() (OS-tz dependent)."""
+    """JSTの今日の日付を返す (date.today()はOS-tz依存のため不可)。"""
     return datetime.now(JST).date()
 
 
 def offset_from_start(unit: IntervalUnit, count: int, n: int) -> relativedelta | timedelta:
-    """Compute the offset to add to start_date for the n-th occurrence (0-indexed)."""
+    """n回目 (0-indexed) の発生日 = start_date + 本オフセット を算出。"""
     if unit is IntervalUnit.WEEK:
         return timedelta(weeks=count * n)
     return relativedelta(months=count * n)
 
 
 def occurrence_date(start: date, unit: IntervalUnit, count: int, n: int) -> date:
-    """Return the date of the n-th occurrence (0-indexed) starting from start_date."""
+    """start_date起点でのn回目 (0-indexed) の発生日を返す。"""
     return start + offset_from_start(unit, count, n)
 
 
 def missed_dates(
     recurring: RecurringExpense, recorded_count: int, today: date,
 ) -> list[date]:
-    """Return dates that are due but not yet recorded.
-
-    Iterates from the (recorded_count)-th occurrence forward, collecting dates
-    that are <= today and (if end_date is set) <= end_date.
-    """
+    """期日到来で未記録の発生日リストを返す (today・end_dateで打ち切り)。"""
     result: list[date] = []
     n = recorded_count
     while True:
@@ -66,11 +62,7 @@ def record_occurrences(
     count: int,
     expensed_at_override: date | None = None,
 ) -> int:
-    """Create `count` Expense rows linked to this recurring expense.
-
-    Uses computed occurrence dates as `expensed_at` unless overridden.
-    Returns the number of records created.
-    """
+    """定期支払に紐づくExpenseをcount件生成 (expensed_atは算出日付か上書き値)。作成件数を返す。"""
     recorded = recurring_expense_repository.count_recorded(db, str(recurring.uuid))
     created = 0
     for i in range(count):
@@ -107,10 +99,7 @@ def record_occurrences(
 
 
 def record_all_due_for_cron(db: Session) -> tuple[int, int]:
-    """Process all active recurring expenses across users.
-
-    Returns (recorded_count, processed_recurring_count).
-    """
+    """全ユーザーの未削除定期支払を処理。返り値は (recorded_count, processed_recurring_count)。"""
     today = jst_today()
     recurrings = recurring_expense_repository.get_all_active_for_cron(db)
     total_recorded = 0


### PR DESCRIPTION
## 概要

#84 で定めた「JSDoc / Python docstringは日本語で記載」ルールに合わせ、backend全docstringを日本語化。

## 変更点

### 対象ファイル (15)

- \`backend/src/config.py\`
- \`backend/src/logger.py\`
- \`backend/src/main.py\`
- \`backend/src/middleware/request_logging.py\`
- \`backend/src/middleware/token_refresh.py\`
- \`backend/src/repository/database.py\`
- \`backend/src/repository/expense_repository.py\`
- \`backend/src/repository/category_repository.py\`
- \`backend/src/repository/user_repository.py\`
- \`backend/src/repository/webauthn_repository.py\`
- \`backend/src/repository/recurring_expense_repository.py\`
- \`backend/src/schema/types.py\`
- \`backend/src/api/auth.py\`
- \`backend/src/api/deps.py\`
- \`backend/src/model/utils.py\`
- \`backend/src/service/jwt_service.py\`
- \`backend/src/service/challenge_store.py\`
- \`backend/src/service/recurring_expense_service.py\`

### 方針

- 1〜2行で目的が伝わる程度に簡潔化
- 冗長な Args / Returns 表記は削除 (型注釈で十分)
- WHY / 制約 / 副作用などを優先

### 不変な点

- インラインコメント (\`# ...\`) は英語ポリシー継続のため変更なし
- API挙動・型シグネチャは無変更

## Test plan

- [x] \`make test-backend\` Pass (55件)
- [x] \`make lint\` Pass