### PR TITLE
feat: 支出にVIBE (感情/状況タグ) 3軸を追加

### DIFF
--- a/backend/alembic/versions/58a540512762_add_expense_vibes.py
+++ b/backend/alembic/versions/58a540512762_add_expense_vibes.py
@@ -1,0 +1,41 @@
+"""支出にVIBE (感情) 3軸カラムを追加
+
+Revision ID: 58a540512762
+Revises: 30a24e9b8516
+Create Date: 2026-05-10 10:09:44.123497
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "58a540512762"
+down_revision: str | Sequence[str] | None = "30a24e9b8516"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    social = sa.Enum("SOLO", "WITH_SOMEONE", name="vibe_social")
+    planning = sa.Enum("ROUTINE", "SPONTANEOUS", name="vibe_planning")
+    necessity = sa.Enum("NEEDED", "WANTED", name="vibe_necessity")
+    social.create(op.get_bind(), checkfirst=True)
+    planning.create(op.get_bind(), checkfirst=True)
+    necessity.create(op.get_bind(), checkfirst=True)
+    op.add_column("expenses", sa.Column("vibe_social", social, nullable=True))
+    op.add_column("expenses", sa.Column("vibe_planning", planning, nullable=True))
+    op.add_column("expenses", sa.Column("vibe_necessity", necessity, nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("expenses", "vibe_necessity")
+    op.drop_column("expenses", "vibe_planning")
+    op.drop_column("expenses", "vibe_social")
+    op.execute("DROP TYPE IF EXISTS vibe_necessity")
+    op.execute("DROP TYPE IF EXISTS vibe_planning")
+    op.execute("DROP TYPE IF EXISTS vibe_social")

--- a/backend/src/api/expenses.py
+++ b/backend/src/api/expenses.py
@@ -52,6 +52,9 @@ def post_expense(
     expense = create_expense(
         db, str(user.uuid), body.name, body.amount, body.expensed_at,
         category_uuids=[body.category_uuid] if body.category_uuid else None,
+        vibe_social=body.vibe_social,
+        vibe_planning=body.vibe_planning,
+        vibe_necessity=body.vibe_necessity,
     )
     return ExpenseResponse.model_validate(expense)
 

--- a/backend/src/model/__init__.py
+++ b/backend/src/model/__init__.py
@@ -1,5 +1,5 @@
 from src.model.category import Category
-from src.model.expense import Expense
+from src.model.expense import Expense, VibeNecessity, VibePlanning, VibeSocial
 from src.model.expense_category_association import ExpenseCategoryAssociation
 from src.model.expense_template import ExpenseTemplate
 from src.model.recurring_expense import IntervalUnit, RecurringExpense
@@ -15,6 +15,9 @@ __all__ = [
     "IntervalUnit",
     "RecurringExpense",
     "User",
+    "VibeNecessity",
+    "VibePlanning",
+    "VibeSocial",
     "WebAuthnCredential",
     "generate_uuid_string",
 ]

--- a/backend/src/model/expense.py
+++ b/backend/src/model/expense.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+import enum
 from datetime import UTC, datetime
 
-from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import CheckConstraint, Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from src.model.utils import generate_uuid_string
 from src.repository.database import Base
+
+
+class VibeSocial(str, enum.Enum):
+    SOLO = "SOLO"
+    WITH_SOMEONE = "WITH_SOMEONE"
+
+
+class VibePlanning(str, enum.Enum):
+    ROUTINE = "ROUTINE"
+    SPONTANEOUS = "SPONTANEOUS"
+
+
+class VibeNecessity(str, enum.Enum):
+    NEEDED = "NEEDED"
+    WANTED = "WANTED"
 
 
 class Expense(Base):
@@ -24,6 +40,15 @@ class Expense(Base):
         String(32),
         ForeignKey("recurring_expenses.uuid", ondelete="SET NULL"),
         nullable=True,
+    )
+    vibe_social: Column[VibeSocial | None] = Column(
+        Enum(VibeSocial, name="vibe_social"), nullable=True,
+    )
+    vibe_planning: Column[VibePlanning | None] = Column(
+        Enum(VibePlanning, name="vibe_planning"), nullable=True,
+    )
+    vibe_necessity: Column[VibeNecessity | None] = Column(
+        Enum(VibeNecessity, name="vibe_necessity"), nullable=True,
     )
     created_at = Column(DateTime, default=lambda: datetime.now(UTC), nullable=False)
     updated_at = Column(

--- a/backend/src/repository/expense_repository.py
+++ b/backend/src/repository/expense_repository.py
@@ -5,7 +5,7 @@ import datetime as dt
 from sqlalchemy.orm import Session, selectinload
 
 from src.model.category import Category
-from src.model.expense import Expense
+from src.model.expense import Expense, VibeNecessity, VibePlanning, VibeSocial
 
 JST = dt.timezone(dt.timedelta(hours=9))
 DECEMBER = 12
@@ -55,9 +55,20 @@ def create_expense(  # noqa: PLR0913
     expensed_at: dt.datetime,
     *,
     category_uuids: list[str] | None = None,
+    vibe_social: VibeSocial | None = None,
+    vibe_planning: VibePlanning | None = None,
+    vibe_necessity: VibeNecessity | None = None,
 ) -> Expense:
     """支出を新規作成。"""
-    expense = Expense(user_uuid=user_uuid, name=name, amount=amount, expensed_at=expensed_at)
+    expense = Expense(
+        user_uuid=user_uuid,
+        name=name,
+        amount=amount,
+        expensed_at=expensed_at,
+        vibe_social=vibe_social,
+        vibe_planning=vibe_planning,
+        vibe_necessity=vibe_necessity,
+    )
 
     if category_uuids:
         categories = db.query(Category).filter(

--- a/backend/src/schema/expense.py
+++ b/backend/src/schema/expense.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.model.expense import VibeNecessity, VibePlanning, VibeSocial
 from src.schema.category import CategoryResponse
 from src.schema.types import JstDatetime, JstInputDatetime
 
@@ -17,6 +18,9 @@ class ExpenseResponse(BaseModel):
     updated_at: JstDatetime
     deleted_at: JstDatetime | None
     categories: list[CategoryResponse]
+    vibe_social: VibeSocial | None
+    vibe_planning: VibePlanning | None
+    vibe_necessity: VibeNecessity | None
 
 
 class ExpenseCreate(BaseModel):
@@ -24,6 +28,9 @@ class ExpenseCreate(BaseModel):
     amount: int = Field(gt=0, description="Must be a positive integer")
     expensed_at: JstInputDatetime
     category_uuid: str | None = None
+    vibe_social: VibeSocial | None = None
+    vibe_planning: VibePlanning | None = None
+    vibe_necessity: VibeNecessity | None = None
 
 
 class ExpenseUpdate(BaseModel):
@@ -31,4 +38,6 @@ class ExpenseUpdate(BaseModel):
     amount: int | None = Field(default=None, gt=0, description="Must be a positive integer")
     expensed_at: JstInputDatetime | None = None
     category_uuid: str | None = None
-
+    vibe_social: VibeSocial | None = None
+    vibe_planning: VibePlanning | None = None
+    vibe_necessity: VibeNecessity | None = None

--- a/backend/tests/api/test_expenses.py
+++ b/backend/tests/api/test_expenses.py
@@ -57,6 +57,27 @@ class TestPostExpense:
         assert data["amount"] == 800
         assert data["expensed_at"] is not None
         assert "uuid" in data
+        assert data["vibe_social"] is None
+        assert data["vibe_planning"] is None
+        assert data["vibe_necessity"] is None
+
+    def test_creates_expense_with_vibes(self, auth_client: TestClient) -> None:
+        res = auth_client.post("/expenses", json={
+            "name": "コーヒー", "amount": 500, "expensed_at": SAMPLE_EXPENSED_AT,
+            "vibe_social": "SOLO", "vibe_planning": "ROUTINE", "vibe_necessity": "WANTED",
+        })
+        assert res.status_code == 201
+        data = res.json()
+        assert data["vibe_social"] == "SOLO"
+        assert data["vibe_planning"] == "ROUTINE"
+        assert data["vibe_necessity"] == "WANTED"
+
+    def test_rejects_invalid_vibe(self, auth_client: TestClient) -> None:
+        res = auth_client.post("/expenses", json={
+            "name": "x", "amount": 100, "expensed_at": SAMPLE_EXPENSED_AT,
+            "vibe_social": "INVALID",
+        })
+        assert res.status_code == 422
 
     def test_creates_expense_with_categories(
         self, auth_client: TestClient, test_user: User, db: Session,
@@ -107,6 +128,18 @@ class TestPatchExpense:
         res = auth_client.patch(f"/expenses/{expense.uuid}", json={"category_uuid": cat.uuid})
         assert res.status_code == 200
         assert len(res.json()["categories"]) == 1
+
+    def test_updates_vibes(self, auth_client: TestClient, test_user: User, db: Session) -> None:
+        expense = _create_expense(db, str(test_user.uuid))
+
+        res = auth_client.patch(f"/expenses/{expense.uuid}", json={
+            "vibe_social": "WITH_SOMEONE", "vibe_necessity": "NEEDED",
+        })
+        assert res.status_code == 200
+        data = res.json()
+        assert data["vibe_social"] == "WITH_SOMEONE"
+        assert data["vibe_necessity"] == "NEEDED"
+        assert data["vibe_planning"] is None
 
     def test_returns_404_for_nonexistent(self, auth_client: TestClient) -> None:
         res = auth_client.patch("/expenses/nonexistent", json={"name": "test"})

--- a/frontend/src/common/libs/types.ts
+++ b/frontend/src/common/libs/types.ts
@@ -40,6 +40,10 @@ export interface CategoryReorderRequest {
   uuids: string[]
 }
 
+export type VibeSocial = "SOLO" | "WITH_SOMEONE"
+export type VibePlanning = "ROUTINE" | "SPONTANEOUS"
+export type VibeNecessity = "NEEDED" | "WANTED"
+
 export interface ExpenseResponse {
   uuid: string
   name: string
@@ -49,6 +53,9 @@ export interface ExpenseResponse {
   updated_at: string
   deleted_at: string | null
   categories: CategoryResponse[]
+  vibe_social: VibeSocial | null
+  vibe_planning: VibePlanning | null
+  vibe_necessity: VibeNecessity | null
 }
 
 export interface ExpenseCreate {
@@ -56,6 +63,9 @@ export interface ExpenseCreate {
   amount: number
   expensed_at: string
   category_uuid?: string | null
+  vibe_social?: VibeSocial | null
+  vibe_planning?: VibePlanning | null
+  vibe_necessity?: VibeNecessity | null
 }
 
 export interface ExpenseUpdate {
@@ -63,6 +73,9 @@ export interface ExpenseUpdate {
   amount?: number
   expensed_at?: string
   category_uuid?: string | null
+  vibe_social?: VibeSocial | null
+  vibe_planning?: VibePlanning | null
+  vibe_necessity?: VibeNecessity | null
 }
 
 export interface UserResponse {

--- a/frontend/src/expense/components/VibePicker.tsx
+++ b/frontend/src/expense/components/VibePicker.tsx
@@ -1,0 +1,75 @@
+import type { VibeNecessity, VibePlanning, VibeSocial } from "../../common/libs/types"
+
+interface VibePickerProps {
+  social: VibeSocial | null
+  planning: VibePlanning | null
+  necessity: VibeNecessity | null
+  onSocialChange: (v: VibeSocial | null) => void
+  onPlanningChange: (v: VibePlanning | null) => void
+  onNecessityChange: (v: VibeNecessity | null) => void
+}
+
+interface AxisProps<T extends string> {
+  current: T | null
+  options: { value: T; label: string }[]
+  onChange: (v: T | null) => void
+}
+
+const Axis = <T extends string>({ current, options, onChange }: AxisProps<T>) => (
+  <div className="flex gap-2">
+    {options.map((opt) => {
+      const on = current === opt.value
+      return (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(on ? null : opt.value)}
+          className={`flex-1 rounded-full border px-3 py-2 text-xs font-semibold transition-colors ${
+            on
+              ? "border-primary bg-primary text-white"
+              : "border-gray-200 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+          }`}
+        >
+          {opt.label}
+        </button>
+      )
+    })}
+  </div>
+)
+
+export const VibePicker = ({
+  social,
+  planning,
+  necessity,
+  onSocialChange,
+  onPlanningChange,
+  onNecessityChange,
+}: VibePickerProps) => (
+  <div className="flex flex-col gap-1.5">
+    <span className="text-xs text-gray-500 dark:text-gray-400">Vibe</span>
+    <Axis
+      current={social}
+      onChange={onSocialChange}
+      options={[
+        { value: "SOLO", label: "Solo" },
+        { value: "WITH_SOMEONE", label: "With someone" },
+      ]}
+    />
+    <Axis
+      current={planning}
+      onChange={onPlanningChange}
+      options={[
+        { value: "ROUTINE", label: "Routine" },
+        { value: "SPONTANEOUS", label: "Spontaneous" },
+      ]}
+    />
+    <Axis
+      current={necessity}
+      onChange={onNecessityChange}
+      options={[
+        { value: "NEEDED", label: "Needed it" },
+        { value: "WANTED", label: "Wanted it" },
+      ]}
+    />
+  </div>
+)

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -6,7 +6,14 @@ import { ConfirmDialog, useConfirmDialog } from "../../common/components/Confirm
 import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
-import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+import type {
+  CategoryResponse,
+  ExpenseResponse,
+  VibeNecessity,
+  VibePlanning,
+  VibeSocial,
+} from "../../common/libs/types"
+import { VibePicker } from "../components/VibePicker"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 
@@ -29,6 +36,9 @@ export const ExpenseDetailPage = () => {
     amount: "",
     expensedAt: "",
     categoryUuid: null as string | null,
+    vibeSocial: null as VibeSocial | null,
+    vibePlanning: null as VibePlanning | null,
+    vibeNecessity: null as VibeNecessity | null,
   })
 
   const fetchData = useCallback(async () => {
@@ -42,6 +52,9 @@ export const ExpenseDetailPage = () => {
         amount: exp.amount.toLocaleString(),
         expensedAt: toLocalDatetime(exp.expensed_at),
         categoryUuid: exp.categories[0]?.uuid ?? null,
+        vibeSocial: exp.vibe_social,
+        vibePlanning: exp.vibe_planning,
+        vibeNecessity: exp.vibe_necessity,
       })
     } catch (err) {
       setError(getErrorMessage(err, "Failed to load"))
@@ -70,6 +83,9 @@ export const ExpenseDetailPage = () => {
         amount: Number(form.amount.replace(/,/g, "")),
         expensed_at: new Date(form.expensedAt).toISOString(),
         category_uuid: form.categoryUuid,
+        vibe_social: form.vibeSocial,
+        vibe_planning: form.vibePlanning,
+        vibe_necessity: form.vibeNecessity,
       })
       navigate(-1)
     } catch (err) {
@@ -183,6 +199,14 @@ export const ExpenseDetailPage = () => {
             </div>
           </div>
         )}
+        <VibePicker
+          social={form.vibeSocial}
+          planning={form.vibePlanning}
+          necessity={form.vibeNecessity}
+          onSocialChange={(v) => setForm((prev) => ({ ...prev, vibeSocial: v }))}
+          onPlanningChange={(v) => setForm((prev) => ({ ...prev, vibePlanning: v }))}
+          onNecessityChange={(v) => setForm((prev) => ({ ...prev, vibeNecessity: v }))}
+        />
       </form>
 
       <button

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -4,7 +4,13 @@ import { useNavigate } from "react-router"
 import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
-import type { CategoryResponse } from "../../common/libs/types"
+import type {
+  CategoryResponse,
+  VibeNecessity,
+  VibePlanning,
+  VibeSocial,
+} from "../../common/libs/types"
+import { VibePicker } from "../components/VibePicker"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 
@@ -27,6 +33,9 @@ export const ExpensesPage = () => {
     amount: "",
     expensedAt: today,
     categoryUuid: null as string | null,
+    vibeSocial: null as VibeSocial | null,
+    vibePlanning: null as VibePlanning | null,
+    vibeNecessity: null as VibeNecessity | null,
   })
 
   const fetchData = useCallback(async () => {
@@ -59,6 +68,9 @@ export const ExpensesPage = () => {
         amount: Number(form.amount.replace(/,/g, "")),
         expensed_at: form.expensedAt,
         category_uuid: form.categoryUuid,
+        vibe_social: form.vibeSocial,
+        vibe_planning: form.vibePlanning,
+        vibe_necessity: form.vibeNecessity,
       })
       navigate("/expense/monthly")
     } catch (err) {
@@ -147,6 +159,14 @@ export const ExpensesPage = () => {
             </div>
           </div>
         )}
+        <VibePicker
+          social={form.vibeSocial}
+          planning={form.vibePlanning}
+          necessity={form.vibeNecessity}
+          onSocialChange={(v) => setForm((prev) => ({ ...prev, vibeSocial: v }))}
+          onPlanningChange={(v) => setForm((prev) => ({ ...prev, vibePlanning: v }))}
+          onNecessityChange={(v) => setForm((prev) => ({ ...prev, vibeNecessity: v }))}
+        />
       </form>
 
       <button


### PR DESCRIPTION
## 概要

#107

支出に VIBE (Social / Planning / Necessity の3軸) を任意で付与可能に。

## バックエンド (案A: 3 ENUM カラム)

### モデル

```python
class VibeSocial(str, Enum): SOLO | WITH_SOMEONE
class VibePlanning(str, Enum): ROUTINE | SPONTANEOUS
class VibeNecessity(str, Enum): NEEDED | WANTED

class Expense:
  + vibe_social: Enum nullable
  + vibe_planning: Enum nullable
  + vibe_necessity: Enum nullable
```

### マイグレーション

\`alembic/versions/58a540512762_add_expense_vibes.py\`:
- 3つの ENUM 型を明示的に \`Enum.create()\` で先に登録 (PostgreSQL 必須)
- expenses に nullable 列を3つ追加
- downgrade で列削除 + ENUM型 DROP

### Schema / Repository / API

- \`ExpenseCreate\` / \`ExpenseUpdate\` / \`ExpenseResponse\` に3フィールド追加
- \`create_expense(... vibe_social=None, vibe_planning=None, vibe_necessity=None)\` の引数追加
- patch は既存の汎用 \`update_expense\` (setattr) でそのまま透過処理

### テスト

- creates_with_vibes (POST 全3軸)
- rejects_invalid_vibe (422)
- updates_vibes (PATCH 部分更新)

合計 66 → 69 passing。

## フロントエンド

### \`common/libs/types.ts\`

- \`VibeSocial\` / \`VibePlanning\` / \`VibeNecessity\` 型 export
- \`ExpenseResponse\` / \`ExpenseCreate\` / \`ExpenseUpdate\` に追加

### \`expense/components/VibePicker.tsx\` (新規)

3軸を縦に並べるピッカー。各軸の2つの選択肢から1つ選択 (再タップで未選択)。

\`\`\`
Vibe
[Solo]        [With someone]
[Routine]     [Spontaneous]
[Needed it]   [Wanted it]
\`\`\`

### ExpensesPage / ExpenseDetailPage

フォーム末尾に \`<VibePicker />\` を配置。state に \`vibeSocial/vibePlanning/vibeNecessity\` を追加し、createExpense / updateExpense の payload に含める。

## Test plan

- [x] \`make test-backend\` Pass (69件)
- [x] \`make lint\` Pass
- [ ] iPhone Safari で支出新規作成時に Vibe 選択 → 保存
- [ ] 編集ページで既存値が反映 → 変更可能