### PR TITLE
feat: TopPageカレンダーの日付タップで日次絞込の支出一覧へ

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -12,6 +12,8 @@ export interface ExpenseFilter {
   categoryUuids: string[]
   min: number
   max: number
+  /** 特定日のみ表示する場合に YYYY-MM-DD を指定。設定時は scope を無視。 */
+  date: string | null
 }
 
 export const SCOPE_OPTIONS: { k: FilterScope; label: string; short: string }[] = [
@@ -26,6 +28,7 @@ export const defaultFilter = (): ExpenseFilter => ({
   categoryUuids: [],
   min: 0,
   max: 0,
+  date: null,
 })
 
 export const filterCount = (f: ExpenseFilter): number => {
@@ -34,6 +37,7 @@ export const filterCount = (f: ExpenseFilter): number => {
   if (f.scope !== "month") n++
   if (f.categoryUuids.length > 0) n++
   if (f.min > 0 || f.max > 0) n++
+  if (f.date) n++
   return n
 }
 
@@ -42,16 +46,25 @@ const sameLocalDay = (a: Date, b: Date): boolean =>
   a.getMonth() === b.getMonth() &&
   a.getDate() === b.getDate()
 
+const parseDateKey = (key: string): Date | null => {
+  const parts = key.split("-").map(Number)
+  if (parts.length !== 3 || parts.some(Number.isNaN)) return null
+  return new Date(parts[0], parts[1] - 1, parts[2])
+}
+
 export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): ExpenseResponse[] => {
   const now = new Date()
   const weekStart = new Date(now)
   weekStart.setDate(weekStart.getDate() - 6)
   weekStart.setHours(0, 0, 0, 0)
+  const targetDate = f.date ? parseDateKey(f.date) : null
 
   return expenses.filter((e) => {
     const d = new Date(e.expensed_at)
 
-    if (f.scope === "week") {
+    if (targetDate) {
+      if (!sameLocalDay(d, targetDate)) return false
+    } else if (f.scope === "week") {
       if (d < weekStart) return false
       if (d > now && !sameLocalDay(d, now)) return false
     } else if (f.scope === "month") {
@@ -268,6 +281,12 @@ interface ExpenseFilterChipsProps {
   onClear: () => void
 }
 
+const formatDateChip = (key: string): string => {
+  const d = parseDateKey(key)
+  if (!d) return key
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
 export const ExpenseFilterChips = ({
   filter,
   categories,
@@ -276,6 +295,7 @@ export const ExpenseFilterChips = ({
 }: ExpenseFilterChipsProps) => {
   const labels: string[] = []
   if (filter.q) labels.push(`"${filter.q}"`)
+  if (filter.date) labels.push(formatDateChip(filter.date))
   for (const uuid of filter.categoryUuids) {
     const c = categories.find((x) => x.uuid === uuid)
     if (c) labels.push(c.name)

--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -33,6 +33,7 @@ const timeLabel = (iso: string): string => {
 
 interface ExpenseListProps {
   expenses: ExpenseResponse[]
+  initialFilter?: ExpenseFilter
 }
 
 interface DayGroup {
@@ -42,9 +43,9 @@ interface DayGroup {
   total: number
 }
 
-export const ExpenseList = ({ expenses }: ExpenseListProps) => {
+export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
   const navigate = useNavigate()
-  const [filter, setFilter] = useState<ExpenseFilter>(defaultFilter)
+  const [filter, setFilter] = useState<ExpenseFilter>(initialFilter ?? defaultFilter())
   const [sheetOpen, setSheetOpen] = useState(false)
 
   const usedCategories = useMemo<CategoryResponse[]>(() => {

--- a/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
@@ -1,11 +1,16 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useSearchParams } from "react-router"
 
 import { api } from "../../common/libs/api"
 import { getErrorMessage } from "../../common/libs/client"
 import type { ExpenseResponse } from "../../common/libs/types"
+import { defaultFilter, type ExpenseFilter } from "../components/ExpenseFilterSheet"
 import { ExpenseList } from "../components/ExpenseList"
 
+const isValidDateKey = (s: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(s)
+
 export const ExpenseMonthlyPage = () => {
+  const [searchParams] = useSearchParams()
   const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
   const [error, setError] = useState("")
 
@@ -21,11 +26,21 @@ export const ExpenseMonthlyPage = () => {
     fetchData()
   }, [fetchData])
 
+  const initialFilter = useMemo<ExpenseFilter>(() => {
+    const dateParam = searchParams.get("date")
+    if (dateParam && isValidDateKey(dateParam)) {
+      return { ...defaultFilter(), date: dateParam }
+    }
+    return defaultFilter()
+    // initial読み取りのみで意図的に searchParams 変更には追従しない
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   return (
     <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden px-5">
       {error && <p className="mt-4 text-sm text-red-600 dark:text-red-400">{error}</p>}
       <h1 className="shrink-0 pt-2 pb-2 text-3xl font-bold tracking-tight">Expense</h1>
-      <ExpenseList expenses={expenses} />
+      <ExpenseList expenses={expenses} initialFilter={initialFilter} />
     </div>
   )
 }

--- a/frontend/src/expense/pages/TopPage.tsx
+++ b/frontend/src/expense/pages/TopPage.tsx
@@ -28,9 +28,10 @@ interface HeatmapProps {
   month: number
   today: number
   totals: number[]
+  onSelectDay: (day: number) => void
 }
 
-const Heatmap = ({ year, month, today, totals }: HeatmapProps) => {
+const Heatmap = ({ year, month, today, totals, onSelectDay }: HeatmapProps) => {
   const daysInMonth = new Date(year, month, 0).getDate()
   const firstDow = new Date(year, month - 1, 1).getDay()
   const max = Math.max(...totals, 0)
@@ -60,10 +61,13 @@ const Heatmap = ({ year, month, today, totals }: HeatmapProps) => {
                 }
               : undefined
           return (
-            <div
+            <button
               key={i}
+              type="button"
+              onClick={() => onSelectDay(day)}
+              disabled={isFuture}
               style={cellStyle}
-              className={`flex aspect-square items-center justify-center rounded-md text-[10px] font-semibold ${
+              className={`flex aspect-square items-center justify-center rounded-md text-[10px] font-semibold disabled:cursor-default ${
                 isFuture
                   ? "border border-dashed border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
                   : isToday
@@ -74,7 +78,7 @@ const Heatmap = ({ year, month, today, totals }: HeatmapProps) => {
               }`}
             >
               {day}
-            </div>
+            </button>
           )
         })}
       </div>
@@ -138,7 +142,16 @@ export const TopPage = () => {
       </div>
 
       <div className="shrink-0 pt-4">
-        <Heatmap year={year} month={month} today={today} totals={totals} />
+        <Heatmap
+          year={year}
+          month={month}
+          today={today}
+          totals={totals}
+          onSelectDay={(day) => {
+            const dateKey = `${year}-${pad(month)}-${pad(day)}`
+            navigate(`/expense/monthly?date=${dateKey}`)
+          }}
+        />
       </div>
 
       <div className="mt-6 shrink-0 border-b border-gray-200 pb-4 dark:border-gray-700">


### PR DESCRIPTION
## 概要

TopPage のカレンダー (Heatmap) の日付セルをタップすると、その日付で絞り込まれた支出一覧画面に遷移する。

## 変更点

### \`ExpenseFilter\` に \`date\` フィールド追加

- \`date: string | null\` (\`YYYY-MM-DD\`)
- 設定時は \`scope\` を無視し、その日の支出のみ表示
- \`filterCount\` に算入されfilter sheet ボタンの件数バッジに反映
- \`ExpenseFilterChips\` で 'May 9' 形式の chip 表示

### \`ExpenseList\` に \`initialFilter\` prop 追加

- 親から初期 filter 状態を受け取り、\`useState\` の初期値に使う
- ユーザーが filter sheet で変更したら通常通り更新される

### \`ExpenseMonthlyPage\` で URL \`?date=\` を読み取り

- \`useSearchParams\` で初期マウント時のみ参照
- \`YYYY-MM-DD\` 形式validation
- 該当時は \`initialFilter\` として ExpenseList に渡す

### \`TopPage\` Heatmap セル click

- \`<div>\` → \`<button>\` 化
- 未来日は \`disabled\`
- click 時 \`navigate('/expense/monthly?date=YYYY-MM-DD')\`

## Test plan

- [x] \`make lint\` Pass
- [ ] /home でカレンダーの過去日タップ → /expense/monthly?date=... へ遷移
- [ ] 遷移先で日付chipが active filter 表示
- [ ] 未来日はクリック不可
- [ ] その日の支出のみリスト表示
- [ ] filter sheet を開いて clear all で全件に戻る