### PR TITLE
fix: backend依存変更時にコンテナを自動再ビルド

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,10 @@ services:
         - action: sync
           path: ./backend/src
           target: /app/src
-        - action: sync
+        - action: rebuild
           path: ./backend/pyproject.toml
-          target: /app/pyproject.toml
-        - action: sync
+        - action: rebuild
           path: ./backend/uv.lock
-          target: /app/uv.lock
         - action: rebuild
           path: ./backend/Dockerfile
 


### PR DESCRIPTION
## 概要

#86

\`docker-compose.yml\` のbackend watch設定で \`pyproject.toml\` と \`uv.lock\` を **sync → rebuild** に変更。
依存追加 (\`uv add <pkg>\`) 後の手動 \`docker compose up -d --build backend\` が不要になる。

## 変更前

\`\`\`yaml
- action: sync
  path: ./backend/pyproject.toml
  target: /app/pyproject.toml
- action: sync
  path: ./backend/uv.lock
  target: /app/uv.lock
\`\`\`

→ ファイルだけコンテナに同期、venvは古い依存のまま → \`ModuleNotFoundError\`

## 変更後

\`\`\`yaml
- action: rebuild
  path: ./backend/pyproject.toml
- action: rebuild
  path: ./backend/uv.lock
\`\`\`

frontend側の \`package.json\` 変更が \`rebuild\` になっているのと同様の挙動。

## トレードオフ

- **メリット**: 依存追加時の手動オペが不要、開発者体験向上
- **デメリット**: 誤って \`pyproject.toml\` を編集した時に rebuild がトリガーされる (数十秒〜分単位)
- **判断**: 依存変更頻度は低いため許容範囲

## Test plan

- [ ] \`uv add\` で依存追加 → \`docker compose watch\` がbackendを自動 rebuild
- [ ] \`pyproject.toml\` を保存しただけで rebuild されることを確認