### PR TITLE
feat: import/export を全 DB スキーマに対応

### DIFF
--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -13,6 +13,7 @@ from src.schema.auth import UserResponse, UserUpdateRequest
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
 from src.schema.user import (
+    ExportRecurringExpenseResponse,
     UserExportResponse,
     UserImportRequest,
     UserImportResponse,
@@ -45,11 +46,12 @@ def export_me(
     db: Annotated[Session, Depends(get_db)],
 ) -> UserExportResponse:
     """現在のユーザーの全データをエクスポート。"""
-    categories, expenses = user_service.export_user_data(db, current_user)
+    categories, expenses, recurrings = user_service.export_user_data(db, current_user)
     return UserExportResponse(
         name=str(current_user.name),
         categories=[CategoryResponse.model_validate(c) for c in categories],
         expenses=[ExpenseResponse.model_validate(e) for e in expenses],
+        recurring_expenses=[ExportRecurringExpenseResponse.model_validate(r) for r in recurrings],
     )
 
 
@@ -60,11 +62,15 @@ def import_me(
     db: Annotated[Session, Depends(get_db)],
 ) -> UserImportResponse:
     """既存データを全削除し、エクスポート済みJSONを再インポート。"""
-    cat_count, exp_count = user_service.import_user_data(db, current_user, body)
+    cat_count, exp_count, rec_count = user_service.import_user_data(db, current_user, body)
     return UserImportResponse(
         categories_count=cat_count,
         expenses_count=exp_count,
-        message=f"Imported {cat_count} categories and {exp_count} expenses",
+        recurring_expenses_count=rec_count,
+        message=(
+            f"Imported {cat_count} categories, {exp_count} expenses, "
+            f"and {rec_count} recurring expenses"
+        ),
     )
 
 

--- a/backend/src/repository/recurring_expense_repository.py
+++ b/backend/src/repository/recurring_expense_repository.py
@@ -87,3 +87,16 @@ def soft_delete(db: Session, recurring: RecurringExpense) -> None:
     """定期支払を論理削除。"""
     recurring.deleted_at = datetime.now(UTC)  # type: ignore[assignment]
     db.commit()
+
+
+def get_all_including_deleted(db: Session, user_uuid: str) -> list[RecurringExpense]:
+    """export用: soft-delete含む全件を取得。"""
+    return db.query(RecurringExpense).filter(RecurringExpense.user_uuid == user_uuid).all()
+
+
+def delete_all_for_user(db: Session, user_uuid: str) -> None:
+    """import用: ユーザーの定期支払を物理削除。"""
+    db.query(RecurringExpense).filter(RecurringExpense.user_uuid == user_uuid).delete(
+        synchronize_session=False,
+    )
+    db.flush()

--- a/backend/src/schema/expense.py
+++ b/backend/src/schema/expense.py
@@ -21,6 +21,7 @@ class ExpenseResponse(BaseModel):
     vibe_social: VibeSocial | None
     vibe_planning: VibePlanning | None
     vibe_necessity: VibeNecessity | None
+    recurring_expense_uuid: str | None
 
 
 class ExpenseCreate(BaseModel):

--- a/backend/src/schema/user.py
+++ b/backend/src/schema/user.py
@@ -1,21 +1,58 @@
 from __future__ import annotations
 
-from pydantic import BaseModel
+from datetime import date
 
+from pydantic import BaseModel, ConfigDict
+
+from src.model.expense import VibeNecessity, VibePlanning, VibeSocial
+from src.model.recurring_expense import IntervalUnit
 from src.schema.category import CategoryResponse
 from src.schema.expense import ExpenseResponse
-from src.schema.types import JstInputDatetime
+from src.schema.types import JstDatetime, JstInputDatetime
+
+
+class ExportRecurringExpenseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    uuid: str
+    name: str
+    amount: int
+    category_uuid: str
+    interval_unit: IntervalUnit
+    interval_count: int
+    start_date: date
+    end_date: date | None
+    created_at: JstDatetime
+    updated_at: JstDatetime
+    deleted_at: JstDatetime | None
 
 
 class UserExportResponse(BaseModel):
     name: str
     categories: list[CategoryResponse]
     expenses: list[ExpenseResponse]
+    recurring_expenses: list[ExportRecurringExpenseResponse]
 
 
 class ImportCategory(BaseModel):
     uuid: str
     name: str
+    symbol: str | None = None
+    position: int = 0
+
+
+class ImportRecurringExpense(BaseModel):
+    uuid: str
+    name: str
+    amount: int
+    category_uuid: str
+    interval_unit: IntervalUnit
+    interval_count: int
+    start_date: date
+    end_date: date | None = None
+    created_at: JstInputDatetime
+    updated_at: JstInputDatetime
+    deleted_at: JstInputDatetime | None = None
 
 
 class ImportExpense(BaseModel):
@@ -26,14 +63,20 @@ class ImportExpense(BaseModel):
     updated_at: JstInputDatetime
     deleted_at: JstInputDatetime | None = None
     categories: list[ImportCategory]
+    vibe_social: VibeSocial | None = None
+    vibe_planning: VibePlanning | None = None
+    vibe_necessity: VibeNecessity | None = None
+    recurring_expense_uuid: str | None = None
 
 
 class UserImportRequest(BaseModel):
     categories: list[ImportCategory]
     expenses: list[ImportExpense]
+    recurring_expenses: list[ImportRecurringExpense] = []
 
 
 class UserImportResponse(BaseModel):
     categories_count: int
     expenses_count: int
+    recurring_expenses_count: int
     message: str

--- a/backend/src/service/user_service.py
+++ b/backend/src/service/user_service.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from src.model.category import Category
 from src.model.expense import Expense
 from src.model.expense_category_association import ExpenseCategoryAssociation
+from src.model.recurring_expense import RecurringExpense
+from src.repository import recurring_expense_repository
 from src.repository.category_repository import (
     delete_all_for_user as delete_all_categories_for_user,
 )
@@ -27,37 +29,72 @@ if TYPE_CHECKING:
 
 def export_user_data(
     db: Session, user: User,
-) -> tuple[list[Category], list[Expense]]:
+) -> tuple[list[Category], list[Expense], list[RecurringExpense]]:
     """ユーザーの全データをexport用に取得。"""
     user_uuid = str(user.uuid)
     categories = get_all_categories(db, user_uuid)
     expenses = get_all_expenses(db, user_uuid, include_deleted=True)
-    return categories, expenses
+    recurrings = recurring_expense_repository.get_all_including_deleted(db, user_uuid)
+    return categories, expenses, recurrings
 
 
 def import_user_data(
     db: Session, user: User, body: UserImportRequest,
-) -> tuple[int, int]:
+) -> tuple[int, int, int]:
     """既存データを全削除し、bodyの内容で再インポート。
 
-    返り値: (categories_count, expenses_count)
+    返り値: (categories_count, expenses_count, recurring_expenses_count)
     """
     user_uuid = str(user.uuid)
 
     # 既存データを一掃 (FK CASCADEでassociationも消える)
     delete_all_expenses_for_user(db, user_uuid)
+    recurring_expense_repository.delete_all_for_user(db, user_uuid)
     delete_all_categories_for_user(db, user_uuid)
 
     # カテゴリを再構築 (旧UUID -> 新UUIDマップ)
     category_uuid_map: dict[str, str] = {}
     for cat in body.categories:
-        new_category = Category(user_uuid=user_uuid, name=cat.name)
+        new_category = Category(
+            user_uuid=user_uuid,
+            name=cat.name,
+            symbol=cat.symbol,
+            position=cat.position,
+        )
         db.add(new_category)
         db.flush()
         category_uuid_map[cat.uuid] = str(new_category.uuid)
 
+    # 定期支払を再構築 (旧UUID -> 新UUIDマップ)
+    recurring_uuid_map: dict[str, str] = {}
+    for rec in body.recurring_expenses:
+        new_cat_uuid = category_uuid_map.get(rec.category_uuid)
+        if not new_cat_uuid:
+            continue
+        new_recurring = RecurringExpense(
+            user_uuid=user_uuid,
+            name=rec.name,
+            amount=rec.amount,
+            category_uuid=new_cat_uuid,
+            interval_unit=rec.interval_unit,
+            interval_count=rec.interval_count,
+            start_date=rec.start_date,
+            end_date=rec.end_date,
+            created_at=rec.created_at,
+            updated_at=rec.updated_at,
+            deleted_at=rec.deleted_at,
+        )
+        db.add(new_recurring)
+        db.flush()
+        recurring_uuid_map[rec.uuid] = str(new_recurring.uuid)
+
     # Expense + association 再構築
     for exp in body.expenses:
+        new_recurring_uuid = (
+            recurring_uuid_map.get(exp.recurring_expense_uuid)
+            if exp.recurring_expense_uuid
+            else None
+        )
         expense = Expense(
             user_uuid=user_uuid,
             name=exp.name,
@@ -66,6 +103,10 @@ def import_user_data(
             created_at=exp.created_at,
             updated_at=exp.updated_at,
             deleted_at=exp.deleted_at,
+            vibe_social=exp.vibe_social,
+            vibe_planning=exp.vibe_planning,
+            vibe_necessity=exp.vibe_necessity,
+            recurring_expense_uuid=new_recurring_uuid,
         )
         db.add(expense)
         db.flush()
@@ -79,4 +120,4 @@ def import_user_data(
                 )
 
     db.commit()
-    return len(body.categories), len(body.expenses)
+    return len(body.categories), len(body.expenses), len(recurring_uuid_map)

--- a/frontend/src/common/libs/types.ts
+++ b/frontend/src/common/libs/types.ts
@@ -56,6 +56,7 @@ export interface ExpenseResponse {
   vibe_social: VibeSocial | null
   vibe_planning: VibePlanning | null
   vibe_necessity: VibeNecessity | null
+  recurring_expense_uuid: string | null
 }
 
 export interface ExpenseCreate {
@@ -86,6 +87,7 @@ export interface UserResponse {
 export interface ImportResponse {
   categories_count: number
   expenses_count: number
+  recurring_expenses_count: number
   message: string
 }
 


### PR DESCRIPTION
## Summary
従来 import/export は category の name のみ、expense の vibe や recurring_expense_uuid、recurring_expenses テーブル全体が欠落していた。今 PR で **DB を丸ごと dump/restore できる** 状態に揃える。

## Export 側の追加
- `UserExportResponse` に `recurring_expenses` を追加 (新規 `ExportRecurringExpenseResponse`)
- `ExpenseResponse` に `recurring_expense_uuid: str | None` を追加 (FE 型側も対応)

## Import 側の追加
- `ImportCategory` に `symbol`, `position` を追加
- `ImportExpense` に `vibe_social/planning/necessity`, `recurring_expense_uuid` を追加
- `UserImportRequest` に `recurring_expenses` を追加 (新規 `ImportRecurringExpense`)
- `UserImportResponse` に `recurring_expenses_count` を追加

## Service 改修
- `export_user_data` が `(categories, expenses, recurring_expenses)` を返却
- `import_user_data` が
  - 既存データを **expenses → recurring_expenses → categories** の順に削除 (FK 整合性)
  - **categories** を symbol/position 込みで再生成
  - **recurring_expenses** を category UUID マップで再生成しつつ旧→新 UUID マップを構築
  - **expenses** を vibe + recurring_expense_uuid 再リンク込みで再生成

## Repository 追加
- `recurring_expense_repository.get_all_including_deleted` (export 用)
- `recurring_expense_repository.delete_all_for_user` (import 用)

## Test plan
- [x] `make lint` Pass
- [x] `make test-backend` Pass (65)
- [ ] 実機で export → import 往復し、recurring + symbol + position + vibe + recurring_expense_uuid 全て保持されることを確認