### PR TITLE
feat: コールドスタート待ち UI 用にグローバルローディングバーを追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import { RouterProvider } from "react-router"
 
+import { GlobalLoadingBar } from "./common/components/GlobalLoadingBar"
 import { router } from "./router"
 
 export const App = () => {
-  return <RouterProvider router={router} />
+  return (
+    <>
+      <GlobalLoadingBar />
+      <RouterProvider router={router} />
+    </>
+  )
 }

--- a/frontend/src/common/components/GlobalLoadingBar.tsx
+++ b/frontend/src/common/components/GlobalLoadingBar.tsx
@@ -18,7 +18,7 @@ export const GlobalLoadingBar = () => {
       }
     }
 
-    return subscribeInflight((count) => {
+    const unsubscribe = subscribeInflight((count) => {
       if (count === 0) {
         cancelTimer()
         setShow(false)
@@ -30,6 +30,11 @@ export const GlobalLoadingBar = () => {
         timer = null
       }, SHOW_DELAY_MS)
     })
+
+    return () => {
+      cancelTimer()
+      unsubscribe()
+    }
   }, [])
 
   if (!show) return null

--- a/frontend/src/common/components/GlobalLoadingBar.tsx
+++ b/frontend/src/common/components/GlobalLoadingBar.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react"
+
+import { subscribeInflight } from "../libs/client"
+
+const SHOW_DELAY_MS = 400
+
+/** in-flight リクエストが SHOW_DELAY_MS 以上続くと上端にスライドバーを表示。cold start 待ち UI 用。 */
+export const GlobalLoadingBar = () => {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null
+    return subscribeInflight((count) => {
+      if (count > 0) {
+        if (!timer) {
+          timer = setTimeout(() => {
+            setShow(true)
+            timer = null
+          }, SHOW_DELAY_MS)
+        }
+      } else {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        setShow(false)
+      }
+    })
+  }, [])
+
+  if (!show) return null
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-0 z-50 h-0.5 overflow-hidden bg-primary/15">
+      <div className="loading-bar-track h-full w-1/3 rounded-full bg-primary" />
+    </div>
+  )
+}

--- a/frontend/src/common/components/GlobalLoadingBar.tsx
+++ b/frontend/src/common/components/GlobalLoadingBar.tsx
@@ -10,21 +10,25 @@ export const GlobalLoadingBar = () => {
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null
-    return subscribeInflight((count) => {
-      if (count > 0) {
-        if (!timer) {
-          timer = setTimeout(() => {
-            setShow(true)
-            timer = null
-          }, SHOW_DELAY_MS)
-        }
-      } else {
-        if (timer) {
-          clearTimeout(timer)
-          timer = null
-        }
-        setShow(false)
+
+    const cancelTimer = () => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
       }
+    }
+
+    return subscribeInflight((count) => {
+      if (count === 0) {
+        cancelTimer()
+        setShow(false)
+        return
+      }
+      if (timer) return
+      timer = setTimeout(() => {
+        setShow(true)
+        timer = null
+      }, SHOW_DELAY_MS)
     })
   }, [])
 

--- a/frontend/src/common/libs/client.ts
+++ b/frontend/src/common/libs/client.ts
@@ -16,6 +16,23 @@ const STATUS_MESSAGES: Record<number, string> = {
 
 const baseUrl = import.meta.env.VITE_API_URL ?? "http://localhost:13000"
 
+type InflightListener = (count: number) => void
+const inflightListeners = new Set<InflightListener>()
+let inflightCount = 0
+
+const notifyInflight = () => {
+  for (const listener of inflightListeners) listener(inflightCount)
+}
+
+/** リクエスト in-flight 数の購読。cold start 中の長時間リクエストを検知する用途。 */
+export const subscribeInflight = (listener: InflightListener): (() => void) => {
+  inflightListeners.add(listener)
+  listener(inflightCount)
+  return () => {
+    inflightListeners.delete(listener)
+  }
+}
+
 const getHeaders = (): HeadersInit => {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -28,11 +45,19 @@ const getHeaders = (): HeadersInit => {
 }
 
 const request = async <T>(method: string, path: string, body?: unknown): Promise<T> => {
-  const response = await fetch(`${baseUrl}${path}`, {
-    method,
-    headers: getHeaders(),
-    body: body ? JSON.stringify(body) : undefined,
-  })
+  inflightCount += 1
+  notifyInflight()
+  let response: Response
+  try {
+    response = await fetch(`${baseUrl}${path}`, {
+      method,
+      headers: getHeaders(),
+      body: body ? JSON.stringify(body) : undefined,
+    })
+  } finally {
+    inflightCount -= 1
+    notifyInflight()
+  }
 
   const newToken = response.headers.get("X-New-Token")
   if (newToken) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -69,6 +69,19 @@ textarea {
   font-size: 16px;
 }
 
+@keyframes loading-bar-slide {
+  0% {
+    transform: translateX(-120%);
+  }
+  100% {
+    transform: translateX(420%);
+  }
+}
+
+.loading-bar-track {
+  animation: loading-bar-slide 1.6s ease-in-out infinite;
+}
+
 input::placeholder {
   color: var(--color-gray-300);
 }


### PR DESCRIPTION
## Summary
- `client.ts` に in-flight リクエスト数のカウンタと購読 API (`subscribeInflight`) を追加
- `GlobalLoadingBar` を新規追加し、リクエスト中で **400ms 経過した時点** から画面上端に薄いプライマリカラーのスライドバーを表示
- リクエストが解決すると即座に非表示
- App ルートに常駐させ、認証画面・サインイン画面でも cold start 待ちを可視化

## 仕組み
- 短時間で完了する request では UI 表示なし (チラ見え防止: 400ms ディレイ)
- cold start (5–15s) や重い API 呼び出し中も常時バーが流れる
- 既存ページの per-feature ローディング (`loading` state) はそのまま動作

## Test plan
- [ ] 通常 API 呼び出し (即時応答) でバーが出ない
- [ ] DevTools の Network throttling (Slow 3G 等) でリクエスト中にバーが上端に出る
- [ ] 失敗時もバーが消える
- [ ] サインイン画面でも cold start 中にバーが出る