### PR TITLE
feat: Category画面をclaude design (CategoryManager + CategoryEdit) と一致

### DIFF
--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -1,232 +1,26 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core"
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
-import {
-  ArrowRightIcon,
-  CheckIcon,
-  DragHandleDots2Icon,
-  Pencil1Icon,
-  PlusIcon,
-  ResetIcon,
-  TrashIcon,
-} from "@radix-ui/react-icons"
-import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "react"
+import { Cross2Icon, PlusIcon } from "@radix-ui/react-icons"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router"
 
-import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
 import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
-import type { CategoryResponse } from "../../common/libs/types"
-
-interface EditingState {
-  uuid: string
-  name: string
-  symbol: string
-}
-
-interface SortableRowProps {
-  category: CategoryResponse
-  loading: boolean
-  editing: EditingState | null
-  setEditing: (e: EditingState | null) => void
-  editInputRef: React.RefObject<HTMLInputElement | null>
-  onUpdate: () => void
-  onStartEdit: (c: CategoryResponse) => void
-  merging: { source: CategoryResponse; targetUuid: string } | null
-  setMerging: (m: { source: CategoryResponse; targetUuid: string } | null) => void
-  onConfirmMerge: () => void
-  onStartMerge: (c: CategoryResponse) => void
-  onConfirmDelete: (c: CategoryResponse) => void
-  categories: CategoryResponse[]
-  reorderDisabled: boolean
-}
-
-const SortableRow = ({
-  category: c,
-  loading,
-  editing,
-  setEditing,
-  editInputRef,
-  onUpdate,
-  onStartEdit,
-  merging,
-  setMerging,
-  onConfirmMerge,
-  onStartMerge,
-  onConfirmDelete,
-  categories,
-  reorderDisabled,
-}: SortableRowProps) => {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: c.uuid,
-    disabled: reorderDisabled,
-  })
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  }
-
-  return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-3 px-5 py-3.5 bg-white dark:bg-gray-800"
-    >
-      {editing?.uuid === c.uuid ? (
-        <div className="flex flex-1 items-center gap-2">
-          <input
-            type="text"
-            value={editing?.symbol ?? ""}
-            onChange={(e) => setEditing(editing ? { ...editing, symbol: e.target.value } : null)}
-            maxLength={8}
-            placeholder="🍱"
-            className="w-12 rounded-lg bg-gray-50 px-2 py-1.5 text-center text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
-          <input
-            ref={editInputRef}
-            type="text"
-            value={editing?.name ?? ""}
-            onChange={(e) => setEditing(editing ? { ...editing, name: e.target.value } : null)}
-            maxLength={50}
-            className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
-          <button
-            type="button"
-            onClick={onUpdate}
-            disabled={loading}
-            className="text-primary hover:text-primary-hover disabled:opacity-50"
-          >
-            <CheckIcon className="size-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setEditing(null)}
-            disabled={loading}
-            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <ResetIcon className="size-4" />
-          </button>
-        </div>
-      ) : merging?.source.uuid === c.uuid ? (
-        <div className="flex flex-1 items-center gap-2">
-          <span className="text-sm text-gray-500 dark:text-gray-400">{c.name}</span>
-          <ArrowRightIcon className="size-3.5 text-gray-400" />
-          <select
-            value={merging.targetUuid}
-            onChange={(e) => setMerging({ ...merging, targetUuid: e.target.value })}
-            className="flex-1 rounded-lg bg-gray-50 px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          >
-            {categories
-              .filter((x) => x.uuid !== c.uuid)
-              .map((x) => (
-                <option key={x.uuid} value={x.uuid}>
-                  {x.name}
-                </option>
-              ))}
-          </select>
-          <button
-            type="button"
-            onClick={onConfirmMerge}
-            disabled={loading}
-            className="text-primary hover:text-primary-hover disabled:opacity-50"
-          >
-            <CheckIcon className="size-4" />
-          </button>
-          <button
-            type="button"
-            onClick={() => setMerging(null)}
-            disabled={loading}
-            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <ResetIcon className="size-4" />
-          </button>
-        </div>
-      ) : (
-        <>
-          <button
-            type="button"
-            {...attributes}
-            {...listeners}
-            disabled={reorderDisabled}
-            aria-label="Reorder"
-            className="cursor-grab touch-none text-gray-300 hover:text-gray-500 disabled:opacity-30 dark:text-gray-600 dark:hover:text-gray-400"
-          >
-            <DragHandleDots2Icon className="size-4" />
-          </button>
-          <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-gray-100 text-sm dark:bg-gray-700">
-            {categoryGlyph(c)}
-          </span>
-          <span className="flex-1 text-sm">{c.name}</span>
-          <button
-            type="button"
-            onClick={() => onStartEdit(c)}
-            disabled={loading}
-            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <Pencil1Icon className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => onStartMerge(c)}
-            disabled={loading || categories.length < 2}
-            className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            <ArrowRightIcon className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={() => onConfirmDelete(c)}
-            disabled={loading}
-            className="text-red-400 hover:text-red-600 disabled:opacity-50"
-          >
-            <TrashIcon className="size-3.5" />
-          </button>
-        </>
-      )}
-    </div>
-  )
-}
+import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
 
 export const CategoriesPage = () => {
+  const navigate = useNavigate()
   const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
   const [error, setError] = useState("")
-  const [name, setName] = useState("")
-  const [symbol, setSymbol] = useState("")
-  const [editing, setEditing] = useState<EditingState | null>(null)
-  const editInputRef = useRef<HTMLInputElement>(null)
-  const [deleteTarget, setDeleteTarget] = useState<CategoryResponse | null>(null)
-  const [merging, setMerging] = useState<{ source: CategoryResponse; targetUuid: string } | null>(
-    null,
-  )
   const [loading, setLoading] = useState(false)
-  const { dialogRef, open: openDialog } = useConfirmDialog()
-  const { dialogRef: mergeDialogRef, open: openMergeDialog } = useConfirmDialog()
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
+  const [confirmDel, setConfirmDel] = useState<string | null>(null)
+  const [mergingFrom, setMergingFrom] = useState<string | null>(null)
 
   const fetchData = useCallback(async () => {
     try {
-      setCategories(await api.getCategories())
+      const [cats, exps] = await Promise.all([api.getCategories(), api.getExpenses()])
+      setCategories(cats)
+      setExpenses(exps)
     } catch (err) {
       setError(getErrorMessage(err, "Failed to fetch data"))
     }
@@ -236,106 +30,22 @@ export const CategoriesPage = () => {
     fetchData()
   }, [fetchData])
 
-  const handleCreate = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    setError("")
-    setLoading(true)
-    try {
-      await api.createCategory({ name, symbol: symbol || null })
-      setName("")
-      setSymbol("")
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to create"))
-    } finally {
-      setLoading(false)
+  const usage = useMemo(() => {
+    const map: Record<string, number> = {}
+    for (const e of expenses) {
+      for (const c of e.categories) {
+        map[c.uuid] = (map[c.uuid] ?? 0) + 1
+      }
     }
-  }
+    return map
+  }, [expenses])
 
-  const confirmDelete = (c: CategoryResponse) => {
-    setDeleteTarget(c)
-    openDialog()
-  }
-
-  const handleDelete = async () => {
-    if (!deleteTarget) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.deleteCategory(deleteTarget.uuid)
-      setDeleteTarget(null)
-      dialogRef.current?.close()
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Delete failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const startEdit = (c: CategoryResponse) => {
-    setEditing({ uuid: c.uuid, name: c.name, symbol: c.symbol ?? "" })
-    requestAnimationFrame(() => editInputRef.current?.focus())
-  }
-
-  const handleUpdate = async () => {
-    if (!editing) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.updateCategory(editing.uuid, {
-        name: editing.name,
-        symbol: editing.symbol || null,
-      })
-      setEditing(null)
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to update"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const startMerge = (c: CategoryResponse) => {
-    const others = categories.filter((x) => x.uuid !== c.uuid)
-    if (others.length === 0) {
-      setError("Need at least one other category to merge into")
-      return
-    }
-    setError("")
-    setMerging({ source: c, targetUuid: others[0].uuid })
-  }
-
-  const confirmMerge = () => {
-    if (!merging) return
-    openMergeDialog()
-  }
-
-  const handleMerge = async () => {
-    if (!merging) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.mergeCategory(merging.source.uuid, { target_uuid: merging.targetUuid })
-      mergeDialogRef.current?.close()
-      setMerging(null)
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Merge failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = categories.findIndex((c) => c.uuid === active.id)
-    const newIndex = categories.findIndex((c) => c.uuid === over.id)
-    if (oldIndex === -1 || newIndex === -1) return
-
-    const reordered = arrayMove(categories, oldIndex, newIndex)
-    // optimistic UI
+  const move = async (index: number, dir: -1 | 1) => {
+    const next = index + dir
+    if (next < 0 || next >= categories.length) return
+    const reordered = [...categories]
+    const [moved] = reordered.splice(index, 1)
+    reordered.splice(next, 0, moved)
     setCategories(reordered)
     setError("")
     try {
@@ -346,97 +56,216 @@ export const CategoriesPage = () => {
     }
   }
 
-  const mergeTarget = merging
-    ? (categories.find((c) => c.uuid === merging.targetUuid) ?? null)
+  const handleDelete = async () => {
+    if (!confirmDel) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.deleteCategory(confirmDel)
+      setConfirmDel(null)
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleMerge = async (targetUuid: string) => {
+    if (!mergingFrom) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.mergeCategory(mergingFrom, { target_uuid: targetUuid })
+      setMergingFrom(null)
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Merge failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const mergingCategory = mergingFrom
+    ? (categories.find((c) => c.uuid === mergingFrom) ?? null)
+    : null
+  const confirmCategory = confirmDel
+    ? (categories.find((c) => c.uuid === confirmDel) ?? null)
     : null
 
-  const reorderDisabled = loading || editing !== null || merging !== null
-
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
-      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
-
-      {/* Create form */}
-      <form
-        onSubmit={handleCreate}
-        className="flex items-center gap-2 rounded-2xl bg-white p-4 shadow-sm dark:bg-gray-800"
-      >
-        <input
-          id="category-symbol"
-          type="text"
-          placeholder="🍱"
-          value={symbol}
-          onChange={(e) => setSymbol(e.target.value)}
-          maxLength={8}
-          className="w-14 rounded-xl bg-gray-50 px-2 py-2.5 text-center text-sm outline-none placeholder:text-gray-300 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-        />
-        <input
-          id="category-name"
-          type="text"
-          placeholder="Food, Transport"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          maxLength={50}
-          className="flex-1 rounded-xl bg-gray-50 px-4 py-2.5 text-sm outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-        />
+    <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between px-4 pt-3 pb-2">
+        <div className="w-10" />
+        <h1 className="text-base font-semibold">Categories</h1>
         <button
-          type="submit"
-          disabled={loading}
-          className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-primary text-white hover:bg-primary-hover disabled:opacity-50"
+          type="button"
+          aria-label="New category"
+          onClick={() => navigate("/category/new")}
+          className="flex w-10 items-center justify-end text-2xl leading-none text-primary"
         >
-          <PlusIcon className="size-4" />
+          +
         </button>
-      </form>
+      </div>
+      <p className="shrink-0 px-5 pb-3 text-xs text-gray-500 dark:text-gray-400">
+        {categories.length} categories · tap to edit
+      </p>
 
-      {/* Category list */}
-      {categories.length > 0 ? (
-        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext
-            items={categories.map((c) => c.uuid)}
-            strategy={verticalListSortingStrategy}
-          >
-            <div className="divide-y divide-gray-100 overflow-hidden rounded-2xl bg-white shadow-sm dark:divide-gray-700 dark:bg-gray-800">
-              {categories.map((c) => (
-                <SortableRow
-                  key={c.uuid}
-                  category={c}
-                  loading={loading}
-                  editing={editing}
-                  setEditing={setEditing}
-                  editInputRef={editInputRef}
-                  onUpdate={handleUpdate}
-                  onStartEdit={startEdit}
-                  merging={merging}
-                  setMerging={setMerging}
-                  onConfirmMerge={confirmMerge}
-                  onStartMerge={startMerge}
-                  onConfirmDelete={confirmDelete}
-                  categories={categories}
-                  reorderDisabled={reorderDisabled}
-                />
-              ))}
-            </div>
-          </SortableContext>
-        </DndContext>
-      ) : (
-        <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">No categories</p>
+      {error && (
+        <p className="mx-5 shrink-0 pb-2 text-sm text-red-600 dark:text-red-400">{error}</p>
       )}
 
-      <ConfirmDialog
-        message={`Delete "${deleteTarget?.name}"?`}
-        onConfirm={handleDelete}
-        loading={loading}
-        dialogRef={dialogRef}
-      />
+      <div className="flex-1 overflow-y-auto px-4 pb-6">
+        {categories.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+            No categories yet
+          </p>
+        ) : (
+          <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+            {categories.map((c, i) => {
+              const used = usage[c.uuid] ?? 0
+              return (
+                <li key={c.uuid} className="flex items-center gap-3 px-3.5 py-3">
+                  <div className="flex flex-col gap-0.5">
+                    <button
+                      type="button"
+                      onClick={() => move(i, -1)}
+                      disabled={i === 0}
+                      aria-label="Move up"
+                      className="text-[11px] leading-none text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
+                    >
+                      ▲
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => move(i, 1)}
+                      disabled={i === categories.length - 1}
+                      aria-label="Move down"
+                      className="text-[11px] leading-none text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
+                    >
+                      ▼
+                    </button>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/category/${c.uuid}`)}
+                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
+                  >
+                    <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base font-bold dark:bg-gray-700">
+                      {categoryGlyph(c)}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold">{c.name}</div>
+                      <div className="text-[11px] text-gray-500 dark:text-gray-400">
+                        {used} {used === 1 ? "expense" : "expenses"}
+                      </div>
+                    </div>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setMergingFrom(c.uuid)}
+                    disabled={categories.length < 2}
+                    aria-label="Merge into another"
+                    className="p-1 text-base text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
+                  >
+                    ⇄
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDel(c.uuid)}
+                    aria-label="Delete"
+                    className="p-1 text-gray-400 dark:text-gray-500"
+                  >
+                    <Cross2Icon className="size-4" />
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
 
-      <ConfirmDialog
-        message={`Merge "${merging?.source.name}" into "${mergeTarget?.name}"? "${merging?.source.name}" will be deleted.`}
-        onConfirm={handleMerge}
-        confirmText="Merge"
-        loading={loading}
-        dialogRef={mergeDialogRef}
-      />
+        <button
+          type="button"
+          onClick={() => navigate("/category/new")}
+          className="mt-3 flex w-full items-center justify-center gap-1 rounded-2xl border border-dashed border-gray-300 bg-white py-3.5 text-sm font-semibold text-primary dark:border-gray-700 dark:bg-gray-800"
+        >
+          <PlusIcon className="size-4" />
+          New category
+        </button>
+      </div>
+
+      {mergingCategory && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
+          <div className="flex max-h-[70%] w-full max-w-sm flex-col rounded-2xl bg-white p-5 dark:bg-gray-800">
+            <div className="text-base font-bold">
+              Merge &quot;{mergingCategory.name}&quot; into…
+            </div>
+            <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+              {(usage[mergingCategory.uuid] ?? 0) > 0
+                ? `${usage[mergingCategory.uuid]} ${usage[mergingCategory.uuid] === 1 ? "expense" : "expenses"} will be re-tagged. "${mergingCategory.name}" will then be removed.`
+                : `"${mergingCategory.name}" will be removed.`}
+            </div>
+            <div className="mt-3 flex-1 overflow-y-auto -mx-2">
+              {categories
+                .filter((c) => c.uuid !== mergingFrom)
+                .map((tc) => (
+                  <button
+                    key={tc.uuid}
+                    type="button"
+                    disabled={loading}
+                    onClick={() => handleMerge(tc.uuid)}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left hover:bg-gray-50 disabled:opacity-50 dark:hover:bg-gray-700"
+                  >
+                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-sm dark:bg-gray-700">
+                      {categoryGlyph(tc)}
+                    </span>
+                    <span className="flex-1 text-sm font-semibold">{tc.name}</span>
+                    <span className="text-[11px] text-gray-400 dark:text-gray-500">
+                      {usage[tc.uuid] ?? 0}
+                    </span>
+                  </button>
+                ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => setMergingFrom(null)}
+              className="mt-3 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {confirmCategory && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
+          <div className="w-full max-w-xs rounded-2xl bg-white p-5 dark:bg-gray-800">
+            <div className="text-base font-bold">Delete &quot;{confirmCategory.name}&quot;?</div>
+            <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+              {(usage[confirmCategory.uuid] ?? 0) > 0
+                ? `${usage[confirmCategory.uuid]} ${usage[confirmCategory.uuid] === 1 ? "expense is" : "expenses are"} tagged with this — they'll become uncategorized.`
+                : "No expenses use this category yet."}
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmDel(null)}
+                className="flex-1 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={loading}
+                className="flex-1 rounded-lg bg-red-600 px-3 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -1,4 +1,22 @@
-import { Cross2Icon, PlusIcon } from "@radix-ui/react-icons"
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { DragHandleDots2Icon, PlusIcon, TrashIcon } from "@radix-ui/react-icons"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router"
 
@@ -6,6 +24,82 @@ import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+
+interface SortableRowProps {
+  category: CategoryResponse
+  used: number
+  onEdit: () => void
+  onMerge: () => void
+  onDelete: () => void
+  mergeDisabled: boolean
+}
+
+const SortableRow = ({
+  category: c,
+  used,
+  onEdit,
+  onMerge,
+  onDelete,
+  mergeDisabled,
+}: SortableRowProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: c.uuid,
+  })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 bg-white px-3.5 py-3 dark:bg-gray-800"
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label="Reorder"
+        className="cursor-grab touch-none p-1 text-gray-400 dark:text-gray-500"
+      >
+        <DragHandleDots2Icon className="size-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base font-bold dark:bg-gray-700">
+          {categoryGlyph(c)}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold">{c.name}</div>
+          <div className="text-[11px] text-gray-500 dark:text-gray-400">
+            {used} {used === 1 ? "expense" : "expenses"}
+          </div>
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={onMerge}
+        disabled={mergeDisabled}
+        aria-label="Merge into another"
+        className="p-1 text-base text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
+      >
+        ⇄
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label="Delete"
+        className="p-1 text-red-400 hover:text-red-600"
+      >
+        <TrashIcon className="size-4" />
+      </button>
+    </li>
+  )
+}
 
 export const CategoriesPage = () => {
   const navigate = useNavigate()
@@ -15,6 +109,12 @@ export const CategoriesPage = () => {
   const [loading, setLoading] = useState(false)
   const [confirmDel, setConfirmDel] = useState<string | null>(null)
   const [mergingFrom, setMergingFrom] = useState<string | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
 
   const fetchData = useCallback(async () => {
     try {
@@ -40,12 +140,13 @@ export const CategoriesPage = () => {
     return map
   }, [expenses])
 
-  const move = async (index: number, dir: -1 | 1) => {
-    const next = index + dir
-    if (next < 0 || next >= categories.length) return
-    const reordered = [...categories]
-    const [moved] = reordered.splice(index, 1)
-    reordered.splice(next, 0, moved)
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = categories.findIndex((c) => c.uuid === active.id)
+    const newIndex = categories.findIndex((c) => c.uuid === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    const reordered = arrayMove(categories, oldIndex, newIndex)
     setCategories(reordered)
     setError("")
     try {
@@ -108,7 +209,7 @@ export const CategoriesPage = () => {
         </button>
       </div>
       <p className="shrink-0 px-5 pb-3 text-xs text-gray-500 dark:text-gray-400">
-        {categories.length} categories · tap to edit
+        {categories.length} categories · drag to reorder, tap to edit
       </p>
 
       {error && (
@@ -121,67 +222,30 @@ export const CategoriesPage = () => {
             No categories yet
           </p>
         ) : (
-          <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
-            {categories.map((c, i) => {
-              const used = usage[c.uuid] ?? 0
-              return (
-                <li key={c.uuid} className="flex items-center gap-3 px-3.5 py-3">
-                  <div className="flex flex-col gap-0.5">
-                    <button
-                      type="button"
-                      onClick={() => move(i, -1)}
-                      disabled={i === 0}
-                      aria-label="Move up"
-                      className="text-[11px] leading-none text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
-                    >
-                      ▲
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => move(i, 1)}
-                      disabled={i === categories.length - 1}
-                      aria-label="Move down"
-                      className="text-[11px] leading-none text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
-                    >
-                      ▼
-                    </button>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/category/${c.uuid}`)}
-                    className="flex min-w-0 flex-1 items-center gap-3 text-left"
-                  >
-                    <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base font-bold dark:bg-gray-700">
-                      {categoryGlyph(c)}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-semibold">{c.name}</div>
-                      <div className="text-[11px] text-gray-500 dark:text-gray-400">
-                        {used} {used === 1 ? "expense" : "expenses"}
-                      </div>
-                    </div>
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setMergingFrom(c.uuid)}
-                    disabled={categories.length < 2}
-                    aria-label="Merge into another"
-                    className="p-1 text-base text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
-                  >
-                    ⇄
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setConfirmDel(c.uuid)}
-                    aria-label="Delete"
-                    className="p-1 text-gray-400 dark:text-gray-500"
-                  >
-                    <Cross2Icon className="size-4" />
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={categories.map((c) => c.uuid)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+                {categories.map((c) => (
+                  <SortableRow
+                    key={c.uuid}
+                    category={c}
+                    used={usage[c.uuid] ?? 0}
+                    onEdit={() => navigate(`/category/${c.uuid}`)}
+                    onMerge={() => setMergingFrom(c.uuid)}
+                    onDelete={() => setConfirmDel(c.uuid)}
+                    mergeDisabled={categories.length < 2}
+                  />
+                ))}
+              </ul>
+            </SortableContext>
+          </DndContext>
         )}
 
         <button
@@ -205,7 +269,7 @@ export const CategoriesPage = () => {
                 ? `${usage[mergingCategory.uuid]} ${usage[mergingCategory.uuid] === 1 ? "expense" : "expenses"} will be re-tagged. "${mergingCategory.name}" will then be removed.`
                 : `"${mergingCategory.name}" will be removed.`}
             </div>
-            <div className="mt-3 flex-1 overflow-y-auto -mx-2">
+            <div className="-mx-2 mt-3 flex-1 overflow-y-auto">
               {categories
                 .filter((c) => c.uuid !== mergingFrom)
                 .map((tc) => (

--- a/frontend/src/category/pages/CategoryEditPage.tsx
+++ b/frontend/src/category/pages/CategoryEditPage.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+
+const CAT_GLYPHS = [
+  "🍴",
+  "🚇",
+  "🏠",
+  "🎬",
+  "🛍️",
+  "💼",
+  "💊",
+  "✨",
+  "☕",
+  "🍷",
+  "🛒",
+  "✈️",
+  "📚",
+  "🎵",
+  "🎮",
+  "🐾",
+  "💡",
+  "💳",
+]
+
+export const CategoryEditPage = () => {
+  const navigate = useNavigate()
+  const { uuid } = useParams<{ uuid: string }>()
+  const isNew = !uuid
+
+  const [name, setName] = useState("")
+  const [glyph, setGlyph] = useState(CAT_GLYPHS[0])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const fetchExisting = useCallback(async () => {
+    if (!uuid) return
+    try {
+      const cats = await api.getCategories()
+      const c = cats.find((x) => x.uuid === uuid)
+      if (c) {
+        setName(c.name)
+        setGlyph(c.symbol ?? CAT_GLYPHS[0])
+      }
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to load"))
+    }
+  }, [uuid])
+
+  useEffect(() => {
+    fetchExisting()
+  }, [fetchExisting])
+
+  const trimmed = name.trim()
+  const canSave = trimmed.length > 0 && glyph.length > 0
+
+  const save = async () => {
+    if (!canSave) return
+    setError("")
+    setLoading(true)
+    try {
+      if (isNew) {
+        await api.createCategory({ name: trimmed, symbol: glyph })
+      } else if (uuid) {
+        await api.updateCategory(uuid, { name: trimmed, symbol: glyph })
+      }
+      navigate("/category")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const onGlyphInput = (v: string) => {
+    const arr = [...v]
+    setGlyph(arr.length > 0 ? arr[arr.length - 1] : "")
+  }
+
+  return (
+    <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between px-4 pt-3 pb-2">
+        <button
+          type="button"
+          onClick={() => navigate("/category")}
+          className="text-sm font-medium text-primary"
+        >
+          Cancel
+        </button>
+        <h1 className="text-base font-semibold">{isNew ? "New category" : "Edit category"}</h1>
+        <button
+          type="button"
+          onClick={save}
+          disabled={!canSave || loading}
+          className="text-sm font-bold text-primary disabled:text-gray-300 dark:disabled:text-gray-600"
+        >
+          Save
+        </button>
+      </div>
+
+      {error && (
+        <p className="shrink-0 px-5 pb-2 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      <div className="flex-1 overflow-y-auto px-5 pt-5 pb-10">
+        <div className="flex justify-center py-5">
+          <div className="flex size-21 items-center justify-center rounded-3xl border border-gray-200 bg-white text-4xl font-bold dark:border-gray-700 dark:bg-gray-800">
+            {glyph || "·"}
+          </div>
+        </div>
+        <div className="mb-6 text-center text-sm font-semibold">{trimmed || "Untitled"}</div>
+
+        <div className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+          Name
+        </div>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Coffee"
+          maxLength={50}
+          className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        />
+
+        <div className="mt-6 mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+          Symbol
+        </div>
+        <input
+          type="text"
+          value={glyph}
+          onChange={(e) => onGlyphInput(e.target.value)}
+          placeholder="Type any emoji or character"
+          maxLength={8}
+          className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-center text-lg outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        />
+        <div className="mt-3 mb-2.5 text-[11px] text-gray-400 dark:text-gray-500">Suggestions</div>
+        <div className="grid grid-cols-8 gap-1.5">
+          {CAT_GLYPHS.map((g, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setGlyph(g)}
+              className={`flex aspect-square items-center justify-center rounded-lg border text-base ${
+                glyph === g
+                  ? "border-gray-900 bg-gray-100 dark:border-gray-100 dark:bg-gray-700"
+                  : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+              }`}
+            >
+              {g}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -25,7 +25,8 @@ const PAGE_TITLES: Record<string, string> = {
   "/expense/template/new": "Record",
   "/expense/recurring": "Recurring",
   "/expense/recurring/new": "New recurring",
-  "/category": "Category",
+  "/category": "Categories",
+  "/category/new": "New category",
   "/setting": "Setting",
 }
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { Navigate, createBrowserRouter } from "react-router"
 import { SignInPage } from "./auth/pages/SignInPage"
 import { SignupPage } from "./auth/pages/SignupPage"
 import { CategoriesPage } from "./category/pages/CategoriesPage"
+import { CategoryEditPage } from "./category/pages/CategoryEditPage"
 import { AppLayout } from "./common/components/AppLayout"
 import { ProtectedRoute } from "./common/components/ProtectedRoute"
 import { RecurringExpenseEditPage } from "./expense-recurring/pages/RecurringExpenseEditPage"
@@ -41,7 +42,14 @@ export const router = createBrowserRouter([
           { path: ":uuid", element: <ExpenseDetailPage /> },
         ],
       },
-      { path: "/category", element: <CategoriesPage /> },
+      {
+        path: "/category",
+        children: [
+          { index: true, element: <CategoriesPage /> },
+          { path: "new", element: <CategoryEditPage /> },
+          { path: ":uuid", element: <CategoryEditPage /> },
+        ],
+      },
       { path: "/setting", element: <SettingsPage /> },
     ],
   },


### PR DESCRIPTION
## 概要

claude.ai/design の **CategoryManagerSheet** と **CategoryEditSheet** を本実装に移植。
新規作成/編集を専用ページに切り出し、リスト画面はマネージャ風UIに刷新。

## 変更点

### CategoriesPage 全面リライト

```
┌──────────────────────────────────┐
│       Categories            +    │ ← header
│ 5 categories · tap to edit       │ ← subtitle
│                                  │
│ ┌───────────────────────────┐    │
│ │ ▲ 🍴 Food                ⇄ × │
│ │ ▼   12 expenses              │
│ ├───────────────────────────┤    │
│ │ ▲ 🚇 Transport           ⇄ × │
│ │ ▼   8 expenses               │
│ └───────────────────────────┘    │
│ ╭─ + New category ─╮  ← dashed   │
│ ╰──────────────────╯              │
└──────────────────────────────────┘
```

- ▲▼ ボタンで並び替え (D&Dからmodal風UIに変更)
- 行タップで /category/:uuid に遷移して編集
- ⇄ ボタンでマージ用モーダルを開く (target選択リスト)
- × ボタンで削除確認モーダル
- 使用件数 (\`N expenses\`) を表示 (全Expense fetchして集計)

### CategoryEditPage (新規)

```
┌──────────────────────────────────┐
│ Cancel  New category  Save       │
│                                  │
│        ┌───────┐                 │
│        │  🍴   │                 │ ← 84x84 preview
│        └───────┘                 │
│         Food                      │
│                                  │
│ NAME                              │
│ [Food                          ]  │
│                                  │
│ SYMBOL                            │
│ [    🍴                       ]   │
│ Suggestions                       │
│ 🍴 🚇 🏠 🎬 🛍 💼 💊 ✨            │
│ ☕ 🍷 🛒 ✈ 📚 🎵 🎮 🐾            │
│ 💡 💳                             │
└──────────────────────────────────┘
```

- /category/new (新規) と /category/:uuid (編集) で同じコンポーネント
- name + symbol 入力
- symbol 入力欄は最後の1グリフのみ採用 (絵文字 ZWJ等 safe)
- 18種の絵文字 suggestion grid (8列)

### Router / Layout

- \`/category\` 配下に \`index\` / \`new\` / \`:uuid\` を追加
- AppLayout PAGE_TITLES: \`/category\` → \"Categories\", \`/category/new\` → \"New category\"

## 不変な点

- backend API は変更なし (既存の CRUD + reorderCategories + mergeCategory を流用)
- categoryGlyph ヘルパー / Symbol カラム仕様は維持

## Test plan

- [x] \`make lint\` Pass
- [ ] /category で一覧 / ▲▼ で並び替え / ⇄ でマージ / × で削除確認
- [ ] / category/new で新規作成 → /category に戻る
- [ ] /category/:uuid で編集 → /category に戻る
- [ ] 絵文字キーボードで symbol 入力可能
- [ ] iPhone Safari で確認