### PR TITLE
chore: db/Dockerfile.dbを削除しpostgresイメージを直接利用

### DIFF
--- a/db/Dockerfile.db
+++ b/db/Dockerfile.db
@@ -1,1 +1,0 @@
-FROM postgres:18-bookworm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,7 @@ services:
           path: ./frontend/package.json
 
   db:
-    build:
-      context: ./db
-      dockerfile: Dockerfile.db
+    image: postgres:18-bookworm
     container_name: burn-style_db
     command: -p ${POSTGRES_PORT}
     env_file:


### PR DESCRIPTION
## 概要

\`db/Dockerfile.db\` の中身は \`FROM postgres:18-bookworm\` 1行のみで、build階層を作る価値が無かった。
\`docker-compose.yml\` で \`image: postgres:18-bookworm\` を直接指定する形に変更し、\`db/\` ディレクトリごと削除。

## 変更点

### 削除

- \`db/Dockerfile.db\`
- \`db/\` ディレクトリ

### docker-compose.yml

```diff
   db:
-    build:
-      context: ./db
-      dockerfile: Dockerfile.db
+    image: postgres:18-bookworm
     container_name: burn-style_db
```

## 動機

- \`db/\` 配下にDockerfile1ファイルしか無く違和感
- build工程ゼロの単純な image 利用なら docker-compose.yml で完結する方が素直

## Test plan

- [x] \`docker compose up -d --build db\` で起動成功
- [x] \`psql\` で疎通確認 (SELECT 1 returns 1)