### PR TITLE
feat: 支出一覧の日付ヘッダに各日合計を表示

### DIFF
--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -39,6 +39,7 @@ interface DayGroup {
   key: string
   label: string
   items: ExpenseResponse[]
+  total: number
 }
 
 export const ExpenseList = ({ expenses }: ExpenseListProps) => {
@@ -76,6 +77,7 @@ export const ExpenseList = ({ expenses }: ExpenseListProps) => {
       key,
       label: dateLabel(key),
       items,
+      total: items.reduce((sum, e) => sum + e.amount, 0),
     }))
   }, [filtered])
 
@@ -166,9 +168,10 @@ export const ExpenseList = ({ expenses }: ExpenseListProps) => {
         <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-2">
           {groups.map((g) => (
             <section key={g.key}>
-              <h2 className="mb-1.5 px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-                {g.label}
-              </h2>
+              <div className="mb-1.5 flex items-baseline justify-between px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+                <h2>{g.label}</h2>
+                <span className="tabular-nums">¥{g.total.toLocaleString()}</span>
+              </div>
               <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
                 {g.items.map((e) => {
                   const c = e.categories[0]


### PR DESCRIPTION
## 概要

#110

\`/expense/monthly\` の支出一覧で、各日付グループ見出しの右端にその日の合計金額を表示。

## 変更点

\`frontend/src/expense/components/ExpenseList.tsx\`:

- \`DayGroup\` に \`total: number\` を追加
- グループ化時に \`items.reduce\` で日次合計を算出
- 見出し行を flex justify-between レイアウトに変更
  - 左: 日付ラベル (\"MAY 9\")
  - 右: \`¥{total.toLocaleString()}\` (tabular-nums)
- 既存filter (search/scope/category/amount) 適用後の合計を反映

## 不変な点

- 行レイアウト・カードのデザイン
- ページ上部の Total 表示

## Test plan

- [x] \`make lint\` Pass
- [ ] iPhone Safari で各日合計が正しく表示
- [ ] フィルタを変更すると日合計が再計算される