### PR TITLE
chore: 静的アセット 404 のリクエストログを debug に降格

### DIFF
--- a/backend/src/middleware/request_logging.py
+++ b/backend/src/middleware/request_logging.py
@@ -11,6 +11,14 @@ from src.logger import get_logger, request_id_var
 
 logger = get_logger("request")
 
+# ブラウザが自動取得する favicon / apple-touch-icon / robots.txt の 404 ノイズを抑止するパス
+_NOISE_PATH_PREFIXES = ("/favicon.ico", "/apple-touch-icon", "/robots.txt")
+_HTTP_NOT_FOUND = 404
+
+
+def _is_static_noise(path: str, status_code: int) -> bool:
+    return status_code == _HTTP_NOT_FOUND and path.startswith(_NOISE_PATH_PREFIXES)
+
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):
     """request_idを採番し、開始/終了アクセスログを出力。"""
@@ -33,7 +41,8 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             request_id_var.reset(token)
 
         duration_ms = round((time.perf_counter() - start) * 1000, 2)
-        logger.info(
+        log = logger.debug if _is_static_noise(request.url.path, response.status_code) else logger.info
+        log(
             "request",
             extra={
                 "method": request.method,


### PR DESCRIPTION
## Summary
- ブラウザが自動取得する `/favicon.ico` `/apple-touch-icon*` `/robots.txt` の 404 リクエストログを INFO → DEBUG に降格
- 通常の 404 (アプリケーションロジック由来) は INFO のまま
- 実損のないノイズだけ静かにする

## 実装
- `src/middleware/request_logging.py` に `_is_static_noise(path, status_code)` ヘルパを追加
- ログレベルだけ切り替え (出力フォーマット・extra フィールドは従来と同一)

## Test plan
- [ ] backend test 全Pass
- [ ] 通常 API 呼び出しの request ログが INFO で残る
- [ ] `/favicon.ico` (404) のログが DEBUG 出力 (デフォルト構成では非表示)