### PR TITLE
feat: カテゴリにsymbol(絵文字)カラムを追加

### DIFF
--- a/backend/alembic/versions/30a24e9b8516_add_categories_symbol.py
+++ b/backend/alembic/versions/30a24e9b8516_add_categories_symbol.py
@@ -1,0 +1,28 @@
+"""カテゴリにsymbolカラム (絵文字) を追加
+
+Revision ID: 30a24e9b8516
+Revises: c4ddc57e2edf
+Create Date: 2026-05-09 23:42:37.769135
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "30a24e9b8516"
+down_revision: str | Sequence[str] | None = "c4ddc57e2edf"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("categories", sa.Column("symbol", sa.String(length=8), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("categories", "symbol")

--- a/backend/src/api/categories.py
+++ b/backend/src/api/categories.py
@@ -43,7 +43,7 @@ def post_category(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[Session, Depends(get_db)],
 ) -> CategoryResponse:
-    category = create_category(db, str(user.uuid), body.name)
+    category = create_category(db, str(user.uuid), body.name, symbol=body.symbol)
     return CategoryResponse.model_validate(category)
 
 
@@ -59,8 +59,8 @@ def patch_category(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
 
     update_data = body.model_dump(exclude_unset=True)
-    if "name" in update_data:
-        category = update_category(db, category, update_data["name"])
+    if update_data:
+        category = update_category(db, category, update_data)
 
     return CategoryResponse.model_validate(category)
 

--- a/backend/src/model/category.py
+++ b/backend/src/model/category.py
@@ -13,6 +13,7 @@ class Category(Base):
     uuid = Column(String(32), primary_key=True, default=generate_uuid_string)
     user_uuid = Column(String(32), ForeignKey("users.uuid", ondelete="CASCADE"), nullable=False)
     name = Column(String, nullable=False)
+    symbol = Column(String(8), nullable=True)
     position = Column(Integer, nullable=False, default=0)
 
     user = relationship("User")

--- a/backend/src/repository/category_repository.py
+++ b/backend/src/repository/category_repository.py
@@ -23,7 +23,9 @@ def get_category_by_uuid(db: Session, uuid: str, user_uuid: str) -> Category | N
     return db.query(Category).filter(Category.uuid == uuid, Category.user_uuid == user_uuid).first()
 
 
-def create_category(db: Session, user_uuid: str, name: str) -> Category:
+def create_category(
+    db: Session, user_uuid: str, name: str, symbol: str | None = None,
+) -> Category:
     """カテゴリを新規作成 (positionは末尾)。"""
     next_position = (
         db.query(func.coalesce(func.max(Category.position), -1))
@@ -31,7 +33,12 @@ def create_category(db: Session, user_uuid: str, name: str) -> Category:
         .scalar()
         or -1
     )
-    category = Category(user_uuid=user_uuid, name=name, position=int(next_position) + 1)
+    category = Category(
+        user_uuid=user_uuid,
+        name=name,
+        symbol=symbol,
+        position=int(next_position) + 1,
+    )
     db.add(category)
     db.commit()
     db.refresh(category)
@@ -94,9 +101,12 @@ def bulk_create_categories(db: Session, user_uuid: str, names: list[str]) -> lis
     return categories
 
 
-def update_category(db: Session, category: Category, name: str) -> Category:
-    """カテゴリ名を更新。"""
-    category.name = name  # type: ignore[assignment]
+def update_category(
+    db: Session, category: Category, fields: dict[str, str | None],
+) -> Category:
+    """カテゴリの指定フィールドを更新 (name / symbol)。"""
+    for key, value in fields.items():
+        setattr(category, key, value)
     db.commit()
     db.refresh(category)
     return category

--- a/backend/src/schema/category.py
+++ b/backend/src/schema/category.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CategoryResponse(BaseModel):
@@ -8,15 +8,18 @@ class CategoryResponse(BaseModel):
 
     uuid: str
     name: str
+    symbol: str | None
     position: int
 
 
 class CategoryCreate(BaseModel):
     name: str
+    symbol: str | None = Field(default=None, max_length=8)
 
 
 class CategoryUpdate(BaseModel):
     name: str | None = None
+    symbol: str | None = Field(default=None, max_length=8)
 
 
 class CategoryMergeRequest(BaseModel):

--- a/backend/tests/api/test_categories.py
+++ b/backend/tests/api/test_categories.py
@@ -38,7 +38,19 @@ class TestPostCategory:
         assert res.status_code == 201
         data = res.json()
         assert data["name"] == "交通費"
+        assert data["symbol"] is None
         assert "uuid" in data
+
+    def test_creates_with_symbol(self, auth_client: TestClient) -> None:
+        res = auth_client.post("/categories", json={"name": "食費", "symbol": "🍎"})
+        assert res.status_code == 201
+        assert res.json()["symbol"] == "🍎"
+
+    def test_rejects_too_long_symbol(self, auth_client: TestClient) -> None:
+        res = auth_client.post(
+            "/categories", json={"name": "x", "symbol": "abcdefghi"},
+        )
+        assert res.status_code == 422
 
     def test_rejects_empty_body(self, auth_client: TestClient) -> None:
         res = auth_client.post("/categories", json={})
@@ -56,6 +68,19 @@ class TestPatchCategory:
         assert res.status_code == 200
         assert res.json()["name"] == "外食費"
         assert res.json()["uuid"] == cat.uuid
+
+    def test_updates_symbol(
+        self, auth_client: TestClient, test_user: User, db: Session,
+    ) -> None:
+        cat = Category(user_uuid=str(test_user.uuid), name="食費")
+        db.add(cat)
+        db.commit()
+        db.refresh(cat)
+
+        res = auth_client.patch(f"/categories/{cat.uuid}", json={"symbol": "🍱"})
+        assert res.status_code == 200
+        assert res.json()["symbol"] == "🍱"
+        assert res.json()["name"] == "食費"
 
     def test_returns_404_for_nonexistent(self, auth_client: TestClient) -> None:
         res = auth_client.patch("/categories/nonexistent", json={"name": "test"})

--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -29,14 +29,21 @@ import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "reac
 
 import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse } from "../../common/libs/types"
+
+interface EditingState {
+  uuid: string
+  name: string
+  symbol: string
+}
 
 interface SortableRowProps {
   category: CategoryResponse
   loading: boolean
-  editing: { uuid: string; name: string } | null
-  setEditing: (e: { uuid: string; name: string } | null) => void
+  editing: EditingState | null
+  setEditing: (e: EditingState | null) => void
   editInputRef: React.RefObject<HTMLInputElement | null>
   onUpdate: () => void
   onStartEdit: (c: CategoryResponse) => void
@@ -83,6 +90,14 @@ const SortableRow = ({
     >
       {editing?.uuid === c.uuid ? (
         <div className="flex flex-1 items-center gap-2">
+          <input
+            type="text"
+            value={editing?.symbol ?? ""}
+            onChange={(e) => setEditing(editing ? { ...editing, symbol: e.target.value } : null)}
+            maxLength={8}
+            placeholder="🍱"
+            className="w-12 rounded-lg bg-gray-50 px-2 py-1.5 text-center text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+          />
           <input
             ref={editInputRef}
             type="text"
@@ -154,6 +169,9 @@ const SortableRow = ({
           >
             <DragHandleDots2Icon className="size-4" />
           </button>
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-gray-100 text-sm dark:bg-gray-700">
+            {categoryGlyph(c)}
+          </span>
           <span className="flex-1 text-sm">{c.name}</span>
           <button
             type="button"
@@ -189,7 +207,8 @@ export const CategoriesPage = () => {
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
   const [name, setName] = useState("")
-  const [editing, setEditing] = useState<{ uuid: string; name: string } | null>(null)
+  const [symbol, setSymbol] = useState("")
+  const [editing, setEditing] = useState<EditingState | null>(null)
   const editInputRef = useRef<HTMLInputElement>(null)
   const [deleteTarget, setDeleteTarget] = useState<CategoryResponse | null>(null)
   const [merging, setMerging] = useState<{ source: CategoryResponse; targetUuid: string } | null>(
@@ -222,8 +241,9 @@ export const CategoriesPage = () => {
     setError("")
     setLoading(true)
     try {
-      await api.createCategory({ name })
+      await api.createCategory({ name, symbol: symbol || null })
       setName("")
+      setSymbol("")
       await fetchData()
     } catch (err) {
       setError(getErrorMessage(err, "Failed to create"))
@@ -254,7 +274,7 @@ export const CategoriesPage = () => {
   }
 
   const startEdit = (c: CategoryResponse) => {
-    setEditing({ uuid: c.uuid, name: c.name })
+    setEditing({ uuid: c.uuid, name: c.name, symbol: c.symbol ?? "" })
     requestAnimationFrame(() => editInputRef.current?.focus())
   }
 
@@ -263,7 +283,10 @@ export const CategoriesPage = () => {
     setError("")
     setLoading(true)
     try {
-      await api.updateCategory(editing.uuid, { name: editing.name })
+      await api.updateCategory(editing.uuid, {
+        name: editing.name,
+        symbol: editing.symbol || null,
+      })
       setEditing(null)
       await fetchData()
     } catch (err) {
@@ -338,6 +361,15 @@ export const CategoriesPage = () => {
         onSubmit={handleCreate}
         className="flex items-center gap-2 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-800"
       >
+        <input
+          id="category-symbol"
+          type="text"
+          placeholder="🍱"
+          value={symbol}
+          onChange={(e) => setSymbol(e.target.value)}
+          maxLength={8}
+          className="w-14 rounded-xl bg-gray-50 px-2 py-2.5 text-center text-sm outline-none placeholder:text-gray-300 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+        />
         <input
           id="category-name"
           type="text"

--- a/frontend/src/common/libs/category.ts
+++ b/frontend/src/common/libs/category.ts
@@ -1,0 +1,10 @@
+import type { CategoryResponse } from "./types"
+
+/** カテゴリのグリフ表示 (symbolがあればsymbol、無ければname頭文字を大文字)。 */
+export const categoryGlyph = (c: Pick<CategoryResponse, "name" | "symbol">): string => {
+  if (c.symbol && c.symbol.trim().length > 0) {
+    return c.symbol
+  }
+  const first = [...c.name][0] ?? ""
+  return first.toUpperCase()
+}

--- a/frontend/src/common/libs/types.ts
+++ b/frontend/src/common/libs/types.ts
@@ -18,15 +18,18 @@ export interface SignInVerifyResponse {
 export interface CategoryResponse {
   uuid: string
   name: string
+  symbol: string | null
   position: number
 }
 
 export interface CategoryCreate {
   name: string
+  symbol?: string | null
 }
 
 export interface CategoryUpdate {
   name?: string
+  symbol?: string | null
 }
 
 export interface CategoryMergeRequest {

--- a/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router"
 
 import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type {
   CategoryResponse,
@@ -217,6 +218,7 @@ export const RecurringExpenseEditPage = () => {
                   : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
               }`}
             >
+              <span className="mr-1">{categoryGlyph(c)}</span>
               {c.name}
             </button>
           ))}

--- a/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { Link, useNavigate } from "react-router"
 
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type {
   IntervalUnit,
@@ -203,6 +204,7 @@ export const RecurringExpenseListPage = () => {
                     <div className="flex flex-1 flex-col">
                       <div className="text-sm font-medium">{r.name}</div>
                       <div className="mt-0.5 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+                        <span>{categoryGlyph(r.category)}</span>
                         <span>{r.category.name}</span>
                         {next && (
                           <>

--- a/frontend/src/expense-template/pages/ExpenseTemplatePage.tsx
+++ b/frontend/src/expense-template/pages/ExpenseTemplatePage.tsx
@@ -11,6 +11,7 @@ import { Link } from "react-router"
 
 import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse, ExpenseTemplateResponse } from "../../common/libs/types"
 
@@ -167,7 +168,7 @@ export const ExpenseTemplatePage = () => {
                 </option>
                 {categories.map((c) => (
                   <option key={c.uuid} value={c.uuid}>
-                    {c.name}
+                    {categoryGlyph(c)} {c.name}
                   </option>
                 ))}
               </select>
@@ -249,7 +250,7 @@ export const ExpenseTemplatePage = () => {
                       >
                         {categories.map((c) => (
                           <option key={c.uuid} value={c.uuid}>
-                            {c.name}
+                            {categoryGlyph(c)} {c.name}
                           </option>
                         ))}
                       </select>
@@ -277,8 +278,9 @@ export const ExpenseTemplatePage = () => {
                 <>
                   <div className="flex min-w-0 flex-1 flex-col">
                     <span className="truncate text-sm">{t.name}</span>
-                    <span className="truncate text-xs text-gray-400 dark:text-gray-500">
-                      {t.category.name}
+                    <span className="flex items-center gap-1 truncate text-xs text-gray-400 dark:text-gray-500">
+                      <span>{categoryGlyph(t.category)}</span>
+                      <span>{t.category.name}</span>
                     </span>
                   </div>
                   <span className="min-w-0 shrink-0 truncate text-sm tabular-nums">

--- a/frontend/src/expense-template/pages/ExpenseTemplateRecordPage.tsx
+++ b/frontend/src/expense-template/pages/ExpenseTemplateRecordPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 import { useNavigate } from "react-router"
 
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { ExpenseTemplateResponse } from "../../common/libs/types"
 
@@ -122,8 +123,9 @@ export const ExpenseTemplateRecordPage = () => {
               <div className="flex items-center gap-3">
                 <div className="flex flex-1 flex-col">
                   <span className="text-sm">{r.template.name}</span>
-                  <span className="text-xs text-gray-400 dark:text-gray-500">
-                    {r.template.category.name}
+                  <span className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                    <span>{categoryGlyph(r.template.category)}</span>
+                    <span>{r.template.category.name}</span>
                   </span>
                 </div>
                 {r.selected ? (

--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -2,6 +2,7 @@ import { ArrowDownIcon, ArrowUpIcon } from "@radix-ui/react-icons"
 import { useMemo, useState } from "react"
 import { useNavigate } from "react-router"
 
+import { categoryGlyph } from "../../common/libs/category"
 import type { ExpenseResponse } from "../../common/libs/types"
 
 type SortKey = "date" | "amount"
@@ -79,8 +80,12 @@ export const ExpenseList = ({ expenses }: ExpenseListProps) => {
               {e.categories.length > 0 && (
                 <div className="flex gap-2">
                   {e.categories.map((c) => (
-                    <span key={c.uuid} className="text-xs text-gray-400 dark:text-gray-500">
-                      {c.name}
+                    <span
+                      key={c.uuid}
+                      className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500"
+                    >
+                      <span>{categoryGlyph(c)}</span>
+                      <span>{c.name}</span>
                     </span>
                   ))}
                 </div>

--- a/frontend/src/expense/components/PieWithStep.tsx
+++ b/frontend/src/expense/components/PieWithStep.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react"
 import type { PieSectorShapeProps } from "recharts"
 import { Pie, PieChart, Sector } from "recharts"
 
+import { categoryGlyph } from "../../common/libs/category"
 import type { ExpenseResponse } from "../../common/libs/types"
 
 const PIE_FILL = "var(--chart-bar)"
@@ -11,50 +12,49 @@ const MAX_OUTER = 100
 interface CategoryTotal {
   name: string
   amount: number
+  symbol: string | null
 }
 
 interface PieWithStepProps {
   expenses: ExpenseResponse[]
 }
 
+const aggregate = (
+  expenses: ExpenseResponse[],
+  excludeNames: ReadonlySet<string> = new Set(),
+): CategoryTotal[] => {
+  const totals = new Map<string, number>()
+  const symbols = new Map<string, string | null>()
+  for (const e of expenses) {
+    if (e.categories.length === 0) {
+      const key = "Uncategorized"
+      if (excludeNames.has(key)) continue
+      totals.set(key, (totals.get(key) ?? 0) + e.amount)
+      if (!symbols.has(key)) symbols.set(key, null)
+    } else {
+      for (const c of e.categories) {
+        if (excludeNames.has(c.name)) continue
+        totals.set(c.name, (totals.get(c.name) ?? 0) + e.amount)
+        if (!symbols.has(c.name)) symbols.set(c.name, c.symbol ?? null)
+      }
+    }
+  }
+  return [...totals.entries()]
+    .map(
+      ([name, amount]): CategoryTotal => ({
+        name,
+        amount,
+        symbol: symbols.get(name) ?? null,
+      }),
+    )
+    .toSorted((a, b) => b.amount - a.amount)
+}
+
 export const PieWithStep = ({ expenses }: PieWithStepProps) => {
   const [hidden, setHidden] = useState<Set<string>>(new Set())
 
-  const allCategories = useMemo(() => {
-    const map = new Map<string, number>()
-    for (const e of expenses) {
-      if (e.categories.length === 0) {
-        map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
-      } else {
-        for (const c of e.categories) {
-          map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
-        }
-      }
-    }
-    return [...map.entries()]
-      .map(([name, amount]) => ({ name, amount }))
-      .toSorted((a, b) => b.amount - a.amount)
-  }, [expenses])
-
-  const visibleData = useMemo(() => {
-    const map = new Map<string, number>()
-    for (const e of expenses) {
-      if (e.categories.length === 0) {
-        if (!hidden.has("Uncategorized")) {
-          map.set("Uncategorized", (map.get("Uncategorized") ?? 0) + e.amount)
-        }
-      } else {
-        for (const c of e.categories) {
-          if (!hidden.has(c.name)) {
-            map.set(c.name, (map.get(c.name) ?? 0) + e.amount)
-          }
-        }
-      }
-    }
-    return [...map.entries()]
-      .map(([name, amount]): CategoryTotal => ({ name, amount }))
-      .toSorted((a, b) => b.amount - a.amount)
-  }, [expenses, hidden])
+  const allCategories = useMemo(() => aggregate(expenses), [expenses])
+  const visibleData = useMemo(() => aggregate(expenses, hidden), [expenses, hidden])
 
   const total = visibleData.reduce((sum, c) => sum + c.amount, 0)
   const maxAmount = visibleData.length > 0 ? visibleData[0].amount : 0
@@ -120,6 +120,7 @@ export const PieWithStep = ({ expenses }: PieWithStepProps) => {
                 <span className="w-5 text-right text-xs text-gray-400 dark:text-gray-500">
                   {i + 1}
                 </span>
+                <span className="w-6 text-center text-sm">{categoryGlyph(cat)}</span>
                 <span className="flex-1 text-left text-sm">{cat.name}</span>
                 {matched && !isHidden && (
                   <div className="flex items-center gap-3">

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from "react-router"
 
 import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
 
@@ -175,6 +176,7 @@ export const ExpenseDetailPage = () => {
                       : "bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
                   }`}
                 >
+                  <span className="mr-1">{categoryGlyph(c)}</span>
                   {c.name}
                 </button>
               ))}

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -2,6 +2,7 @@ import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "reac
 import { useNavigate } from "react-router"
 
 import { api } from "../../common/libs/api"
+import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse } from "../../common/libs/types"
 
@@ -139,6 +140,7 @@ export const ExpensesPage = () => {
                       : "bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
                   }`}
                 >
+                  <span className="mr-1">{categoryGlyph(c)}</span>
                   {c.name}
                 </button>
               ))}


### PR DESCRIPTION
## 概要

#99

カテゴリに symbol (絵文字) カラムを追加。
未設定時は **カテゴリ名の頭文字を大文字化したもの** をUIで代替表示する。

## バックエンド

### モデル

```
categories
+ symbol  String(8)  nullable
```

- 既存データは null のまま (backfill 不要)
- 4バイト絵文字 + ZWJ で複数 code point になっても収まる長さ8

### スキーマ

- \`CategoryCreate\` / \`Update\` / \`Response\` に \`symbol: str | None\` (max_length=8)

### Repository

- \`create_category(... , symbol=None)\` シグネチャ拡張
- \`update_category(category, fields: dict)\` に変更し name/symbol 共通処理化

### テスト追加

- creates_with_symbol
- rejects_too_long_symbol (9文字で422)
- updates_symbol

## フロントエンド

### \`common/libs/category.ts\`

\`\`\`ts
categoryGlyph(c) → c.symbol || c.name[0].toUpperCase()
\`\`\`

### CategoriesPage

- 作成フォーム: symbol入力欄 (w-14 固定幅、絵文字placeholder)
- 編集モード: symbol入力欄を name の左に追加
- 各行: 丸いバッジでグリフ表示 (symbolあれば絵文字、無ければ頭文字)

## 残課題 (本PR外)

カテゴリ表示は Expense 系画面、定期支払、ExpenseTemplate にも存在。
本PRでは CategoriesPage のみに導入。残りは別PRで段階的に展開予定。

## Test plan

- [x] \`make test-backend\` Pass (63件)
- [x] \`make lint\` Pass
- [ ] CategoriesPage で symbol 入力 → 一覧で絵文字表示
- [ ] symbol 未入力で作成 → 名前頭文字バッジ表示
- [ ] iOS Safari で絵文字キーボードから入力可能