### PR TITLE
fix: 支出一覧のスクロール領域上部の余白を拡大

### DIFF
--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -166,7 +166,7 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
           {expenses.length === 0 ? "No expenses yet" : "No matches for this filter"}
         </p>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-2">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-4">
           {groups.map((g) => (
             <section key={g.key}>
               <div className="mb-1.5 flex items-baseline justify-between px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">

--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -166,7 +166,7 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
           {expenses.length === 0 ? "No expenses yet" : "No matches for this filter"}
         </p>
       ) : (
-        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-4">
+        <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-2">
           {groups.map((g) => (
             <section key={g.key}>
               <div className="mb-1.5 flex items-baseline justify-between px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">


### PR DESCRIPTION
## Summary
- Week/Month/All スコープボタン直下のスクロール領域 `pt-2` → `pt-4` に拡大
- スクロール時にフィルタ行と先頭アイテムが近接していた問題を解消

Closes #116

## Test plan
- [ ] `/expense/monthly` でフィルタ行とリスト先頭の余白が広がっていることを確認
- [ ] スクロール時もフィルタとリストの境界が視覚的に明瞭であることを確認