### PR TITLE
refactor: FE を 1ファイル1コンポーネントに分割

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterChips.tsx
+++ b/frontend/src/expense/components/ExpenseFilterChips.tsx
@@ -1,0 +1,57 @@
+import type { CategoryResponse } from "../../common/libs/types"
+import { type ExpenseFilter, parseDateKey } from "../libs/expenseFilter"
+
+interface ExpenseFilterChipsProps {
+  filter: ExpenseFilter
+  categories: CategoryResponse[]
+  onOpen: () => void
+  onClear: () => void
+}
+
+const formatDateChip = (key: string): string => {
+  const d = parseDateKey(key)
+  if (!d) return key
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+export const ExpenseFilterChips = ({
+  filter,
+  categories,
+  onOpen,
+  onClear,
+}: ExpenseFilterChipsProps) => {
+  const labels: string[] = []
+  if (filter.q) labels.push(`"${filter.q}"`)
+  if (filter.date) labels.push(formatDateChip(filter.date))
+  for (const uuid of filter.categoryUuids) {
+    const c = categories.find((x) => x.uuid === uuid)
+    if (c) labels.push(c.name)
+  }
+  if (filter.min > 0 || filter.max > 0) {
+    labels.push(
+      filter.max
+        ? `¥${filter.min.toLocaleString()}–${filter.max.toLocaleString()}`
+        : `¥${filter.min.toLocaleString()}+`,
+    )
+  }
+
+  if (labels.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 py-2">
+      {labels.map((l, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={onOpen}
+          className="rounded-xl bg-primary/10 px-2.5 py-1 text-[11px] font-semibold text-primary"
+        >
+          {l}
+        </button>
+      ))}
+      <button type="button" onClick={onClear} className="px-1.5 py-1 text-[11px] text-gray-400">
+        clear all
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -2,85 +2,8 @@ import { Cross2Icon } from "@radix-ui/react-icons"
 import { useEffect, useRef, useState } from "react"
 
 import { categoryGlyph } from "../../common/libs/category"
-import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
-
-export type FilterScope = "week" | "month" | "all"
-
-export interface ExpenseFilter {
-  q: string
-  scope: FilterScope
-  categoryUuids: string[]
-  min: number
-  max: number
-  /** 特定日のみ表示する場合に YYYY-MM-DD を指定。設定時は scope を無視。 */
-  date: string | null
-}
-
-export const SCOPE_OPTIONS: { k: FilterScope; label: string; short: string }[] = [
-  { k: "week", label: "This week", short: "Week" },
-  { k: "month", label: "This month", short: "Month" },
-  { k: "all", label: "All time", short: "All" },
-]
-
-export const defaultFilter = (): ExpenseFilter => ({
-  q: "",
-  scope: "month",
-  categoryUuids: [],
-  min: 0,
-  max: 0,
-  date: null,
-})
-
-export const filterCount = (f: ExpenseFilter): number => {
-  let n = 0
-  if (f.q) n++
-  if (f.scope !== "month") n++
-  if (f.categoryUuids.length > 0) n++
-  if (f.min > 0 || f.max > 0) n++
-  if (f.date) n++
-  return n
-}
-
-const sameLocalDay = (a: Date, b: Date): boolean =>
-  a.getFullYear() === b.getFullYear() &&
-  a.getMonth() === b.getMonth() &&
-  a.getDate() === b.getDate()
-
-const parseDateKey = (key: string): Date | null => {
-  const parts = key.split("-").map(Number)
-  if (parts.length !== 3 || parts.some(Number.isNaN)) return null
-  return new Date(parts[0], parts[1] - 1, parts[2])
-}
-
-export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): ExpenseResponse[] => {
-  const now = new Date()
-  const weekStart = new Date(now)
-  weekStart.setDate(weekStart.getDate() - 6)
-  weekStart.setHours(0, 0, 0, 0)
-  const targetDate = f.date ? parseDateKey(f.date) : null
-
-  return expenses.filter((e) => {
-    const d = new Date(e.expensed_at)
-
-    if (targetDate) {
-      if (!sameLocalDay(d, targetDate)) return false
-    } else if (f.scope === "week") {
-      if (d < weekStart) return false
-      if (d > now && !sameLocalDay(d, now)) return false
-    } else if (f.scope === "month") {
-      if (d.getFullYear() !== now.getFullYear() || d.getMonth() !== now.getMonth()) return false
-    }
-
-    if (f.q && !e.name.toLowerCase().includes(f.q.toLowerCase())) return false
-    if (f.categoryUuids.length > 0) {
-      const hit = e.categories.some((c) => f.categoryUuids.includes(c.uuid))
-      if (!hit) return false
-    }
-    if (f.min > 0 && e.amount < f.min) return false
-    if (f.max > 0 && e.amount > f.max) return false
-    return true
-  })
-}
+import type { CategoryResponse } from "../../common/libs/types"
+import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
 
 interface ExpenseFilterSheetProps {
   open: boolean
@@ -271,60 +194,5 @@ export const ExpenseFilterSheet = ({
         </div>
       </div>
     </dialog>
-  )
-}
-
-interface ExpenseFilterChipsProps {
-  filter: ExpenseFilter
-  categories: CategoryResponse[]
-  onOpen: () => void
-  onClear: () => void
-}
-
-const formatDateChip = (key: string): string => {
-  const d = parseDateKey(key)
-  if (!d) return key
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-export const ExpenseFilterChips = ({
-  filter,
-  categories,
-  onOpen,
-  onClear,
-}: ExpenseFilterChipsProps) => {
-  const labels: string[] = []
-  if (filter.q) labels.push(`"${filter.q}"`)
-  if (filter.date) labels.push(formatDateChip(filter.date))
-  for (const uuid of filter.categoryUuids) {
-    const c = categories.find((x) => x.uuid === uuid)
-    if (c) labels.push(c.name)
-  }
-  if (filter.min > 0 || filter.max > 0) {
-    labels.push(
-      filter.max
-        ? `¥${filter.min.toLocaleString()}–${filter.max.toLocaleString()}`
-        : `¥${filter.min.toLocaleString()}+`,
-    )
-  }
-
-  if (labels.length === 0) return null
-
-  return (
-    <div className="flex flex-wrap items-center gap-1.5 py-2">
-      {labels.map((l, i) => (
-        <button
-          key={i}
-          type="button"
-          onClick={onOpen}
-          className="rounded-xl bg-primary/10 px-2.5 py-1 text-[11px] font-semibold text-primary"
-        >
-          {l}
-        </button>
-      ))}
-      <button type="button" onClick={onClear} className="px-1.5 py-1 text-[11px] text-gray-400">
-        clear all
-      </button>
-    </div>
   )
 }

--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -8,11 +8,11 @@ import {
   applyFilter,
   defaultFilter,
   type ExpenseFilter,
-  ExpenseFilterChips,
-  ExpenseFilterSheet,
   filterCount,
   SCOPE_OPTIONS,
-} from "./ExpenseFilterSheet"
+} from "../libs/expenseFilter"
+import { ExpenseFilterChips } from "./ExpenseFilterChips"
+import { ExpenseFilterSheet } from "./ExpenseFilterSheet"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 

--- a/frontend/src/expense/components/InsightYearChart.tsx
+++ b/frontend/src/expense/components/InsightYearChart.tsx
@@ -1,0 +1,117 @@
+export interface YearMonth {
+  key: string
+  label: string
+  year: number
+  month: number
+  amount: number
+  current: boolean
+}
+
+interface InsightYearChartProps {
+  year: YearMonth[]
+}
+
+export const InsightYearChart = ({ year }: InsightYearChartProps) => {
+  const yMax = Math.max(...year.map((d) => d.amount), 1) * 1.05
+  const total = year.reduce((s, d) => s + d.amount, 0)
+  const avg = Math.round(total / year.length)
+  const peak = year.reduce((max, d) => (d.amount > max.amount ? d : max), year[0])
+  const W = 340
+  const H = 160
+  const pad = 24
+  const xAt = (i: number) => pad + (i / (year.length - 1)) * (W - pad * 2)
+  const yAt = (v: number) => H - 26 - (v / yMax) * (H - 50)
+  const linePath = year.map((d, i) => `${i === 0 ? "M" : "L"} ${xAt(i)} ${yAt(d.amount)}`).join(" ")
+  const areaPath = `${linePath} L ${xAt(year.length - 1)} ${H - 26} L ${pad} ${H - 26} Z`
+
+  return (
+    <div>
+      <div className="flex items-baseline gap-2 px-2 pb-1">
+        <span className="text-xl font-bold tracking-tight tabular-nums">
+          {`¥${(total / 1000).toFixed(1)}k`}
+        </span>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          total · ¥{avg.toLocaleString()}/mo avg
+        </span>
+      </div>
+      <svg
+        width="100%"
+        viewBox={`0 0 ${W} ${H}`}
+        preserveAspectRatio="none"
+        className="mt-1.5 block"
+      >
+        <line
+          x1={pad}
+          x2={W - pad}
+          y1={yAt(avg)}
+          y2={yAt(avg)}
+          stroke="currentColor"
+          strokeWidth="0.5"
+          strokeDasharray="3 3"
+          opacity="0.3"
+        />
+        <path d={areaPath} fill="var(--color-primary)" fillOpacity="0.14" />
+        <path
+          d={linePath}
+          fill="none"
+          stroke="var(--color-primary)"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        {year.map((d, i) => {
+          const cw = ((W - pad * 2) / year.length) * 0.55
+          const x = xAt(i) - cw / 2
+          const y = yAt(d.amount)
+          return (
+            <rect
+              key={i}
+              x={x}
+              y={y}
+              width={cw}
+              height={H - 26 - y}
+              fill="var(--color-primary)"
+              fillOpacity={d.current ? 0.85 : 0.28}
+              rx="2"
+            />
+          )
+        })}
+        {year.map((d, i) => (
+          <circle
+            key={`p${i}`}
+            cx={xAt(i)}
+            cy={yAt(d.amount)}
+            r={d.current ? 3.5 : 2}
+            fill={d.current ? "var(--color-primary)" : "#ffffff"}
+            stroke="var(--color-primary)"
+            strokeWidth="1.2"
+          />
+        ))}
+        {year.map((d, i) => (
+          <text
+            key={`l${i}`}
+            x={xAt(i)}
+            y={H - 8}
+            textAnchor="middle"
+            fontSize="9"
+            fill="currentColor"
+            opacity={d.current ? 1 : 0.5}
+            fontWeight={d.current ? 700 : 500}
+            fontFamily="inherit"
+          >
+            {d.label}
+          </text>
+        ))}
+      </svg>
+      <div className="flex items-center justify-between px-2 pt-1.5 text-[11px] text-gray-500 dark:text-gray-400">
+        <span className="flex items-center gap-1.5">
+          <span className="h-0.5 w-3.5 bg-primary opacity-50" />
+          monthly avg ¥{avg.toLocaleString()}
+        </span>
+        <span className="tabular-nums">
+          peak ¥{Math.round(peak.amount).toLocaleString()} · {peak.label}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense/components/TopHeatmap.tsx
+++ b/frontend/src/expense/components/TopHeatmap.tsx
@@ -1,0 +1,62 @@
+interface TopHeatmapProps {
+  year: number
+  month: number
+  today: number
+  totals: number[]
+  onSelectDay: (day: number) => void
+}
+
+export const TopHeatmap = ({ year, month, today, totals, onSelectDay }: TopHeatmapProps) => {
+  const daysInMonth = new Date(year, month, 0).getDate()
+  const firstDow = new Date(year, month - 1, 1).getDay()
+  const max = Math.max(...totals, 0)
+
+  return (
+    <div>
+      <div className="mb-1.5 grid grid-cols-7 text-center text-[9px] font-semibold tracking-wide text-gray-400 dark:text-gray-500">
+        {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
+          <span key={i}>{d}</span>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-1">
+        {Array.from({ length: firstDow }).map((_, i) => (
+          <div key={`sp${i}`} />
+        ))}
+        {Array.from({ length: daysInMonth }).map((_, i) => {
+          const day = i + 1
+          const v = totals[i] ?? 0
+          const isToday = day === today
+          const isFuture = day > today
+          const intensity = max > 0 ? 22 + (v / max) * 72 : 0
+          const cellStyle =
+            !isFuture && v > 0
+              ? {
+                  background: `color-mix(in oklab, var(--color-primary) ${intensity}%, #edf2f7)`,
+                  color: v / max > 0.5 ? "#fff" : "#4a5568",
+                }
+              : undefined
+          return (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onSelectDay(day)}
+              disabled={isFuture}
+              style={cellStyle}
+              className={`flex aspect-square items-center justify-center rounded-md text-[10px] font-semibold disabled:cursor-default ${
+                isFuture
+                  ? "border border-dashed border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
+                  : isToday
+                    ? "border-[1.5px] border-gray-900 dark:border-gray-100"
+                    : v === 0
+                      ? "bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500"
+                      : ""
+              }`}
+            >
+              {day}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense/components/VibeChip.tsx
+++ b/frontend/src/expense/components/VibeChip.tsx
@@ -1,0 +1,19 @@
+interface VibeChipProps {
+  active: boolean
+  label: string
+  onClick: () => void
+}
+
+export const VibeChip = ({ active, label, onClick }: VibeChipProps) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={`rounded-xl border px-3 py-2 text-center text-xs font-semibold transition-colors ${
+      active
+        ? "border-primary bg-primary text-white"
+        : "border-gray-200 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+    }`}
+  >
+    {label}
+  </button>
+)

--- a/frontend/src/expense/components/VibePicker.tsx
+++ b/frontend/src/expense/components/VibePicker.tsx
@@ -1,4 +1,5 @@
 import type { VibeNecessity, VibePlanning, VibeSocial } from "../../common/libs/types"
+import { VibeChip } from "./VibeChip"
 
 interface VibePickerProps {
   social: VibeSocial | null
@@ -9,28 +10,8 @@ interface VibePickerProps {
   onNecessityChange: (v: VibeNecessity | null) => void
 }
 
-interface ChipProps {
-  active: boolean
-  label: string
-  onClick: () => void
-}
-
-const Chip = ({ active, label, onClick }: ChipProps) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className={`rounded-xl border px-3 py-2 text-center text-xs font-semibold transition-colors ${
-      active
-        ? "border-primary bg-primary text-white"
-        : "border-gray-200 bg-white text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
-    }`}
-  >
-    {label}
-  </button>
-)
-
-const Separator = () => (
-  <div className="self-center h-px w-full bg-gray-200 opacity-60 dark:bg-gray-700" />
+const separator = (
+  <div className="h-px w-full self-center bg-gray-200 opacity-60 dark:bg-gray-700" />
 )
 
 export const VibePicker = ({
@@ -51,37 +32,37 @@ export const VibePicker = ({
       </span>
     </div>
     <div className="grid grid-cols-[1fr_12px_1fr] gap-y-1.5">
-      <Chip
+      <VibeChip
         active={social === "SOLO"}
         label="Solo"
         onClick={() => onSocialChange(social === "SOLO" ? null : "SOLO")}
       />
-      <Separator />
-      <Chip
+      {separator}
+      <VibeChip
         active={social === "WITH_SOMEONE"}
         label="With someone"
         onClick={() => onSocialChange(social === "WITH_SOMEONE" ? null : "WITH_SOMEONE")}
       />
 
-      <Chip
+      <VibeChip
         active={planning === "ROUTINE"}
         label="Routine"
         onClick={() => onPlanningChange(planning === "ROUTINE" ? null : "ROUTINE")}
       />
-      <Separator />
-      <Chip
+      {separator}
+      <VibeChip
         active={planning === "SPONTANEOUS"}
         label="Spontaneous"
         onClick={() => onPlanningChange(planning === "SPONTANEOUS" ? null : "SPONTANEOUS")}
       />
 
-      <Chip
+      <VibeChip
         active={necessity === "NEEDED"}
         label="Needed it"
         onClick={() => onNecessityChange(necessity === "NEEDED" ? null : "NEEDED")}
       />
-      <Separator />
-      <Chip
+      {separator}
+      <VibeChip
         active={necessity === "WANTED"}
         label="Wanted it"
         onClick={() => onNecessityChange(necessity === "WANTED" ? null : "WANTED")}

--- a/frontend/src/expense/libs/expenseFilter.ts
+++ b/frontend/src/expense/libs/expenseFilter.ts
@@ -1,0 +1,79 @@
+import type { ExpenseResponse } from "../../common/libs/types"
+
+export type FilterScope = "week" | "month" | "all"
+
+export interface ExpenseFilter {
+  q: string
+  scope: FilterScope
+  categoryUuids: string[]
+  min: number
+  max: number
+  /** 特定日のみ表示する場合に YYYY-MM-DD を指定。設定時は scope を無視。 */
+  date: string | null
+}
+
+export const SCOPE_OPTIONS: { k: FilterScope; label: string; short: string }[] = [
+  { k: "week", label: "This week", short: "Week" },
+  { k: "month", label: "This month", short: "Month" },
+  { k: "all", label: "All time", short: "All" },
+]
+
+export const defaultFilter = (): ExpenseFilter => ({
+  q: "",
+  scope: "month",
+  categoryUuids: [],
+  min: 0,
+  max: 0,
+  date: null,
+})
+
+export const filterCount = (f: ExpenseFilter): number => {
+  let n = 0
+  if (f.q) n++
+  if (f.scope !== "month") n++
+  if (f.categoryUuids.length > 0) n++
+  if (f.min > 0 || f.max > 0) n++
+  if (f.date) n++
+  return n
+}
+
+const sameLocalDay = (a: Date, b: Date): boolean =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate()
+
+export const parseDateKey = (key: string): Date | null => {
+  const parts = key.split("-").map(Number)
+  if (parts.length !== 3 || parts.some(Number.isNaN)) return null
+  return new Date(parts[0], parts[1] - 1, parts[2])
+}
+
+export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): ExpenseResponse[] => {
+  const now = new Date()
+  const weekStart = new Date(now)
+  weekStart.setDate(weekStart.getDate() - 6)
+  weekStart.setHours(0, 0, 0, 0)
+  const targetDate = f.date ? parseDateKey(f.date) : null
+
+  return expenses.filter((e) => {
+    const d = new Date(e.expensed_at)
+
+    if (targetDate) {
+      if (!sameLocalDay(d, targetDate)) return false
+    } else if (f.scope === "week") {
+      if (d < weekStart) return false
+      if (d > now && !sameLocalDay(d, now)) return false
+    } else if (f.scope === "month") {
+      if (d.getFullYear() !== now.getFullYear() || d.getMonth() !== now.getMonth()) return false
+    }
+
+    if (f.q && !e.name.toLowerCase().includes(f.q.toLowerCase())) return false
+    if (f.categoryUuids.length > 0) {
+      const hit = e.categories.some((c) => f.categoryUuids.includes(c.uuid))
+      if (!hit) return false
+    }
+    if (f.min > 0 && e.amount < f.min) return false
+    if (f.max > 0 && e.amount > f.max) return false
+    return true
+  })
+}

--- a/frontend/src/expense/pages/ExpenseInsightPage.tsx
+++ b/frontend/src/expense/pages/ExpenseInsightPage.tsx
@@ -4,6 +4,7 @@ import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+import { InsightYearChart, type YearMonth } from "../components/InsightYearChart"
 
 const VIBE_LABELS: { key: string; label: string; field: keyof ExpenseResponse }[] = [
   { key: "ROUTINE", label: "Routine", field: "vibe_planning" },
@@ -30,15 +31,6 @@ interface CategoryStat {
   category: CategoryResponse | null
   amount: number
   pct: number
-}
-
-interface YearMonth {
-  key: string
-  label: string
-  year: number
-  month: number
-  amount: number
-  current: boolean
 }
 
 const computeVibes = (expenses: ExpenseResponse[]): VibeStat[] => {
@@ -107,115 +99,6 @@ const computeYear = (expenses: ExpenseResponse[]): YearMonth[] => {
   return months
 }
 
-interface YearChartProps {
-  year: YearMonth[]
-}
-
-const YearChart = ({ year }: YearChartProps) => {
-  const yMax = Math.max(...year.map((d) => d.amount), 1) * 1.05
-  const total = year.reduce((s, d) => s + d.amount, 0)
-  const avg = Math.round(total / year.length)
-  const peak = year.reduce((max, d) => (d.amount > max.amount ? d : max), year[0])
-  const W = 340
-  const H = 160
-  const pad = 24
-  const xAt = (i: number) => pad + (i / (year.length - 1)) * (W - pad * 2)
-  const yAt = (v: number) => H - 26 - (v / yMax) * (H - 50)
-  const linePath = year.map((d, i) => `${i === 0 ? "M" : "L"} ${xAt(i)} ${yAt(d.amount)}`).join(" ")
-  const areaPath = `${linePath} L ${xAt(year.length - 1)} ${H - 26} L ${pad} ${H - 26} Z`
-
-  return (
-    <div>
-      <div className="flex items-baseline gap-2 px-2 pb-1">
-        <span className="text-xl font-bold tracking-tight tabular-nums">
-          {`¥${(total / 1000).toFixed(1)}k`}
-        </span>
-        <span className="text-xs text-gray-500 dark:text-gray-400">
-          total · ¥{avg.toLocaleString()}/mo avg
-        </span>
-      </div>
-      <svg
-        width="100%"
-        viewBox={`0 0 ${W} ${H}`}
-        preserveAspectRatio="none"
-        className="mt-1.5 block"
-      >
-        <line
-          x1={pad}
-          x2={W - pad}
-          y1={yAt(avg)}
-          y2={yAt(avg)}
-          stroke="currentColor"
-          strokeWidth="0.5"
-          strokeDasharray="3 3"
-          opacity="0.3"
-        />
-        <path d={areaPath} fill="var(--color-primary)" fillOpacity="0.14" />
-        <path
-          d={linePath}
-          fill="none"
-          stroke="var(--color-primary)"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {year.map((d, i) => {
-          const cw = ((W - pad * 2) / year.length) * 0.55
-          const x = xAt(i) - cw / 2
-          const y = yAt(d.amount)
-          return (
-            <rect
-              key={i}
-              x={x}
-              y={y}
-              width={cw}
-              height={H - 26 - y}
-              fill="var(--color-primary)"
-              fillOpacity={d.current ? 0.85 : 0.28}
-              rx="2"
-            />
-          )
-        })}
-        {year.map((d, i) => (
-          <circle
-            key={`p${i}`}
-            cx={xAt(i)}
-            cy={yAt(d.amount)}
-            r={d.current ? 3.5 : 2}
-            fill={d.current ? "var(--color-primary)" : "#ffffff"}
-            stroke="var(--color-primary)"
-            strokeWidth="1.2"
-          />
-        ))}
-        {year.map((d, i) => (
-          <text
-            key={`l${i}`}
-            x={xAt(i)}
-            y={H - 8}
-            textAnchor="middle"
-            fontSize="9"
-            fill="currentColor"
-            opacity={d.current ? 1 : 0.5}
-            fontWeight={d.current ? 700 : 500}
-            fontFamily="inherit"
-          >
-            {d.label}
-          </text>
-        ))}
-      </svg>
-      <div className="flex items-center justify-between px-2 pt-1.5 text-[11px] text-gray-500 dark:text-gray-400">
-        <span className="flex items-center gap-1.5">
-          <span className="h-0.5 w-3.5 bg-primary opacity-50" />
-          monthly avg ¥{avg.toLocaleString()}
-        </span>
-        <span className="tabular-nums">
-          peak ¥{Math.round(peak.amount).toLocaleString()} · {peak.label}
-        </span>
-      </div>
-    </div>
-  )
-}
-
 export const ExpenseInsightPage = () => {
   const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
   const [error, setError] = useState("")
@@ -269,7 +152,6 @@ export const ExpenseInsightPage = () => {
       </div>
 
       <div className="flex-1 overflow-y-auto px-5 pb-8">
-        {/* 1. Vibe ratio */}
         <div className="mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           Why you spent
         </div>
@@ -318,7 +200,6 @@ export const ExpenseInsightPage = () => {
           )}
         </div>
 
-        {/* 2. This month by category */}
         <div className="mt-6 mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           This month by category
         </div>
@@ -371,12 +252,11 @@ export const ExpenseInsightPage = () => {
           )}
         </div>
 
-        {/* 3. Last 12 months */}
         <div className="mt-6 mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           Last 12 months
         </div>
         <div className="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-          <YearChart year={yearMonths} />
+          <InsightYearChart year={yearMonths} />
         </div>
       </div>
     </div>

--- a/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
@@ -4,8 +4,8 @@ import { useSearchParams } from "react-router"
 import { api } from "../../common/libs/api"
 import { getErrorMessage } from "../../common/libs/client"
 import type { ExpenseResponse } from "../../common/libs/types"
-import { defaultFilter, type ExpenseFilter } from "../components/ExpenseFilterSheet"
 import { ExpenseList } from "../components/ExpenseList"
+import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
 
 const isValidDateKey = (s: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(s)
 

--- a/frontend/src/expense/pages/TopPage.tsx
+++ b/frontend/src/expense/pages/TopPage.tsx
@@ -5,6 +5,7 @@ import { api } from "../../common/libs/api"
 import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
 import type { ExpenseResponse } from "../../common/libs/types"
+import { TopHeatmap } from "../components/TopHeatmap"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 
@@ -21,69 +22,6 @@ const dayShort = (iso: string): string => {
 const timeLabel = (iso: string): string => {
   const d = new Date(iso)
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
-interface HeatmapProps {
-  year: number
-  month: number
-  today: number
-  totals: number[]
-  onSelectDay: (day: number) => void
-}
-
-const Heatmap = ({ year, month, today, totals, onSelectDay }: HeatmapProps) => {
-  const daysInMonth = new Date(year, month, 0).getDate()
-  const firstDow = new Date(year, month - 1, 1).getDay()
-  const max = Math.max(...totals, 0)
-
-  return (
-    <div>
-      <div className="mb-1.5 grid grid-cols-7 text-center text-[9px] font-semibold tracking-wide text-gray-400 dark:text-gray-500">
-        {["S", "M", "T", "W", "T", "F", "S"].map((d, i) => (
-          <span key={i}>{d}</span>
-        ))}
-      </div>
-      <div className="grid grid-cols-7 gap-1">
-        {Array.from({ length: firstDow }).map((_, i) => (
-          <div key={`sp${i}`} />
-        ))}
-        {Array.from({ length: daysInMonth }).map((_, i) => {
-          const day = i + 1
-          const v = totals[i] ?? 0
-          const isToday = day === today
-          const isFuture = day > today
-          const intensity = max > 0 ? 22 + (v / max) * 72 : 0
-          const cellStyle =
-            !isFuture && v > 0
-              ? {
-                  background: `color-mix(in oklab, var(--color-primary) ${intensity}%, #edf2f7)`,
-                  color: v / max > 0.5 ? "#fff" : "#4a5568",
-                }
-              : undefined
-          return (
-            <button
-              key={i}
-              type="button"
-              onClick={() => onSelectDay(day)}
-              disabled={isFuture}
-              style={cellStyle}
-              className={`flex aspect-square items-center justify-center rounded-md text-[10px] font-semibold disabled:cursor-default ${
-                isFuture
-                  ? "border border-dashed border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
-                  : isToday
-                    ? "border-[1.5px] border-gray-900 dark:border-gray-100"
-                    : v === 0
-                      ? "bg-gray-100 text-gray-400 dark:bg-gray-700 dark:text-gray-500"
-                      : ""
-              }`}
-            >
-              {day}
-            </button>
-          )
-        })}
-      </div>
-    </div>
-  )
 }
 
 export const TopPage = () => {
@@ -142,7 +80,7 @@ export const TopPage = () => {
       </div>
 
       <div className="shrink-0 pt-4">
-        <Heatmap
+        <TopHeatmap
           year={year}
           month={month}
           today={today}

--- a/frontend/src/setting/components/SettingsRow.tsx
+++ b/frontend/src/setting/components/SettingsRow.tsx
@@ -1,0 +1,40 @@
+import { ChevronRightIcon, RowsIcon } from "@radix-ui/react-icons"
+
+export interface SettingsRowAction {
+  label: string
+  Icon: typeof RowsIcon
+  onClick: () => void
+  accent?: boolean
+  disabled?: boolean
+}
+
+interface SettingsRowProps {
+  row: SettingsRowAction
+  divided: boolean
+}
+
+export const SettingsRow = ({ row, divided }: SettingsRowProps) => {
+  const { Icon } = row
+  return (
+    <button
+      type="button"
+      onClick={row.onClick}
+      disabled={row.disabled}
+      className={`flex w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-gray-50 disabled:opacity-50 dark:hover:bg-gray-700/40 ${
+        divided ? "border-t border-gray-100 dark:border-gray-700" : ""
+      }`}
+    >
+      <span
+        className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${
+          row.accent
+            ? "bg-primary/10 text-primary"
+            : "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
+        }`}
+      >
+        <Icon className="size-4" />
+      </span>
+      <span className="flex-1 truncate text-sm font-semibold">{row.label}</span>
+      <ChevronRightIcon className="size-4 shrink-0 text-gray-300 dark:text-gray-600" />
+    </button>
+  )
+}

--- a/frontend/src/setting/components/SettingsSectionLabel.tsx
+++ b/frontend/src/setting/components/SettingsSectionLabel.tsx
@@ -1,0 +1,9 @@
+interface SettingsSectionLabelProps {
+  children: React.ReactNode
+}
+
+export const SettingsSectionLabel = ({ children }: SettingsSectionLabelProps) => (
+  <div className="px-2 pb-2 text-[10px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+    {children}
+  </div>
+)

--- a/frontend/src/setting/pages/SettingsPage.tsx
+++ b/frontend/src/setting/pages/SettingsPage.tsx
@@ -1,6 +1,5 @@
 import {
   CheckIcon,
-  ChevronRightIcon,
   CounterClockwiseClockIcon,
   DownloadIcon,
   ExitIcon,
@@ -20,19 +19,13 @@ import { getErrorMessage } from "../../common/libs/client"
 import { STORAGE_KEYS } from "../../common/libs/constants"
 import { type ThemeMode, applyTheme, getStoredTheme } from "../../common/libs/theme"
 import type { UserResponse } from "../../common/libs/types"
+import { SettingsRow, type SettingsRowAction } from "../components/SettingsRow"
+import { SettingsSectionLabel } from "../components/SettingsSectionLabel"
 
 interface OutletContext {
   user: UserResponse | null
   onLogout: () => void
   refreshUser: () => Promise<void>
-}
-
-interface RowAction {
-  label: string
-  Icon: typeof RowsIcon
-  onClick: () => void
-  accent?: boolean
-  disabled?: boolean
 }
 
 export const SettingsPage = () => {
@@ -137,7 +130,7 @@ export const SettingsPage = () => {
     }
   }
 
-  const navRows: RowAction[] = [
+  const navRows: SettingsRowAction[] = [
     {
       label: "Categories",
       Icon: RowsIcon,
@@ -158,7 +151,7 @@ export const SettingsPage = () => {
     },
   ]
 
-  const dataRows: RowAction[] = [
+  const dataRows: SettingsRowAction[] = [
     {
       label: "Import data",
       Icon: DownloadIcon,
@@ -232,7 +225,7 @@ export const SettingsPage = () => {
       </div>
 
       <div>
-        <SectionLabel>Preferences</SectionLabel>
+        <SettingsSectionLabel>Preferences</SettingsSectionLabel>
         <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
           <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">Theme</p>
           <div className="flex gap-2">
@@ -255,7 +248,7 @@ export const SettingsPage = () => {
       </div>
 
       <div>
-        <SectionLabel>Your data</SectionLabel>
+        <SettingsSectionLabel>Your data</SettingsSectionLabel>
         <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
           {dataRows.map((row, i) => (
             <SettingsRow key={row.label} row={row} divided={i > 0} />
@@ -271,7 +264,7 @@ export const SettingsPage = () => {
       </div>
 
       <div>
-        <SectionLabel>Account</SectionLabel>
+        <SettingsSectionLabel>Account</SettingsSectionLabel>
         <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
           <button
             type="button"
@@ -323,42 +316,5 @@ export const SettingsPage = () => {
         dialogRef={importDialogRef}
       />
     </div>
-  )
-}
-
-const SectionLabel = ({ children }: { children: React.ReactNode }) => (
-  <div className="px-2 pb-2 text-[10px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-    {children}
-  </div>
-)
-
-interface SettingsRowProps {
-  row: RowAction
-  divided: boolean
-}
-
-const SettingsRow = ({ row, divided }: SettingsRowProps) => {
-  const { Icon } = row
-  return (
-    <button
-      type="button"
-      onClick={row.onClick}
-      disabled={row.disabled}
-      className={`flex w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-gray-50 disabled:opacity-50 dark:hover:bg-gray-700/40 ${
-        divided ? "border-t border-gray-100 dark:border-gray-700" : ""
-      }`}
-    >
-      <span
-        className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${
-          row.accent
-            ? "bg-primary/10 text-primary"
-            : "bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400"
-        }`}
-      >
-        <Icon className="size-4" />
-      </span>
-      <span className="flex-1 truncate text-sm font-semibold">{row.label}</span>
-      <ChevronRightIcon className="size-4 shrink-0 text-gray-300 dark:text-gray-600" />
-    </button>
   )
 }


### PR DESCRIPTION
## Summary
複数コンポーネントが同居していたファイルを分割し、1ファイル1コンポーネントに整理。フィルタ関連のロジックは `libs/expenseFilter.ts` に集約。

## 分割

### 抽出
| 元 | 新規ファイル |
|---|---|
| `VibePicker.tsx` の `Chip` | `expense/components/VibeChip.tsx` |
| `TopPage.tsx` の `Heatmap` | `expense/components/TopHeatmap.tsx` |
| `ExpenseInsightPage.tsx` の `YearChart` | `expense/components/InsightYearChart.tsx` |
| `SettingsPage.tsx` の `SettingsRow` | `setting/components/SettingsRow.tsx` |
| `SettingsPage.tsx` の `SectionLabel` | `setting/components/SettingsSectionLabel.tsx` |
| `ExpenseFilterSheet.tsx` の `ExpenseFilterChips` | `expense/components/ExpenseFilterChips.tsx` |

### ライブラリに集約
- `ExpenseFilterSheet.tsx` 内のフィルタヘルパ (`applyFilter` / `defaultFilter` / `filterCount` / `SCOPE_OPTIONS` / 型) → `expense/libs/expenseFilter.ts`

### インライン化
- `VibePicker.tsx` 内の `Separator` (純粋に装飾的な div) → JSX リテラルとして埋め込み

## 副作用
- `make lint` 全Pass
- 既存のロジック・スタイルは無変更