### PR TITLE
chore: モバイル小ヘッダ (ページタイトル) を削除

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 import { BarChartIcon, HomeIcon, PersonIcon, PlusIcon, RowsIcon } from "@radix-ui/react-icons"
 import { useCallback, useEffect, useState } from "react"
-import { Outlet, useLocation, useNavigate } from "react-router"
+import { Outlet, useNavigate } from "react-router"
 
 import { api } from "../libs/api"
 import { STORAGE_KEYS } from "../libs/constants"
@@ -16,26 +16,8 @@ const navItems = [
   { label: "You", to: "/setting", icon: PersonIcon },
 ]
 
-const PAGE_TITLES: Record<string, string> = {
-  "/": "BurnStyle",
-  "/expense/new": "Expense",
-  "/expense/monthly": "Expense",
-  "/expense/annual": "Insights",
-  "/expense/template": "Template",
-  "/expense/template/new": "Record",
-  "/expense/recurring": "Recurring",
-  "/expense/recurring/new": "New recurring",
-  "/category": "Categories",
-  "/category/new": "New category",
-  "/setting": "Setting",
-}
-
-const getPageTitle = (pathname: string): string =>
-  PAGE_TITLES[pathname] ?? (pathname.startsWith("/expense/") ? "Expense" : "")
-
 export const AppLayout = () => {
   const navigate = useNavigate()
-  const location = useLocation()
   const [user, setUser] = useState<UserResponse | null>(null)
 
   const fetchUser = useCallback(async () => {
@@ -60,10 +42,7 @@ export const AppLayout = () => {
     <div className="flex h-screen bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
       <LayoutLaptop navItems={navItems} userName={user?.name} onLogout={onLogout} />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex shrink-0 items-center border-b border-gray-100 px-4 py-3 dark:border-gray-700 md:hidden">
-          <h1 className="text-lg font-bold">{getPageTitle(location.pathname)}</h1>
-        </header>
-        <main className="flex-1 overflow-y-auto pt-6 pb-[calc(env(safe-area-inset-bottom)+5rem)] md:pb-0">
+        <main className="flex-1 overflow-y-auto pt-[calc(env(safe-area-inset-top)+0.5rem)] pb-[calc(env(safe-area-inset-bottom)+5rem)] md:pt-6 md:pb-0">
           <Outlet context={{ user, onLogout, refreshUser: fetchUser }} />
         </main>
       </div>


### PR DESCRIPTION
## 概要

各ページが design 由来の独自ヘッダを持つようになったため、AppLayout 上部にあった小ヘッダ (ページタイトル) を撤去。

## 変更点

\`frontend/src/common/components/AppLayout.tsx\`:

- 上部 \`<header>\` セクションを削除
- \`PAGE_TITLES\` / \`getPageTitle\` / \`useLocation\` import を撤去
- \`main\` の上下 padding に \`env(safe-area-inset-top)\` を含めて iOS のステータスバー被りを回避

## 不変な点

- 各ページが自前で持つタイトル (TopPageの \"MAY 2026\", ExpenseMonthlyPageの \"Expense\", CategoriesPageの \"Categories\" 等) はそのまま
- フッター (LayoutPhone) / サイドバー (LayoutLaptop) は変更なし

## Test plan

- [x] \`make lint\` Pass
- [ ] iPhone Safari で各ページに二重ヘッダが無いこと確認
- [ ] safe-area の上端で内容が被らない