### PR TITLE
ci: backend deploy で migration を独立ジョブに分割

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -38,8 +38,9 @@ jobs:
       - name: test
         run: cd backend && uv run pytest -v
 
-  deploy:
+  migrate:
     needs: lint-and-test
+    if: inputs.environment == 'production'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -56,15 +57,10 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel
 
-      - name: Pull Vercel Environment Information
-        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
-
       - name: Install dependencies
-        if: inputs.environment == 'production'
         run: cd backend && uv sync --all-groups
 
       - name: Run database migrations
-        if: inputs.environment == 'production'
         env:
           VERCEL_ENV: production
         run: |
@@ -74,6 +70,23 @@ jobs:
           . .env.production
           set +a
           uv run alembic upgrade head
+
+  deploy:
+    needs: [lint-and-test, migrate]
+    if: |
+      always() &&
+      needs.lint-and-test.result == 'success' &&
+      (needs.migrate.result == 'success' || needs.migrate.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel
+
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build
         run: vercel build ${{ inputs.environment == 'production' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- backend の deploy workflow で、DB migration ステップを `migrate` ジョブとして deploy ジョブから分離
- ジョブ構成
  - `lint-and-test`
  - `migrate` (production のみ実行 / `lint-and-test` 後)
  - `deploy` (`lint-and-test` + `migrate` 後 / preview 時は migrate skip でも実行)
- preview 環境では `migrate` を skip し、`deploy` は `needs.migrate.result == 'skipped'` も許容
- 失敗箇所と responsibilities が明確になり、migration 失敗時に deploy が走らないこと・retry 単位が独立することがメリット

## Test plan
- [ ] preview 実行で migrate が skip され deploy が走ること
- [ ] production 実行で migrate → deploy の順に実行され成功すること
- [ ] migration が失敗したとき deploy が実行されないこと