### PR TITLE
feat: 支出新規作成ページをclaude design AddSheetに一新

### DIFF
--- a/frontend/src/expense/components/VibePicker.tsx
+++ b/frontend/src/expense/components/VibePicker.tsx
@@ -9,32 +9,28 @@ interface VibePickerProps {
   onNecessityChange: (v: VibeNecessity | null) => void
 }
 
-interface AxisProps<T extends string> {
-  current: T | null
-  options: { value: T; label: string }[]
-  onChange: (v: T | null) => void
+interface ChipProps {
+  active: boolean
+  label: string
+  onClick: () => void
 }
 
-const Axis = <T extends string>({ current, options, onChange }: AxisProps<T>) => (
-  <div className="flex gap-2">
-    {options.map((opt) => {
-      const on = current === opt.value
-      return (
-        <button
-          key={opt.value}
-          type="button"
-          onClick={() => onChange(on ? null : opt.value)}
-          className={`flex-1 rounded-full border px-3 py-2 text-xs font-semibold transition-colors ${
-            on
-              ? "border-primary bg-primary text-white"
-              : "border-gray-200 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
-          }`}
-        >
-          {opt.label}
-        </button>
-      )
-    })}
-  </div>
+const Chip = ({ active, label, onClick }: ChipProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`rounded-xl border px-3 py-2 text-center text-xs font-semibold transition-colors ${
+      active
+        ? "border-primary bg-primary text-white"
+        : "border-gray-200 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+    }`}
+  >
+    {label}
+  </button>
+)
+
+const Separator = () => (
+  <div className="self-center h-px w-full bg-gray-200 opacity-60 dark:bg-gray-700" />
 )
 
 export const VibePicker = ({
@@ -45,31 +41,51 @@ export const VibePicker = ({
   onPlanningChange,
   onNecessityChange,
 }: VibePickerProps) => (
-  <div className="flex flex-col gap-1.5">
-    <span className="text-xs text-gray-500 dark:text-gray-400">Vibe</span>
-    <Axis
-      current={social}
-      onChange={onSocialChange}
-      options={[
-        { value: "SOLO", label: "Solo" },
-        { value: "WITH_SOMEONE", label: "With someone" },
-      ]}
-    />
-    <Axis
-      current={planning}
-      onChange={onPlanningChange}
-      options={[
-        { value: "ROUTINE", label: "Routine" },
-        { value: "SPONTANEOUS", label: "Spontaneous" },
-      ]}
-    />
-    <Axis
-      current={necessity}
-      onChange={onNecessityChange}
-      options={[
-        { value: "NEEDED", label: "Needed it" },
-        { value: "WANTED", label: "Wanted it" },
-      ]}
-    />
+  <div className="flex flex-col gap-2">
+    <div className="flex items-baseline justify-between">
+      <span className="text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
+        Vibe
+      </span>
+      <span className="text-[10px] tracking-wide text-gray-400 dark:text-gray-500">
+        pick one per row
+      </span>
+    </div>
+    <div className="grid grid-cols-[1fr_12px_1fr] gap-y-1.5">
+      <Chip
+        active={social === "SOLO"}
+        label="Solo"
+        onClick={() => onSocialChange(social === "SOLO" ? null : "SOLO")}
+      />
+      <Separator />
+      <Chip
+        active={social === "WITH_SOMEONE"}
+        label="With someone"
+        onClick={() => onSocialChange(social === "WITH_SOMEONE" ? null : "WITH_SOMEONE")}
+      />
+
+      <Chip
+        active={planning === "ROUTINE"}
+        label="Routine"
+        onClick={() => onPlanningChange(planning === "ROUTINE" ? null : "ROUTINE")}
+      />
+      <Separator />
+      <Chip
+        active={planning === "SPONTANEOUS"}
+        label="Spontaneous"
+        onClick={() => onPlanningChange(planning === "SPONTANEOUS" ? null : "SPONTANEOUS")}
+      />
+
+      <Chip
+        active={necessity === "NEEDED"}
+        label="Needed it"
+        onClick={() => onNecessityChange(necessity === "NEEDED" ? null : "NEEDED")}
+      />
+      <Separator />
+      <Chip
+        active={necessity === "WANTED"}
+        label="Wanted it"
+        onClick={() => onNecessityChange(necessity === "WANTED" ? null : "WANTED")}
+      />
+    </div>
   </div>
 )

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -1,4 +1,3 @@
-import { Cross2Icon } from "@radix-ui/react-icons"
 import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useNavigate } from "react-router"
 
@@ -72,19 +71,10 @@ export const ExpensesPage = () => {
       onSubmit={handleSubmit}
       className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="flex shrink-0 items-center justify-between px-4 pt-2 pb-1">
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          aria-label="Cancel"
-          className="p-1.5 text-gray-500 dark:text-gray-400"
-        >
-          <Cross2Icon className="size-5" />
-        </button>
+      <div className="flex shrink-0 justify-center px-4 pt-8 pb-2">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           New expense
         </span>
-        <div className="size-9" />
       </div>
 
       {error && (

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -1,3 +1,4 @@
+import { Cross2Icon } from "@radix-ui/react-icons"
 import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useNavigate } from "react-router"
 
@@ -12,12 +13,6 @@ import type {
 } from "../../common/libs/types"
 import { VibePicker } from "../components/VibePicker"
 
-const pad = (n: number) => String(n).padStart(2, "0")
-
-const toLocalDatetime = (d: Date) => {
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
 export const ExpensesPage = () => {
   const navigate = useNavigate()
   const nameRef = useRef<HTMLInputElement>(null)
@@ -25,18 +20,12 @@ export const ExpensesPage = () => {
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
 
-  // Create form
-  const now = new Date()
-  const today = toLocalDatetime(now)
-  const [form, setForm] = useState({
-    name: "",
-    amount: "",
-    expensedAt: today,
-    categoryUuid: null as string | null,
-    vibeSocial: null as VibeSocial | null,
-    vibePlanning: null as VibePlanning | null,
-    vibeNecessity: null as VibeNecessity | null,
-  })
+  const [name, setName] = useState("")
+  const [amount, setAmount] = useState("")
+  const [categoryUuid, setCategoryUuid] = useState<string | null>(null)
+  const [vibeSocial, setVibeSocial] = useState<VibeSocial | null>(null)
+  const [vibePlanning, setVibePlanning] = useState<VibePlanning | null>(null)
+  const [vibeNecessity, setVibeNecessity] = useState<VibeNecessity | null>(null)
 
   const fetchData = useCallback(async () => {
     try {
@@ -51,26 +40,24 @@ export const ExpensesPage = () => {
     nameRef.current?.focus()
   }, [fetchData])
 
-  const selectCategory = (uuid: string) => {
-    setForm((prev) => ({
-      ...prev,
-      categoryUuid: prev.categoryUuid === uuid ? null : uuid,
-    }))
+  const handleAmountChange = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, "")
+    setAmount(digits ? Number(digits).toLocaleString() : "")
   }
 
-  const handleCreate = async (e: SubmitEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
     e.preventDefault()
     setError("")
     setLoading(true)
     try {
       await api.createExpense({
-        name: form.name,
-        amount: Number(form.amount.replace(/,/g, "")),
-        expensed_at: form.expensedAt,
-        category_uuid: form.categoryUuid,
-        vibe_social: form.vibeSocial,
-        vibe_planning: form.vibePlanning,
-        vibe_necessity: form.vibeNecessity,
+        name,
+        amount: Number(amount.replace(/,/g, "")),
+        expensed_at: new Date().toISOString(),
+        category_uuid: categoryUuid,
+        vibe_social: vibeSocial,
+        vibe_planning: vibePlanning,
+        vibe_necessity: vibeNecessity,
       })
       navigate("/expense/monthly")
     } catch (err) {
@@ -81,111 +68,120 @@ export const ExpensesPage = () => {
   }
 
   return (
-    <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
-      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
+    >
+      <div className="flex shrink-0 items-center justify-between px-4 pt-2 pb-1">
+        <button
+          type="button"
+          onClick={() => navigate(-1)}
+          aria-label="Cancel"
+          className="p-1.5 text-gray-500 dark:text-gray-400"
+        >
+          <Cross2Icon className="size-5" />
+        </button>
+        <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
+          New expense
+        </span>
+        <div className="size-9" />
+      </div>
 
-      <form
-        id="expense-form"
-        onSubmit={handleCreate}
-        className="flex flex-col gap-4 rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800"
-      >
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="expense-name" className="text-xs text-gray-500 dark:text-gray-400">
-            Name
-          </label>
+      {error && (
+        <p className="mx-5 shrink-0 pb-1 text-sm text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="px-5 pt-3">
           <input
             ref={nameRef}
-            id="expense-name"
             type="text"
-            placeholder="Lunch"
-            value={form.name}
-            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
             required
             maxLength={100}
-            className="rounded-xl bg-gray-50 px-4 py-3 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
+            placeholder="What was this?"
+            className="w-full bg-transparent text-2xl font-bold tracking-tight outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
           />
+          <div className="mt-2 h-px bg-gray-200 dark:bg-gray-700" />
         </div>
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="expense-amount" className="text-xs text-gray-500 dark:text-gray-400">
-            Amount
-          </label>
-          <input
-            id="expense-amount"
-            type="text"
-            inputMode="numeric"
-            placeholder="1,000"
-            value={form.amount}
-            onChange={(e) => {
-              const raw = e.target.value.replace(/[^0-9]/g, "")
-              const formatted = raw ? Number(raw).toLocaleString() : ""
-              setForm((prev) => ({ ...prev, amount: formatted }))
-            }}
-            required
-            className="rounded-xl bg-gray-50 px-4 py-3 text-base outline-none placeholder:text-gray-400 focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
+
+        <div className="px-5 pt-5 text-center">
+          <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+            What did this cost you
+          </div>
+          <div className="mt-2 flex items-baseline justify-center gap-1">
+            <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={amount}
+              onChange={(e) => handleAmountChange(e.target.value)}
+              required
+              placeholder="0"
+              className="w-44 bg-transparent text-center text-5xl font-bold tracking-tighter tabular-nums outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
+            />
+          </div>
         </div>
-        <div className="flex flex-col gap-1.5">
-          <label htmlFor="expense-date" className="text-xs text-gray-500 dark:text-gray-400">
-            Date
-          </label>
-          <input
-            id="expense-date"
-            type="datetime-local"
-            value={form.expensedAt}
-            onChange={(e) => setForm((prev) => ({ ...prev, expensedAt: e.target.value }))}
-            required
-            className="rounded-xl bg-gray-50 px-4 py-3 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:bg-gray-700 dark:text-gray-100"
-          />
-        </div>
+
         {categories.length > 0 && (
-          <div className="flex flex-col gap-1.5">
-            <span className="text-xs text-gray-500 dark:text-gray-400">Category</span>
+          <div className="px-4 pt-4">
             <div className="flex flex-wrap gap-2">
-              {categories.map((c) => (
-                <button
-                  key={c.uuid}
-                  type="button"
-                  onClick={() => selectCategory(c.uuid)}
-                  className={`rounded-full px-4 py-2 text-sm transition-colors ${
-                    form.categoryUuid === c.uuid
-                      ? "bg-primary text-white"
-                      : "bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
-                  }`}
-                >
-                  <span className="mr-1">{categoryGlyph(c)}</span>
-                  {c.name}
-                </button>
-              ))}
+              {categories.map((c) => {
+                const active = categoryUuid === c.uuid
+                return (
+                  <button
+                    key={c.uuid}
+                    type="button"
+                    onClick={() => setCategoryUuid(active ? null : c.uuid)}
+                    className={`flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-xs font-semibold ${
+                      active
+                        ? "border-primary bg-primary text-white"
+                        : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                    }`}
+                  >
+                    <span>{categoryGlyph(c)}</span>
+                    <span>{c.name}</span>
+                  </button>
+                )
+              })}
+              <button
+                type="button"
+                onClick={() => navigate("/category/new")}
+                className="flex items-center rounded-2xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
+              >
+                + Category
+              </button>
             </div>
+            {!categoryUuid && (
+              <p className="px-1 pt-2 text-[11px] text-gray-400 dark:text-gray-500">
+                No category — saved without one.
+              </p>
+            )}
           </div>
         )}
-        <VibePicker
-          social={form.vibeSocial}
-          planning={form.vibePlanning}
-          necessity={form.vibeNecessity}
-          onSocialChange={(v) => setForm((prev) => ({ ...prev, vibeSocial: v }))}
-          onPlanningChange={(v) => setForm((prev) => ({ ...prev, vibePlanning: v }))}
-          onNecessityChange={(v) => setForm((prev) => ({ ...prev, vibeNecessity: v }))}
-        />
-      </form>
 
-      <button
-        type="submit"
-        form="expense-form"
-        disabled={loading}
-        className="rounded-xl bg-primary px-5 py-4 text-white hover:bg-primary-hover disabled:opacity-50"
-      >
-        {loading ? "Adding..." : "Add"}
-      </button>
+        <div className="px-4 pt-5 pb-4">
+          <VibePicker
+            social={vibeSocial}
+            planning={vibePlanning}
+            necessity={vibeNecessity}
+            onSocialChange={setVibeSocial}
+            onPlanningChange={setVibePlanning}
+            onNecessityChange={setVibeNecessity}
+          />
+        </div>
+      </div>
 
-      <button
-        type="button"
-        onClick={() => navigate("/expense/template/new")}
-        disabled={loading}
-        className="rounded-xl border border-gray-200 px-5 py-4 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-      >
-        Template
-      </button>
-    </div>
+      <div className="shrink-0 px-4 pt-2 pb-3">
+        <button
+          type="submit"
+          disabled={loading || !name || !amount}
+          className="w-full rounded-2xl bg-primary px-4 py-4 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
+        >
+          {loading ? "Saving…" : "Save expense"}
+        </button>
+      </div>
+    </form>
   )
 }


### PR DESCRIPTION
## 概要

claude.ai/design の **AddSheet (quick add)** を本実装に適用。
\`/expense/new\` の入力体験を、design 通りのモバイル最適化レイアウトに刷新。

## 変更点

### ExpensesPage 全面リライト

```
┌──────────────────────────────────┐
│ ×          NEW EXPENSE           │ ← header
│                                  │
│ What was this?                   │ ← name (large title style)
│ ────────────────────────────     │
│                                  │
│      WHAT DID THIS COST YOU      │
│            ¥ 1,200               │ ← centered huge amount
│                                  │
│ [🍴 Food] [🚇 Transit] [+Cat]    │ ← category chips
│                                  │
│ Vibe              pick one/row   │
│ [Solo]    —    [With someone]    │
│ [Routine] —    [Spontaneous]     │
│ [Needed]  —    [Wanted]          │
│                                  │
│ ┌──────────────────────────────┐ │
│ │      Save expense            │ │ ← bottom-anchored
│ └──────────────────────────────┘ │
└──────────────────────────────────┘
```

#### 主要変更

- **タイトル風 name 入力**: \`text-2xl font-bold tracking-tight\` の大入力
- **金額の中央巨大表示**: \`text-5xl font-bold tabular-nums\` で打ち込みも視覚的に
- **カテゴリチップ**: 横並び、未選択時は注釈表示
- **'+ Category'**: 破線チップで /category/new 遷移
- **VibePicker**: ペア+区切り線レイアウトに刷新
- **下部固定 Save ボタン**: shadow 付き primary、name + amount 必須

#### 削除

- **日付入力**: 常に \`now()\` 送信。日付変更は編集ページで対応
- **Template ボタン**: Settings → Template 配下があるため重複削除

### VibePicker

design の grid 'pick one per row' レイアウトに統一。ExpenseDetailPage も自動的に同じ表示に。

## Test plan

- [x] \`make lint\` Pass
- [ ] iPhone Safari で大型入力欄に絵文字キーボード/数字キーボードが適切に表示
- [ ] 金額未入力 / 名前未入力で Save が disabled
- [ ] Save 後に /expense/monthly に遷移し、リストに反映される