### PR TITLE
fix: deploy ジョブに setup-python/setup-uv を復元

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -82,6 +82,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "backend/.python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Install Vercel CLI
         run: npm install -g vercel
 


### PR DESCRIPTION
## Summary
PR #120 で migration ジョブを切り出した際、deploy ジョブ側から `actions/setup-python@v6` と `astral-sh/setup-uv@v7` を誤って削除した。Vercel の Python builder は `vercel build` 時に PATH 上の **uv で依存解決** するため、削除後は以下のエラーで build が失敗する。

```
WARNING! Build not running on Vercel. System environment variables will not be available.
Error: uv is required but was not found in PATH.
```

## Fix
deploy ジョブの「Install Vercel CLI」ステップ前に setup-python + setup-uv を復元。

## Test plan
- [ ] `workflow_dispatch` で preview / production 両方のデプロイが成功すること