### PR TITLE
fix: ritual表記をrecurringに統一しend_date入力欄を削除

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -22,7 +22,7 @@ const PAGE_TITLES: Record<string, string> = {
   "/expense/template": "Template",
   "/expense/template/new": "Record",
   "/expense/recurring": "Recurring",
-  "/expense/recurring/new": "New ritual",
+  "/expense/recurring/new": "New recurring",
   "/category": "Category",
   "/setting": "Setting",
 }

--- a/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
@@ -49,7 +49,6 @@ export const RecurringExpenseEditPage = () => {
   const [amount, setAmount] = useState("")
   const [frequencyKey, setFrequencyKey] = useState("monthly")
   const [startDate, setStartDate] = useState(todayJst)
-  const [endDate, setEndDate] = useState("")
   const [categoryUuid, setCategoryUuid] = useState("")
 
   const fetchData = useCallback(async () => {
@@ -62,7 +61,6 @@ export const RecurringExpenseEditPage = () => {
         setAmount(r.amount.toLocaleString())
         setFrequencyKey(matchFrequency(r.interval_unit, r.interval_count))
         setStartDate(r.start_date)
-        setEndDate(r.end_date ?? "")
         setCategoryUuid(r.category.uuid)
       } else if (cats.length > 0) {
         setCategoryUuid(cats[0].uuid)
@@ -94,7 +92,6 @@ export const RecurringExpenseEditPage = () => {
           interval_unit: freq.unit,
           interval_count: freq.count,
           start_date: startDate,
-          end_date: endDate || null,
           category_uuid: categoryUuid,
         }
         await api.updateRecurringExpense(uuid, data)
@@ -105,7 +102,6 @@ export const RecurringExpenseEditPage = () => {
           interval_unit: freq.unit,
           interval_count: freq.count,
           start_date: startDate,
-          end_date: endDate || null,
           category_uuid: categoryUuid,
         }
         await api.createRecurringExpense(data)
@@ -140,7 +136,7 @@ export const RecurringExpenseEditPage = () => {
       {/* Name + amount card */}
       <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
         <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-name">
-          Name this ritual
+          Name this recurring
         </label>
         <input
           id="recurring-name"
@@ -191,7 +187,7 @@ export const RecurringExpenseEditPage = () => {
         </div>
       </div>
 
-      {/* Dates */}
+      {/* Start date */}
       <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
         <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-start">
           Start date
@@ -202,20 +198,6 @@ export const RecurringExpenseEditPage = () => {
           value={startDate}
           onChange={(e) => setStartDate(e.target.value)}
           required
-          className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
-        />
-
-        <label
-          className="mt-4 block text-xs text-gray-500 dark:text-gray-400"
-          htmlFor="recurring-end"
-        >
-          End date (optional)
-        </label>
-        <input
-          id="recurring-end"
-          type="date"
-          value={endDate}
-          onChange={(e) => setEndDate(e.target.value)}
           className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
         />
       </div>
@@ -270,7 +252,7 @@ export const RecurringExpenseEditPage = () => {
             disabled={loading}
             className="mt-4 rounded-2xl py-3 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
           >
-            Stop this ritual
+            Stop this recurring
           </button>
         )}
       </div>

--- a/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
@@ -128,7 +128,7 @@ export const RecurringExpenseListPage = () => {
         <div className="text-xs text-gray-500 dark:text-gray-400">Every month</div>
         <div className="mt-1 text-3xl font-light tracking-tight">¥{formatAmount(totalMonthly)}</div>
         <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          {items.length} {items.length === 1 ? "ritual" : "rituals"}
+          {items.length} {items.length === 1 ? "recurring" : "recurrings"}
         </div>
       </div>
 
@@ -171,7 +171,7 @@ export const RecurringExpenseListPage = () => {
         className="flex items-center justify-center gap-2 rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover"
       >
         <PlusIcon className="size-4" />
-        Add ritual
+        Add recurring
       </Link>
 
       {/* Grouped list */}
@@ -228,7 +228,9 @@ export const RecurringExpenseListPage = () => {
       })}
 
       {items.length === 0 && (
-        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">No rituals yet</p>
+        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+          No recurrings yet
+        </p>
       )}
     </div>
   )


### PR DESCRIPTION
## 変更点

### 表記統一: ritual → recurring

- \`AppLayout.tsx\`: \"New ritual\" → \"New recurring\"
- \`RecurringExpenseListPage.tsx\`:
  - \"ritual / rituals\" → \"recurring / recurrings\"
  - \"Add ritual\" → \"Add recurring\"
  - \"No rituals yet\" → \"No recurrings yet\"
- \`RecurringExpenseEditPage.tsx\`:
  - \"Name this ritual\" → \"Name this recurring\"
  - \"Stop this ritual\" → \"Stop this recurring\"

### end_date 入力欄削除

- 入力フォームの \"End date (optional)\" を削除
- state / submit ペイロードからも \`end_date\` を除外
- モデル側の \`end_date\` カラムは将来用途のため残置 (nullable)

## Test plan

- [x] \`make lint\` Pass
- [ ] /expense/recurring/new で end date 欄が無いこと確認
- [ ] 既存recurring編集時に end_date 関連エラー無し