### PR TITLE
feat: カテゴリの並び順をD&Dで保存・統合時にposition詰め

### DIFF
--- a/backend/alembic/versions/c4ddc57e2edf_add_categories_position.py
+++ b/backend/alembic/versions/c4ddc57e2edf_add_categories_position.py
@@ -1,0 +1,43 @@
+"""カテゴリに並び順カラムを追加
+
+Revision ID: c4ddc57e2edf
+Revises: aec700ae61d2
+Create Date: 2026-05-09 22:35:15.130741
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4ddc57e2edf"
+down_revision: str | Sequence[str] | None = "aec700ae61d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # nullableで追加 → 既存行をユーザーごとにuuid順でposition埋め → NOT NULL化
+    op.add_column(
+        "categories", sa.Column("position", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE categories AS c
+        SET position = sub.rn - 1
+        FROM (
+            SELECT uuid, ROW_NUMBER() OVER (PARTITION BY user_uuid ORDER BY uuid) AS rn
+            FROM categories
+        ) AS sub
+        WHERE c.uuid = sub.uuid
+        """,
+    )
+    op.alter_column("categories", "position", nullable=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("categories", "position")

--- a/backend/src/api/categories.py
+++ b/backend/src/api/categories.py
@@ -13,12 +13,14 @@ from src.repository.category_repository import (
     get_all_categories,
     get_category_by_uuid,
     merge_categories,
+    reorder_categories,
     update_category,
 )
 from src.repository.database import get_db
 from src.schema.category import (
     CategoryCreate,
     CategoryMergeRequest,
+    CategoryReorderRequest,
     CategoryResponse,
     CategoryUpdate,
 )
@@ -75,6 +77,21 @@ def delete_category_endpoint(
 
     delete_category(db, category)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@category_router.put("/order")
+def put_category_order(
+    body: CategoryReorderRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+) -> list[CategoryResponse]:
+    try:
+        categories = reorder_categories(db, str(user.uuid), body.uuids)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e),
+        ) from None
+    return [CategoryResponse.model_validate(c) for c in categories]
 
 
 @category_router.post("/{uuid}/merge")

--- a/backend/src/model/category.py
+++ b/backend/src/model/category.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.model.utils import generate_uuid_string
@@ -13,6 +13,7 @@ class Category(Base):
     uuid = Column(String(32), primary_key=True, default=generate_uuid_string)
     user_uuid = Column(String(32), ForeignKey("users.uuid", ondelete="CASCADE"), nullable=False)
     name = Column(String, nullable=False)
+    position = Column(Integer, nullable=False, default=0)
 
     user = relationship("User")
 

--- a/backend/src/repository/category_repository.py
+++ b/backend/src/repository/category_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from src.model.category import Category
@@ -8,8 +9,13 @@ from src.model.expense_template import ExpenseTemplate
 
 
 def get_all_categories(db: Session, user_uuid: str) -> list[Category]:
-    """カテゴリ一覧を取得。"""
-    return db.query(Category).filter(Category.user_uuid == user_uuid).all()
+    """カテゴリ一覧を取得 (position昇順、tiebreakerにuuid)。"""
+    return (
+        db.query(Category)
+        .filter(Category.user_uuid == user_uuid)
+        .order_by(Category.position.asc(), Category.uuid.asc())
+        .all()
+    )
 
 
 def get_category_by_uuid(db: Session, uuid: str, user_uuid: str) -> Category | None:
@@ -18,12 +24,53 @@ def get_category_by_uuid(db: Session, uuid: str, user_uuid: str) -> Category | N
 
 
 def create_category(db: Session, user_uuid: str, name: str) -> Category:
-    """カテゴリを新規作成。"""
-    category = Category(user_uuid=user_uuid, name=name)
+    """カテゴリを新規作成 (positionは末尾)。"""
+    next_position = (
+        db.query(func.coalesce(func.max(Category.position), -1))
+        .filter(Category.user_uuid == user_uuid)
+        .scalar()
+        or -1
+    )
+    category = Category(user_uuid=user_uuid, name=name, position=int(next_position) + 1)
     db.add(category)
     db.commit()
     db.refresh(category)
     return category
+
+
+def reorder_categories(db: Session, user_uuid: str, ordered_uuids: list[str]) -> list[Category]:
+    """渡されたUUID列順にpositionを 0,1,2,... で割り当てて保存。
+
+    user_uuidに属する全カテゴリが含まれる必要があり、欠落・他ユーザー所有 UUID 混入時は ValueError。
+    """
+    existing = (
+        db.query(Category)
+        .filter(Category.user_uuid == user_uuid)
+        .all()
+    )
+    existing_uuids = {str(c.uuid) for c in existing}
+    given_uuids = set(ordered_uuids)
+    if existing_uuids != given_uuids or len(ordered_uuids) != len(given_uuids):
+        raise ValueError("ordered_uuids must be a permutation of the user's category uuids")
+
+    by_uuid = {str(c.uuid): c for c in existing}
+    for index, uuid in enumerate(ordered_uuids):
+        by_uuid[uuid].position = index  # type: ignore[assignment]
+    db.commit()
+    return get_all_categories(db, user_uuid)
+
+
+def compact_positions(db: Session, user_uuid: str) -> None:
+    """user_uuidに属するカテゴリのpositionを 0,1,2,... に詰め直す (merge後の隙間を埋める)。"""
+    categories = (
+        db.query(Category)
+        .filter(Category.user_uuid == user_uuid)
+        .order_by(Category.position.asc(), Category.uuid.asc())
+        .all()
+    )
+    for index, c in enumerate(categories):
+        c.position = index  # type: ignore[assignment]
+    db.commit()
 
 
 def delete_all_categories(db: Session) -> None:
@@ -89,7 +136,10 @@ def merge_categories(db: Session, source: Category, target: Category) -> Categor
         {"category_uuid": target.uuid},
     )
 
+    user_uuid = str(source.user_uuid)
     db.delete(source)
     db.commit()
+    # sourceの抜けた分をpositionに反映
+    compact_positions(db, user_uuid)
     db.refresh(target)
     return target

--- a/backend/src/schema/category.py
+++ b/backend/src/schema/category.py
@@ -8,6 +8,7 @@ class CategoryResponse(BaseModel):
 
     uuid: str
     name: str
+    position: int
 
 
 class CategoryCreate(BaseModel):
@@ -20,4 +21,8 @@ class CategoryUpdate(BaseModel):
 
 class CategoryMergeRequest(BaseModel):
     target_uuid: str
+
+
+class CategoryReorderRequest(BaseModel):
+    uuids: list[str]
 

--- a/backend/tests/api/test_categories.py
+++ b/backend/tests/api/test_categories.py
@@ -90,6 +90,63 @@ class TestDeleteCategory:
         assert res.status_code == 404
 
 
+class TestReorderCategories:
+    def _create_three(self, db: Session, user: User) -> list[Category]:
+        cats = [
+            Category(user_uuid=str(user.uuid), name=f"cat{i}", position=i)
+            for i in range(3)
+        ]
+        db.add_all(cats)
+        db.commit()
+        for c in cats:
+            db.refresh(c)
+        return cats
+
+    def test_reorders_categories(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        cats = self._create_three(db, test_user)
+        new_order = [cats[2].uuid, cats[0].uuid, cats[1].uuid]
+
+        res = auth_client.put("/categories/order", json={"uuids": new_order})
+        assert res.status_code == 200
+
+        listed = auth_client.get("/categories").json()
+        assert [c["uuid"] for c in listed] == new_order
+        assert [c["position"] for c in listed] == [0, 1, 2]
+
+    def test_rejects_partial_uuids(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        cats = self._create_three(db, test_user)
+        res = auth_client.put("/categories/order", json={"uuids": [cats[0].uuid]})
+        assert res.status_code == 400
+
+    def test_rejects_unknown_uuid(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        cats = self._create_three(db, test_user)
+        res = auth_client.put(
+            "/categories/order",
+            json={"uuids": [cats[0].uuid, cats[1].uuid, "nonexistent"]},
+        )
+        assert res.status_code == 400
+
+
+class TestCategoryListOrder:
+    def test_returns_in_position_order(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        c1 = Category(user_uuid=str(test_user.uuid), name="a", position=2)
+        c2 = Category(user_uuid=str(test_user.uuid), name="b", position=0)
+        c3 = Category(user_uuid=str(test_user.uuid), name="c", position=1)
+        db.add_all([c1, c2, c3])
+        db.commit()
+
+        listed = auth_client.get("/categories").json()
+        assert [c["name"] for c in listed] == ["b", "c", "a"]
+
+
 class TestMergeCategory:
     def _create_pair(self, db: Session, user: User) -> tuple[Category, Category]:
         source = Category(user_uuid=str(user.uuid), name="外食")
@@ -119,7 +176,9 @@ class TestMergeCategory:
 
         res = auth_client.post(f"/categories/{source.uuid}/merge", json={"target_uuid": target.uuid})
         assert res.status_code == 200
-        assert res.json() == {"uuid": target.uuid, "name": target.name}
+        body = res.json()
+        assert body["uuid"] == target.uuid
+        assert body["name"] == target.name
 
         remaining = auth_client.get("/categories").json()
         assert {c["uuid"] for c in remaining} == {target.uuid}
@@ -223,3 +282,22 @@ class TestMergeCategory:
 
         res = auth_client.post(f"/categories/{source.uuid}/merge", json={"target_uuid": target.uuid})
         assert res.status_code == 404
+
+    def test_compacts_positions_after_merge(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        a = Category(user_uuid=str(test_user.uuid), name="a", position=0)
+        b = Category(user_uuid=str(test_user.uuid), name="b", position=1)
+        c = Category(user_uuid=str(test_user.uuid), name="c", position=2)
+        db.add_all([a, b, c])
+        db.commit()
+        db.refresh(a)
+        db.refresh(b)
+        db.refresh(c)
+
+        # 真ん中の b を a に統合 → b の隙間 (position=1) を c が埋める
+        res = auth_client.post(f"/categories/{b.uuid}/merge", json={"target_uuid": a.uuid})
+        assert res.status_code == 200
+
+        listed = auth_client.get("/categories").json()
+        assert [(c["name"], c["position"]) for c in listed] == [("a", 0), ("c", 1)]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.3.0",
         "@tailwindcss/vite": "^4.2.2",
@@ -26,6 +29,59 @@
         "oxlint": "^1.58.0",
         "typescript": "~5.9.3",
         "vite": "^8.0.1"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,9 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.3.0",
     "@tailwindcss/vite": "^4.2.2",

--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -1,6 +1,25 @@
 import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import {
   ArrowRightIcon,
   CheckIcon,
+  DragHandleDots2Icon,
   Pencil1Icon,
   PlusIcon,
   ResetIcon,
@@ -12,6 +31,159 @@ import { ConfirmDialog, useConfirmDialog } from "../../common/components/Confirm
 import { api } from "../../common/libs/api"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse } from "../../common/libs/types"
+
+interface SortableRowProps {
+  category: CategoryResponse
+  loading: boolean
+  editing: { uuid: string; name: string } | null
+  setEditing: (e: { uuid: string; name: string } | null) => void
+  editInputRef: React.RefObject<HTMLInputElement | null>
+  onUpdate: () => void
+  onStartEdit: (c: CategoryResponse) => void
+  merging: { source: CategoryResponse; targetUuid: string } | null
+  setMerging: (m: { source: CategoryResponse; targetUuid: string } | null) => void
+  onConfirmMerge: () => void
+  onStartMerge: (c: CategoryResponse) => void
+  onConfirmDelete: (c: CategoryResponse) => void
+  categories: CategoryResponse[]
+  reorderDisabled: boolean
+}
+
+const SortableRow = ({
+  category: c,
+  loading,
+  editing,
+  setEditing,
+  editInputRef,
+  onUpdate,
+  onStartEdit,
+  merging,
+  setMerging,
+  onConfirmMerge,
+  onStartMerge,
+  onConfirmDelete,
+  categories,
+  reorderDisabled,
+}: SortableRowProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: c.uuid,
+    disabled: reorderDisabled,
+  })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 px-5 py-3.5 bg-white dark:bg-gray-800"
+    >
+      {editing?.uuid === c.uuid ? (
+        <div className="flex flex-1 items-center gap-2">
+          <input
+            ref={editInputRef}
+            type="text"
+            value={editing?.name ?? ""}
+            onChange={(e) => setEditing(editing ? { ...editing, name: e.target.value } : null)}
+            maxLength={50}
+            className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+          />
+          <button
+            type="button"
+            onClick={onUpdate}
+            disabled={loading}
+            className="text-primary hover:text-primary-hover disabled:opacity-50"
+          >
+            <CheckIcon className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setEditing(null)}
+            disabled={loading}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <ResetIcon className="size-4" />
+          </button>
+        </div>
+      ) : merging?.source.uuid === c.uuid ? (
+        <div className="flex flex-1 items-center gap-2">
+          <span className="text-sm text-gray-500 dark:text-gray-400">{c.name}</span>
+          <ArrowRightIcon className="size-3.5 text-gray-400" />
+          <select
+            value={merging.targetUuid}
+            onChange={(e) => setMerging({ ...merging, targetUuid: e.target.value })}
+            className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+          >
+            {categories
+              .filter((x) => x.uuid !== c.uuid)
+              .map((x) => (
+                <option key={x.uuid} value={x.uuid}>
+                  {x.name}
+                </option>
+              ))}
+          </select>
+          <button
+            type="button"
+            onClick={onConfirmMerge}
+            disabled={loading}
+            className="text-primary hover:text-primary-hover disabled:opacity-50"
+          >
+            <CheckIcon className="size-4" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setMerging(null)}
+            disabled={loading}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <ResetIcon className="size-4" />
+          </button>
+        </div>
+      ) : (
+        <>
+          <button
+            type="button"
+            {...attributes}
+            {...listeners}
+            disabled={reorderDisabled}
+            aria-label="Reorder"
+            className="cursor-grab touch-none text-gray-300 hover:text-gray-500 disabled:opacity-30 dark:text-gray-600 dark:hover:text-gray-400"
+          >
+            <DragHandleDots2Icon className="size-4" />
+          </button>
+          <span className="flex-1 text-sm">{c.name}</span>
+          <button
+            type="button"
+            onClick={() => onStartEdit(c)}
+            disabled={loading}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <Pencil1Icon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onStartMerge(c)}
+            disabled={loading || categories.length < 2}
+            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
+          >
+            <ArrowRightIcon className="size-3.5" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirmDelete(c)}
+            disabled={loading}
+            className="text-red-400 hover:text-red-600 disabled:opacity-50"
+          >
+            <TrashIcon className="size-3.5" />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}
 
 export const CategoriesPage = () => {
   const [categories, setCategories] = useState<CategoryResponse[]>([])
@@ -26,6 +198,12 @@ export const CategoriesPage = () => {
   const [loading, setLoading] = useState(false)
   const { dialogRef, open: openDialog } = useConfirmDialog()
   const { dialogRef: mergeDialogRef, open: openMergeDialog } = useConfirmDialog()
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
 
   const fetchData = useCallback(async () => {
     try {
@@ -126,9 +304,30 @@ export const CategoriesPage = () => {
     }
   }
 
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = categories.findIndex((c) => c.uuid === active.id)
+    const newIndex = categories.findIndex((c) => c.uuid === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const reordered = arrayMove(categories, oldIndex, newIndex)
+    // optimistic UI
+    setCategories(reordered)
+    setError("")
+    try {
+      await api.reorderCategories({ uuids: reordered.map((c) => c.uuid) })
+    } catch (err) {
+      setError(getErrorMessage(err, "Reorder failed"))
+      await fetchData()
+    }
+  }
+
   const mergeTarget = merging
     ? (categories.find((c) => c.uuid === merging.targetUuid) ?? null)
     : null
+
+  const reorderDisabled = loading || editing !== null || merging !== null
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
@@ -160,106 +359,34 @@ export const CategoriesPage = () => {
 
       {/* Category list */}
       {categories.length > 0 ? (
-        <div className="divide-y divide-gray-100 overflow-hidden rounded-2xl bg-white shadow-sm dark:divide-gray-700 dark:bg-gray-800">
-          {categories.map((c) => (
-            <div key={c.uuid} className="flex items-center gap-3 px-5 py-3.5">
-              {editing?.uuid === c.uuid ? (
-                <div className="flex flex-1 items-center gap-2">
-                  <input
-                    ref={editInputRef}
-                    type="text"
-                    value={editing?.name ?? ""}
-                    onChange={(e) =>
-                      setEditing((prev) => (prev ? { ...prev, name: e.target.value } : null))
-                    }
-                    maxLength={50}
-                    className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-                  />
-                  <button
-                    type="button"
-                    onClick={handleUpdate}
-                    disabled={loading}
-                    className="text-primary hover:text-primary-hover disabled:opacity-50"
-                  >
-                    <CheckIcon className="size-4" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setEditing(null)}
-                    disabled={loading}
-                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-                  >
-                    <ResetIcon className="size-4" />
-                  </button>
-                </div>
-              ) : merging?.source.uuid === c.uuid ? (
-                <div className="flex flex-1 items-center gap-2">
-                  <span className="text-sm text-gray-500 dark:text-gray-400">{c.name}</span>
-                  <ArrowRightIcon className="size-3.5 text-gray-400" />
-                  <select
-                    value={merging.targetUuid}
-                    onChange={(e) =>
-                      setMerging((prev) => (prev ? { ...prev, targetUuid: e.target.value } : null))
-                    }
-                    className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-                  >
-                    {categories
-                      .filter((x) => x.uuid !== c.uuid)
-                      .map((x) => (
-                        <option key={x.uuid} value={x.uuid}>
-                          {x.name}
-                        </option>
-                      ))}
-                  </select>
-                  <button
-                    type="button"
-                    onClick={confirmMerge}
-                    disabled={loading}
-                    className="text-primary hover:text-primary-hover disabled:opacity-50"
-                  >
-                    <CheckIcon className="size-4" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setMerging(null)}
-                    disabled={loading}
-                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-                  >
-                    <ResetIcon className="size-4" />
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <span className="flex-1 text-sm">{c.name}</span>
-                  <button
-                    type="button"
-                    onClick={() => startEdit(c)}
-                    disabled={loading}
-                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-                  >
-                    <Pencil1Icon className="size-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => startMerge(c)}
-                    disabled={loading || categories.length < 2}
-                    className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-                  >
-                    <ArrowRightIcon className="size-3.5" />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => confirmDelete(c)}
-                    disabled={loading}
-                    className="text-red-400 hover:text-red-600 disabled:opacity-50"
-                  >
-                    <TrashIcon className="size-3.5" />
-                  </button>
-                </>
-              )}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext
+            items={categories.map((c) => c.uuid)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="divide-y divide-gray-100 overflow-hidden rounded-2xl bg-white shadow-sm dark:divide-gray-700 dark:bg-gray-800">
+              {categories.map((c) => (
+                <SortableRow
+                  key={c.uuid}
+                  category={c}
+                  loading={loading}
+                  editing={editing}
+                  setEditing={setEditing}
+                  editInputRef={editInputRef}
+                  onUpdate={handleUpdate}
+                  onStartEdit={startEdit}
+                  merging={merging}
+                  setMerging={setMerging}
+                  onConfirmMerge={confirmMerge}
+                  onStartMerge={startMerge}
+                  onConfirmDelete={confirmDelete}
+                  categories={categories}
+                  reorderDisabled={reorderDisabled}
+                />
+              ))}
             </div>
-          ))}
-        </div>
+          </SortableContext>
+        </DndContext>
       ) : (
         <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">No categories</p>
       )}

--- a/frontend/src/common/libs/api.ts
+++ b/frontend/src/common/libs/api.ts
@@ -2,6 +2,7 @@ import { client } from "./client"
 import type {
   CategoryCreate,
   CategoryMergeRequest,
+  CategoryReorderRequest,
   CategoryResponse,
   CategoryUpdate,
   ExpenseCreate,
@@ -95,6 +96,9 @@ const deleteCategory = (uuid: string): Promise<void> => client.delete<void>(`/ca
 const mergeCategory = (uuid: string, data: CategoryMergeRequest): Promise<CategoryResponse> =>
   client.post<CategoryResponse>(`/categories/${uuid}/merge`, data)
 
+const reorderCategories = (data: CategoryReorderRequest): Promise<CategoryResponse[]> =>
+  client.put<CategoryResponse[]>("/categories/order", data)
+
 // --- Expense ---
 
 const getExpense = (uuid: string): Promise<ExpenseResponse> =>
@@ -175,6 +179,7 @@ export const api = {
   updateCategory,
   deleteCategory,
   mergeCategory,
+  reorderCategories,
   getExpense,
   getExpenses,
   createExpense,

--- a/frontend/src/common/libs/client.ts
+++ b/frontend/src/common/libs/client.ts
@@ -73,6 +73,7 @@ export const getErrorMessage = (err: unknown, fallback: string): string =>
 export const client = {
   get: <T>(path: string) => request<T>("GET", path),
   post: <T>(path: string, body?: unknown) => request<T>("POST", path, body),
+  put: <T>(path: string, body?: unknown) => request<T>("PUT", path, body),
   patch: <T>(path: string, body?: unknown) => request<T>("PATCH", path, body),
   delete: <T>(path: string) => request<T>("DELETE", path),
 }

--- a/frontend/src/common/libs/types.ts
+++ b/frontend/src/common/libs/types.ts
@@ -18,6 +18,7 @@ export interface SignInVerifyResponse {
 export interface CategoryResponse {
   uuid: string
   name: string
+  position: number
 }
 
 export interface CategoryCreate {
@@ -30,6 +31,10 @@ export interface CategoryUpdate {
 
 export interface CategoryMergeRequest {
   target_uuid: string
+}
+
+export interface CategoryReorderRequest {
+  uuids: string[]
 }
 
 export interface ExpenseResponse {


### PR DESCRIPTION
## 概要

#95

カテゴリの並び順を永続化し、D&D で並び替えできるようにする。
カテゴリ統合 (#76) でカテゴリが消えた際は position の隙間を自動で詰める。

## バックエンド

### モデル

```
categories
+ position  Integer  NOT NULL  DEFAULT 0
```

### マイグレーション

`alembic/versions/c4ddc57e2edf_add_categories_position.py`
- nullable で追加 → ユーザーごとに `ROW_NUMBER() OVER (PARTITION BY user_uuid ORDER BY uuid)` で 0,1,2,... を埋める → NOT NULL 化

### リポジトリ

- `get_all_categories`: `ORDER BY position ASC, uuid ASC`
- `create_category`: 末尾position (max+1) を自動採番
- `reorder_categories(user_uuid, ordered_uuids)`: 一括並び替え。UUIDリストが完全な順列でなければ ValueError
- `compact_positions(user_uuid)`: 0,1,2,... に詰め直す
- `merge_categories`: 統合後に `compact_positions` を呼び出し

### API

- `PUT /categories/order` 追加 (body: `{uuids: [...]}`)
- 順列でない/不正UUID混入時は 400

### テスト

- 順序取得 (position 0,1,2 を逆挿入してposition順に返ることを確認)
- reorder 成功
- partial/unknown UUID で 400
- merge 後の position 詰め (3件中の中央merge → 残り2件が 0,1)

## フロントエンド

### 依存追加

- `@dnd-kit/core`
- `@dnd-kit/sortable`
- `@dnd-kit/utilities`

### CategoriesPage

- 各行にドラッグハンドル (`DragHandleDots2Icon`)
- 縦方向 Sortable リストでD&D
- Sensors:
  - `PointerSensor` (distance=5px でドラッグ開始)
  - `TouchSensor` (delay=200ms で誤タップ防止)
  - `KeyboardSensor` (アクセシビリティ)
- optimistic UI で並び替え反映、失敗時に再取得
- 編集中/統合中はD&Dを無効化

## Test plan

- [x] \`make test-backend\` Pass (60件)
- [x] \`make lint\` Pass
- [ ] D&Dでカテゴリを並び替え → リロード後も順序が保持される
- [ ] カテゴリ統合 → 隙間が詰まる
- [ ] iPhone Safari でD&Dが動作する (200ms ロングタップで開始)