### PR TITLE
refactor: FE コンポーネントを100行以内に分割

### DIFF
--- a/frontend/src/category/components/CategoryDeleteModal.tsx
+++ b/frontend/src/category/components/CategoryDeleteModal.tsx
@@ -1,0 +1,48 @@
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface CategoryDeleteModalProps {
+  category: CategoryResponse
+  used: number
+  loading: boolean
+  onDelete: () => void
+  onClose: () => void
+}
+
+export const CategoryDeleteModal = ({
+  category,
+  used,
+  loading,
+  onDelete,
+  onClose,
+}: CategoryDeleteModalProps) => {
+  const subtitle =
+    used > 0
+      ? `${used} ${used === 1 ? "expense is" : "expenses are"} tagged with this — they'll become uncategorized.`
+      : "No expenses use this category yet."
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
+      <div className="w-full max-w-xs rounded-2xl bg-white p-5 dark:bg-gray-800">
+        <div className="text-base font-bold">Delete &quot;{category.name}&quot;?</div>
+        <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{subtitle}</div>
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={loading}
+            className="flex-1 rounded-lg bg-red-600 px-3 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/category/components/CategoryGlyphPicker.tsx
+++ b/frontend/src/category/components/CategoryGlyphPicker.tsx
@@ -1,0 +1,67 @@
+const SUGGESTED_GLYPHS = [
+  "🍴",
+  "🚇",
+  "🏠",
+  "🎬",
+  "🛍️",
+  "💼",
+  "💊",
+  "✨",
+  "☕",
+  "🍷",
+  "🛒",
+  "✈️",
+  "📚",
+  "🎵",
+  "🎮",
+  "🐾",
+  "💡",
+  "💳",
+]
+
+export const DEFAULT_GLYPH = SUGGESTED_GLYPHS[0]
+
+interface CategoryGlyphPickerProps {
+  glyph: string
+  onChange: (g: string) => void
+}
+
+export const CategoryGlyphPicker = ({ glyph, onChange }: CategoryGlyphPickerProps) => {
+  const handleInput = (v: string) => {
+    const arr = [...v]
+    onChange(arr.length > 0 ? arr[arr.length - 1] : "")
+  }
+
+  return (
+    <>
+      <div className="mt-6 mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Symbol
+      </div>
+      <input
+        type="text"
+        value={glyph}
+        onChange={(e) => handleInput(e.target.value)}
+        placeholder="Type any emoji or character"
+        maxLength={8}
+        className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-center text-lg outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+      />
+      <div className="mt-3 mb-2.5 text-[11px] text-gray-400 dark:text-gray-500">Suggestions</div>
+      <div className="grid grid-cols-8 gap-1.5">
+        {SUGGESTED_GLYPHS.map((g, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onChange(g)}
+            className={`flex aspect-square items-center justify-center rounded-lg border text-base ${
+              glyph === g
+                ? "border-gray-900 bg-gray-100 dark:border-gray-100 dark:bg-gray-700"
+                : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
+            }`}
+          >
+            {g}
+          </button>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/category/components/CategoryList.tsx
+++ b/frontend/src/category/components/CategoryList.tsx
@@ -1,0 +1,62 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable"
+
+import type { CategoryResponse } from "../../common/libs/types"
+import { CategorySortableRow } from "./CategorySortableRow"
+
+interface CategoryListProps {
+  categories: CategoryResponse[]
+  usage: Record<string, number>
+  onEdit: (uuid: string) => void
+  onMerge: (uuid: string) => void
+  onDelete: (uuid: string) => void
+  onDragEnd: (event: DragEndEvent) => void
+}
+
+export const CategoryList = ({
+  categories,
+  usage,
+  onEdit,
+  onMerge,
+  onDelete,
+  onDragEnd,
+}: CategoryListProps) => {
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <SortableContext items={categories.map((c) => c.uuid)} strategy={verticalListSortingStrategy}>
+        <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+          {categories.map((c) => (
+            <CategorySortableRow
+              key={c.uuid}
+              category={c}
+              used={usage[c.uuid] ?? 0}
+              onEdit={() => onEdit(c.uuid)}
+              onMerge={() => onMerge(c.uuid)}
+              onDelete={() => onDelete(c.uuid)}
+              mergeDisabled={categories.length < 2}
+            />
+          ))}
+        </ul>
+      </SortableContext>
+    </DndContext>
+  )
+}

--- a/frontend/src/category/components/CategoryMergeModal.tsx
+++ b/frontend/src/category/components/CategoryMergeModal.tsx
@@ -1,0 +1,61 @@
+import { categoryGlyph } from "../../common/libs/category"
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface CategoryMergeModalProps {
+  source: CategoryResponse
+  candidates: CategoryResponse[]
+  usage: Record<string, number>
+  loading: boolean
+  onMerge: (targetUuid: string) => void
+  onClose: () => void
+}
+
+export const CategoryMergeModal = ({
+  source,
+  candidates,
+  usage,
+  loading,
+  onMerge,
+  onClose,
+}: CategoryMergeModalProps) => {
+  const sourceUsed = usage[source.uuid] ?? 0
+  const subtitle =
+    sourceUsed > 0
+      ? `${sourceUsed} ${sourceUsed === 1 ? "expense" : "expenses"} will be re-tagged. "${source.name}" will then be removed.`
+      : `"${source.name}" will be removed.`
+
+  return (
+    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
+      <div className="flex max-h-[70%] w-full max-w-sm flex-col rounded-2xl bg-white p-5 dark:bg-gray-800">
+        <div className="text-base font-bold">Merge &quot;{source.name}&quot; into…</div>
+        <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">{subtitle}</div>
+        <div className="-mx-2 mt-3 flex-1 overflow-y-auto">
+          {candidates.map((tc) => (
+            <button
+              key={tc.uuid}
+              type="button"
+              disabled={loading}
+              onClick={() => onMerge(tc.uuid)}
+              className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left hover:bg-gray-50 disabled:opacity-50 dark:hover:bg-gray-700"
+            >
+              <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-sm dark:bg-gray-700">
+                {categoryGlyph(tc)}
+              </span>
+              <span className="flex-1 text-sm font-semibold">{tc.name}</span>
+              <span className="text-[11px] text-gray-400 dark:text-gray-500">
+                {usage[tc.uuid] ?? 0}
+              </span>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-3 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/category/components/CategorySortableRow.tsx
+++ b/frontend/src/category/components/CategorySortableRow.tsx
@@ -1,0 +1,82 @@
+import { useSortable } from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { DragHandleDots2Icon, TrashIcon } from "@radix-ui/react-icons"
+
+import { categoryGlyph } from "../../common/libs/category"
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface CategorySortableRowProps {
+  category: CategoryResponse
+  used: number
+  onEdit: () => void
+  onMerge: () => void
+  onDelete: () => void
+  mergeDisabled: boolean
+}
+
+export const CategorySortableRow = ({
+  category: c,
+  used,
+  onEdit,
+  onMerge,
+  onDelete,
+  mergeDisabled,
+}: CategorySortableRowProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: c.uuid,
+  })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 bg-white px-3.5 py-3 dark:bg-gray-800"
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label="Reorder"
+        className="cursor-grab touch-none p-1 text-gray-400 dark:text-gray-500"
+      >
+        <DragHandleDots2Icon className="size-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="flex min-w-0 flex-1 items-center gap-3 text-left"
+      >
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base font-bold dark:bg-gray-700">
+          {categoryGlyph(c)}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-semibold">{c.name}</div>
+          <div className="text-[11px] text-gray-500 dark:text-gray-400">
+            {used} {used === 1 ? "expense" : "expenses"}
+          </div>
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={onMerge}
+        disabled={mergeDisabled}
+        aria-label="Merge into another"
+        className="p-1 text-base text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
+      >
+        ⇄
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label="Delete"
+        className="p-1 text-red-400 hover:text-red-600"
+      >
+        <TrashIcon className="size-4" />
+      </button>
+    </li>
+  )
+}

--- a/frontend/src/category/hooks/useCategoriesPage.ts
+++ b/frontend/src/category/hooks/useCategoriesPage.ts
@@ -1,0 +1,110 @@
+import { type DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+
+/** カテゴリ一覧のデータ取得・並び替え・統合・削除をまとめて管理。 */
+export const useCategoriesPage = () => {
+  const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [confirmDel, setConfirmDel] = useState<string | null>(null)
+  const [mergingFrom, setMergingFrom] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [cats, exps] = await Promise.all([api.getCategories(), api.getExpenses()])
+      setCategories(cats)
+      setExpenses(exps)
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const usage = useMemo(() => {
+    const map: Record<string, number> = {}
+    for (const e of expenses) {
+      for (const c of e.categories) {
+        map[c.uuid] = (map[c.uuid] ?? 0) + 1
+      }
+    }
+    return map
+  }, [expenses])
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = categories.findIndex((c) => c.uuid === active.id)
+    const newIndex = categories.findIndex((c) => c.uuid === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+    const reordered = arrayMove(categories, oldIndex, newIndex)
+    setCategories(reordered)
+    setError("")
+    try {
+      await api.reorderCategories({ uuids: reordered.map((c) => c.uuid) })
+    } catch (err) {
+      setError(getErrorMessage(err, "Reorder failed"))
+      await fetchData()
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!confirmDel) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.deleteCategory(confirmDel)
+      setConfirmDel(null)
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleMerge = async (targetUuid: string) => {
+    if (!mergingFrom) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.mergeCategory(mergingFrom, { target_uuid: targetUuid })
+      setMergingFrom(null)
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Merge failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const mergingCategory = mergingFrom
+    ? (categories.find((c) => c.uuid === mergingFrom) ?? null)
+    : null
+  const confirmCategory = confirmDel
+    ? (categories.find((c) => c.uuid === confirmDel) ?? null)
+    : null
+
+  return {
+    categories,
+    usage,
+    error,
+    loading,
+    mergingCategory,
+    confirmCategory,
+    mergingFrom,
+    setMergingFrom,
+    setConfirmDel,
+    handleDragEnd,
+    handleDelete,
+    handleMerge,
+  }
+}

--- a/frontend/src/category/hooks/useCategoryEditForm.ts
+++ b/frontend/src/category/hooks/useCategoryEditForm.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate } from "react-router"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import { DEFAULT_GLYPH } from "../components/CategoryGlyphPicker"
+
+/** カテゴリの新規/編集フォーム state とハンドラ。 */
+export const useCategoryEditForm = (uuid: string | undefined) => {
+  const navigate = useNavigate()
+  const isNew = !uuid
+
+  const [name, setName] = useState("")
+  const [glyph, setGlyph] = useState(DEFAULT_GLYPH)
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const fetchExisting = useCallback(async () => {
+    if (!uuid) return
+    try {
+      const cats = await api.getCategories()
+      const c = cats.find((x) => x.uuid === uuid)
+      if (c) {
+        setName(c.name)
+        setGlyph(c.symbol ?? DEFAULT_GLYPH)
+      }
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to load"))
+    }
+  }, [uuid])
+
+  useEffect(() => {
+    fetchExisting()
+  }, [fetchExisting])
+
+  const trimmed = name.trim()
+  const canSave = trimmed.length > 0 && glyph.length > 0
+
+  const save = async () => {
+    if (!canSave) return
+    setError("")
+    setLoading(true)
+    try {
+      if (isNew) {
+        await api.createCategory({ name: trimmed, symbol: glyph })
+      } else if (uuid) {
+        await api.updateCategory(uuid, { name: trimmed, symbol: glyph })
+      }
+      navigate("/category")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    isNew,
+    name,
+    setName,
+    glyph,
+    setGlyph,
+    error,
+    loading,
+    trimmed,
+    canSave,
+    save,
+  }
+}

--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -1,198 +1,27 @@
-import {
-  closestCenter,
-  DndContext,
-  type DragEndEvent,
-  KeyboardSensor,
-  PointerSensor,
-  TouchSensor,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core"
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  useSortable,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
-import { DragHandleDots2Icon, PlusIcon, TrashIcon } from "@radix-ui/react-icons"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { PlusIcon } from "@radix-ui/react-icons"
 import { useNavigate } from "react-router"
 
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
-
-interface SortableRowProps {
-  category: CategoryResponse
-  used: number
-  onEdit: () => void
-  onMerge: () => void
-  onDelete: () => void
-  mergeDisabled: boolean
-}
-
-const SortableRow = ({
-  category: c,
-  used,
-  onEdit,
-  onMerge,
-  onDelete,
-  mergeDisabled,
-}: SortableRowProps) => {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: c.uuid,
-  })
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-  }
-  return (
-    <li
-      ref={setNodeRef}
-      style={style}
-      className="flex items-center gap-3 bg-white px-3.5 py-3 dark:bg-gray-800"
-    >
-      <button
-        type="button"
-        {...attributes}
-        {...listeners}
-        aria-label="Reorder"
-        className="cursor-grab touch-none p-1 text-gray-400 dark:text-gray-500"
-      >
-        <DragHandleDots2Icon className="size-4" />
-      </button>
-      <button
-        type="button"
-        onClick={onEdit}
-        className="flex min-w-0 flex-1 items-center gap-3 text-left"
-      >
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base font-bold dark:bg-gray-700">
-          {categoryGlyph(c)}
-        </span>
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{c.name}</div>
-          <div className="text-[11px] text-gray-500 dark:text-gray-400">
-            {used} {used === 1 ? "expense" : "expenses"}
-          </div>
-        </div>
-      </button>
-      <button
-        type="button"
-        onClick={onMerge}
-        disabled={mergeDisabled}
-        aria-label="Merge into another"
-        className="p-1 text-base text-gray-400 disabled:text-gray-200 dark:text-gray-500 dark:disabled:text-gray-700"
-      >
-        ⇄
-      </button>
-      <button
-        type="button"
-        onClick={onDelete}
-        aria-label="Delete"
-        className="p-1 text-red-400 hover:text-red-600"
-      >
-        <TrashIcon className="size-4" />
-      </button>
-    </li>
-  )
-}
+import { CategoryDeleteModal } from "../components/CategoryDeleteModal"
+import { CategoryList } from "../components/CategoryList"
+import { CategoryMergeModal } from "../components/CategoryMergeModal"
+import { useCategoriesPage } from "../hooks/useCategoriesPage"
 
 export const CategoriesPage = () => {
   const navigate = useNavigate()
-  const [categories, setCategories] = useState<CategoryResponse[]>([])
-  const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-  const [confirmDel, setConfirmDel] = useState<string | null>(null)
-  const [mergingFrom, setMergingFrom] = useState<string | null>(null)
-
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
-  )
-
-  const fetchData = useCallback(async () => {
-    try {
-      const [cats, exps] = await Promise.all([api.getCategories(), api.getExpenses()])
-      setCategories(cats)
-      setExpenses(exps)
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to fetch data"))
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchData()
-  }, [fetchData])
-
-  const usage = useMemo(() => {
-    const map: Record<string, number> = {}
-    for (const e of expenses) {
-      for (const c of e.categories) {
-        map[c.uuid] = (map[c.uuid] ?? 0) + 1
-      }
-    }
-    return map
-  }, [expenses])
-
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-    const oldIndex = categories.findIndex((c) => c.uuid === active.id)
-    const newIndex = categories.findIndex((c) => c.uuid === over.id)
-    if (oldIndex === -1 || newIndex === -1) return
-    const reordered = arrayMove(categories, oldIndex, newIndex)
-    setCategories(reordered)
-    setError("")
-    try {
-      await api.reorderCategories({ uuids: reordered.map((c) => c.uuid) })
-    } catch (err) {
-      setError(getErrorMessage(err, "Reorder failed"))
-      await fetchData()
-    }
-  }
-
-  const handleDelete = async () => {
-    if (!confirmDel) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.deleteCategory(confirmDel)
-      setConfirmDel(null)
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Delete failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleMerge = async (targetUuid: string) => {
-    if (!mergingFrom) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.mergeCategory(mergingFrom, { target_uuid: targetUuid })
-      setMergingFrom(null)
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Merge failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const mergingCategory = mergingFrom
-    ? (categories.find((c) => c.uuid === mergingFrom) ?? null)
-    : null
-  const confirmCategory = confirmDel
-    ? (categories.find((c) => c.uuid === confirmDel) ?? null)
-    : null
+  const {
+    categories,
+    usage,
+    error,
+    loading,
+    mergingCategory,
+    confirmCategory,
+    mergingFrom,
+    setMergingFrom,
+    setConfirmDel,
+    handleDragEnd,
+    handleDelete,
+    handleMerge,
+  } = useCategoriesPage()
 
   return (
     <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
@@ -222,30 +51,14 @@ export const CategoriesPage = () => {
             No categories yet
           </p>
         ) : (
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
+          <CategoryList
+            categories={categories}
+            usage={usage}
+            onEdit={(uuid) => navigate(`/category/${uuid}`)}
+            onMerge={setMergingFrom}
+            onDelete={setConfirmDel}
             onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={categories.map((c) => c.uuid)}
-              strategy={verticalListSortingStrategy}
-            >
-              <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
-                {categories.map((c) => (
-                  <SortableRow
-                    key={c.uuid}
-                    category={c}
-                    used={usage[c.uuid] ?? 0}
-                    onEdit={() => navigate(`/category/${c.uuid}`)}
-                    onMerge={() => setMergingFrom(c.uuid)}
-                    onDelete={() => setConfirmDel(c.uuid)}
-                    mergeDisabled={categories.length < 2}
-                  />
-                ))}
-              </ul>
-            </SortableContext>
-          </DndContext>
+          />
         )}
 
         <button
@@ -259,76 +72,24 @@ export const CategoriesPage = () => {
       </div>
 
       {mergingCategory && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
-          <div className="flex max-h-[70%] w-full max-w-sm flex-col rounded-2xl bg-white p-5 dark:bg-gray-800">
-            <div className="text-base font-bold">
-              Merge &quot;{mergingCategory.name}&quot; into…
-            </div>
-            <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
-              {(usage[mergingCategory.uuid] ?? 0) > 0
-                ? `${usage[mergingCategory.uuid]} ${usage[mergingCategory.uuid] === 1 ? "expense" : "expenses"} will be re-tagged. "${mergingCategory.name}" will then be removed.`
-                : `"${mergingCategory.name}" will be removed.`}
-            </div>
-            <div className="-mx-2 mt-3 flex-1 overflow-y-auto">
-              {categories
-                .filter((c) => c.uuid !== mergingFrom)
-                .map((tc) => (
-                  <button
-                    key={tc.uuid}
-                    type="button"
-                    disabled={loading}
-                    onClick={() => handleMerge(tc.uuid)}
-                    className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2.5 text-left hover:bg-gray-50 disabled:opacity-50 dark:hover:bg-gray-700"
-                  >
-                    <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-sm dark:bg-gray-700">
-                      {categoryGlyph(tc)}
-                    </span>
-                    <span className="flex-1 text-sm font-semibold">{tc.name}</span>
-                    <span className="text-[11px] text-gray-400 dark:text-gray-500">
-                      {usage[tc.uuid] ?? 0}
-                    </span>
-                  </button>
-                ))}
-            </div>
-            <button
-              type="button"
-              onClick={() => setMergingFrom(null)}
-              className="mt-3 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <CategoryMergeModal
+          source={mergingCategory}
+          candidates={categories.filter((c) => c.uuid !== mergingFrom)}
+          usage={usage}
+          loading={loading}
+          onMerge={handleMerge}
+          onClose={() => setMergingFrom(null)}
+        />
       )}
 
       {confirmCategory && (
-        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/45 p-6">
-          <div className="w-full max-w-xs rounded-2xl bg-white p-5 dark:bg-gray-800">
-            <div className="text-base font-bold">Delete &quot;{confirmCategory.name}&quot;?</div>
-            <div className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
-              {(usage[confirmCategory.uuid] ?? 0) > 0
-                ? `${usage[confirmCategory.uuid]} ${usage[confirmCategory.uuid] === 1 ? "expense is" : "expenses are"} tagged with this — they'll become uncategorized.`
-                : "No expenses use this category yet."}
-            </div>
-            <div className="mt-4 flex gap-2">
-              <button
-                type="button"
-                onClick={() => setConfirmDel(null)}
-                className="flex-1 rounded-lg bg-gray-100 px-3 py-2.5 text-sm font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleDelete}
-                disabled={loading}
-                className="flex-1 rounded-lg bg-red-600 px-3 py-2.5 text-sm font-semibold text-white disabled:opacity-50"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-        </div>
+        <CategoryDeleteModal
+          category={confirmCategory}
+          used={usage[confirmCategory.uuid] ?? 0}
+          loading={loading}
+          onDelete={handleDelete}
+          onClose={() => setConfirmDel(null)}
+        />
       )}
     </div>
   )

--- a/frontend/src/category/pages/CategoryEditPage.tsx
+++ b/frontend/src/category/pages/CategoryEditPage.tsx
@@ -1,83 +1,12 @@
-import { useCallback, useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router"
 
-import { api } from "../../common/libs/api"
-import { getErrorMessage } from "../../common/libs/client"
-
-const CAT_GLYPHS = [
-  "🍴",
-  "🚇",
-  "🏠",
-  "🎬",
-  "🛍️",
-  "💼",
-  "💊",
-  "✨",
-  "☕",
-  "🍷",
-  "🛒",
-  "✈️",
-  "📚",
-  "🎵",
-  "🎮",
-  "🐾",
-  "💡",
-  "💳",
-]
+import { CategoryGlyphPicker } from "../components/CategoryGlyphPicker"
+import { useCategoryEditForm } from "../hooks/useCategoryEditForm"
 
 export const CategoryEditPage = () => {
   const navigate = useNavigate()
   const { uuid } = useParams<{ uuid: string }>()
-  const isNew = !uuid
-
-  const [name, setName] = useState("")
-  const [glyph, setGlyph] = useState(CAT_GLYPHS[0])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-
-  const fetchExisting = useCallback(async () => {
-    if (!uuid) return
-    try {
-      const cats = await api.getCategories()
-      const c = cats.find((x) => x.uuid === uuid)
-      if (c) {
-        setName(c.name)
-        setGlyph(c.symbol ?? CAT_GLYPHS[0])
-      }
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to load"))
-    }
-  }, [uuid])
-
-  useEffect(() => {
-    fetchExisting()
-  }, [fetchExisting])
-
-  const trimmed = name.trim()
-  const canSave = trimmed.length > 0 && glyph.length > 0
-
-  const save = async () => {
-    if (!canSave) return
-    setError("")
-    setLoading(true)
-    try {
-      if (isNew) {
-        await api.createCategory({ name: trimmed, symbol: glyph })
-      } else if (uuid) {
-        await api.updateCategory(uuid, { name: trimmed, symbol: glyph })
-      }
-      navigate("/category")
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to save"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const onGlyphInput = (v: string) => {
-    const arr = [...v]
-    setGlyph(arr.length > 0 ? arr[arr.length - 1] : "")
-  }
+  const f = useCategoryEditForm(uuid)
 
   return (
     <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
@@ -89,69 +18,42 @@ export const CategoryEditPage = () => {
         >
           Cancel
         </button>
-        <h1 className="text-base font-semibold">{isNew ? "New category" : "Edit category"}</h1>
+        <h1 className="text-base font-semibold">{f.isNew ? "New category" : "Edit category"}</h1>
         <button
           type="button"
-          onClick={save}
-          disabled={!canSave || loading}
+          onClick={f.save}
+          disabled={!f.canSave || f.loading}
           className="text-sm font-bold text-primary disabled:text-gray-300 dark:disabled:text-gray-600"
         >
           Save
         </button>
       </div>
 
-      {error && (
-        <p className="shrink-0 px-5 pb-2 text-sm text-red-600 dark:text-red-400">{error}</p>
+      {f.error && (
+        <p className="shrink-0 px-5 pb-2 text-sm text-red-600 dark:text-red-400">{f.error}</p>
       )}
 
       <div className="flex-1 overflow-y-auto px-5 pt-5 pb-10">
         <div className="flex justify-center py-5">
           <div className="flex size-21 items-center justify-center rounded-3xl border border-gray-200 bg-white text-4xl font-bold dark:border-gray-700 dark:bg-gray-800">
-            {glyph || "·"}
+            {f.glyph || "·"}
           </div>
         </div>
-        <div className="mb-6 text-center text-sm font-semibold">{trimmed || "Untitled"}</div>
+        <div className="mb-6 text-center text-sm font-semibold">{f.trimmed || "Untitled"}</div>
 
         <div className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
           Name
         </div>
         <input
           type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
+          value={f.name}
+          onChange={(e) => f.setName(e.target.value)}
           placeholder="e.g. Coffee"
           maxLength={50}
           className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-base outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
         />
 
-        <div className="mt-6 mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-          Symbol
-        </div>
-        <input
-          type="text"
-          value={glyph}
-          onChange={(e) => onGlyphInput(e.target.value)}
-          placeholder="Type any emoji or character"
-          maxLength={8}
-          className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-center text-lg outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-        />
-        <div className="mt-3 mb-2.5 text-[11px] text-gray-400 dark:text-gray-500">Suggestions</div>
-        <div className="grid grid-cols-8 gap-1.5">
-          {CAT_GLYPHS.map((g, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => setGlyph(g)}
-              className={`flex aspect-square items-center justify-center rounded-lg border text-base ${
-                glyph === g
-                  ? "border-gray-900 bg-gray-100 dark:border-gray-100 dark:bg-gray-700"
-                  : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800"
-              }`}
-            >
-              {g}
-            </button>
-          ))}
-        </div>
+        <CategoryGlyphPicker glyph={f.glyph} onChange={f.setGlyph} />
       </div>
     </div>
   )

--- a/frontend/src/expense-recurring/components/RecurringCategoryPicker.tsx
+++ b/frontend/src/expense-recurring/components/RecurringCategoryPicker.tsx
@@ -1,0 +1,40 @@
+import { categoryGlyph } from "../../common/libs/category"
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface RecurringCategoryPickerProps {
+  categories: CategoryResponse[]
+  selectedUuid: string
+  onChange: (uuid: string) => void
+}
+
+export const RecurringCategoryPicker = ({
+  categories,
+  selectedUuid,
+  onChange,
+}: RecurringCategoryPickerProps) => (
+  <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+    <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">Category</div>
+    <div className="flex flex-wrap gap-2">
+      {categories.map((c) => (
+        <button
+          key={c.uuid}
+          type="button"
+          onClick={() => onChange(c.uuid)}
+          className={`rounded-full px-4 py-2 text-sm transition-colors ${
+            selectedUuid === c.uuid
+              ? "bg-primary text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+          }`}
+        >
+          <span className="mr-1">{categoryGlyph(c)}</span>
+          {c.name}
+        </button>
+      ))}
+    </div>
+    {categories.length === 0 && (
+      <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+        Create a category first from /category
+      </p>
+    )}
+  </div>
+)

--- a/frontend/src/expense-recurring/components/RecurringDueList.tsx
+++ b/frontend/src/expense-recurring/components/RecurringDueList.tsx
@@ -1,0 +1,48 @@
+import type { RecurringExpenseDueResponse } from "../../common/libs/types"
+
+const formatDate = (iso: string): string => {
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+interface RecurringDueListProps {
+  due: RecurringExpenseDueResponse[]
+  loading: boolean
+  onRecord: (uuid: string, missedCount: number) => void
+}
+
+export const RecurringDueList = ({ due, loading, onRecord }: RecurringDueListProps) => {
+  if (due.length === 0) return null
+
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+      <div className="mb-3 text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
+        Coming up
+      </div>
+      <div className="flex flex-col gap-3">
+        {due.map((d) => (
+          <button
+            key={d.uuid}
+            type="button"
+            onClick={() => onRecord(d.uuid, d.missed_count)}
+            disabled={loading}
+            className="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3 text-left hover:bg-gray-100 disabled:opacity-50 dark:bg-gray-700 dark:hover:bg-gray-600"
+          >
+            <div className="flex flex-1 flex-col">
+              <div className="text-sm font-medium">{d.name}</div>
+              <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                {d.missed_count > 1
+                  ? `${d.missed_count} unrecorded · oldest ${formatDate(d.missed_dates[0])}`
+                  : `due ${formatDate(d.missed_dates[0])}`}
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-sm font-medium">¥{d.amount.toLocaleString("en-US")}</div>
+              <div className="mt-0.5 text-xs text-primary">Tap to record</div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense-recurring/components/RecurringFormActions.tsx
+++ b/frontend/src/expense-recurring/components/RecurringFormActions.tsx
@@ -1,0 +1,43 @@
+interface RecurringFormActionsProps {
+  isEdit: boolean
+  loading: boolean
+  canSubmit: boolean
+  onCancel: () => void
+  onOpenDelete: () => void
+}
+
+export const RecurringFormActions = ({
+  isEdit,
+  loading,
+  canSubmit,
+  onCancel,
+  onOpenDelete,
+}: RecurringFormActionsProps) => (
+  <div className="flex flex-col gap-3">
+    <button
+      type="submit"
+      disabled={loading || !canSubmit}
+      className="rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover disabled:opacity-50"
+    >
+      {loading ? "Saving..." : isEdit ? "Save" : "Create"}
+    </button>
+    <button
+      type="button"
+      onClick={onCancel}
+      disabled={loading}
+      className="rounded-2xl border border-gray-200 py-3 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+    >
+      Cancel
+    </button>
+    {isEdit && (
+      <button
+        type="button"
+        onClick={onOpenDelete}
+        disabled={loading}
+        className="mt-4 rounded-2xl py-3 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
+      >
+        Stop this recurring
+      </button>
+    )}
+  </div>
+)

--- a/frontend/src/expense-recurring/components/RecurringFrequencyGroup.tsx
+++ b/frontend/src/expense-recurring/components/RecurringFrequencyGroup.tsx
@@ -1,0 +1,80 @@
+import { ChevronRightIcon } from "@radix-ui/react-icons"
+import { useNavigate } from "react-router"
+
+import { categoryGlyph } from "../../common/libs/category"
+import type { RecurringExpenseDueResponse, RecurringExpenseResponse } from "../../common/libs/types"
+import { type FrequencyOption, monthlyEquivalent, PERIOD_LABEL } from "../libs/recurringFrequency"
+
+const formatDate = (iso: string): string => {
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+const nextDueOf = (
+  r: RecurringExpenseResponse,
+  due: RecurringExpenseDueResponse[],
+): string | null => {
+  const d = due.find((x) => x.uuid === r.uuid)
+  return d && d.missed_dates.length > 0 ? d.missed_dates[0] : null
+}
+
+interface RecurringFrequencyGroupProps {
+  group: FrequencyOption
+  items: RecurringExpenseResponse[]
+  due: RecurringExpenseDueResponse[]
+}
+
+export const RecurringFrequencyGroup = ({ group, items, due }: RecurringFrequencyGroupProps) => {
+  const navigate = useNavigate()
+  if (items.length === 0) return null
+
+  const groupTotal = items.reduce(
+    (sum, r) => sum + monthlyEquivalent(r.amount, r.interval_unit, r.interval_count),
+    0,
+  )
+
+  return (
+    <div className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-gray-800">
+      <div className="flex items-center justify-between px-5 py-3 text-xs font-medium text-gray-500 dark:text-gray-400">
+        <span>{group.label}</span>
+        <span>
+          {items.length} · ¥{groupTotal.toLocaleString("en-US")}/mo
+        </span>
+      </div>
+      <div className="divide-y divide-gray-100 dark:divide-gray-700">
+        {items.map((r) => {
+          const next = nextDueOf(r, due)
+          return (
+            <button
+              key={r.uuid}
+              type="button"
+              onClick={() => navigate(`/expense/recurring/${r.uuid}`)}
+              className="flex w-full items-center gap-3 px-5 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              <div className="flex flex-1 flex-col">
+                <div className="text-sm font-medium">{r.name}</div>
+                <div className="mt-0.5 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  <span>{categoryGlyph(r.category)}</span>
+                  <span>{r.category.name}</span>
+                  {next && (
+                    <>
+                      <span>·</span>
+                      <span>next {formatDate(next)}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+              <div className="text-right">
+                <div className="text-sm font-medium">¥{r.amount.toLocaleString("en-US")}</div>
+                <div className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
+                  {PERIOD_LABEL[group.key]}
+                </div>
+              </div>
+              <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense-recurring/components/RecurringFrequencyPicker.tsx
+++ b/frontend/src/expense-recurring/components/RecurringFrequencyPicker.tsx
@@ -1,0 +1,31 @@
+import { FREQUENCY_OPTIONS } from "../libs/recurringFrequency"
+
+interface RecurringFrequencyPickerProps {
+  selectedKey: string
+  onChange: (key: string) => void
+}
+
+export const RecurringFrequencyPicker = ({
+  selectedKey,
+  onChange,
+}: RecurringFrequencyPickerProps) => (
+  <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+    <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">How often</div>
+    <div className="flex flex-wrap gap-2">
+      {FREQUENCY_OPTIONS.map((f) => (
+        <button
+          key={f.key}
+          type="button"
+          onClick={() => onChange(f.key)}
+          className={`rounded-full px-4 py-2 text-sm transition-colors ${
+            selectedKey === f.key
+              ? "bg-primary text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+          }`}
+        >
+          {f.label}
+        </button>
+      ))}
+    </div>
+  </div>
+)

--- a/frontend/src/expense-recurring/components/RecurringNameAmountFields.tsx
+++ b/frontend/src/expense-recurring/components/RecurringNameAmountFields.tsx
@@ -1,0 +1,49 @@
+interface RecurringNameAmountFieldsProps {
+  name: string
+  amount: string
+  onNameChange: (v: string) => void
+  onAmountChange: (v: string) => void
+}
+
+export const RecurringNameAmountFields = ({
+  name,
+  amount,
+  onNameChange,
+  onAmountChange,
+}: RecurringNameAmountFieldsProps) => {
+  const handleAmount = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, "")
+    onAmountChange(digits ? Number(digits).toLocaleString() : "")
+  }
+
+  return (
+    <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
+      <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-name">
+        Name this recurring
+      </label>
+      <input
+        id="recurring-name"
+        type="text"
+        value={name}
+        onChange={(e) => onNameChange(e.target.value)}
+        required
+        maxLength={50}
+        placeholder="House cleaner"
+        className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-lg outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+      />
+      <div className="mt-4 flex items-baseline gap-1">
+        <span className="text-2xl text-gray-400">¥</span>
+        <input
+          id="recurring-amount"
+          type="text"
+          inputMode="numeric"
+          value={amount}
+          onChange={(e) => handleAmount(e.target.value)}
+          required
+          placeholder="0"
+          className="flex-1 border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-2xl outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense-recurring/components/RecurringSummaryCard.tsx
+++ b/frontend/src/expense-recurring/components/RecurringSummaryCard.tsx
@@ -1,0 +1,16 @@
+interface RecurringSummaryCardProps {
+  totalMonthly: number
+  count: number
+}
+
+export const RecurringSummaryCard = ({ totalMonthly, count }: RecurringSummaryCardProps) => (
+  <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-gray-800">
+    <div className="text-xs text-gray-500 dark:text-gray-400">Every month</div>
+    <div className="mt-1 text-3xl font-light tracking-tight">
+      ¥{totalMonthly.toLocaleString("en-US")}
+    </div>
+    <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+      {count} {count === 1 ? "recurring" : "recurrings"}
+    </div>
+  </div>
+)

--- a/frontend/src/expense-recurring/hooks/useRecurringExpenseForm.ts
+++ b/frontend/src/expense-recurring/hooks/useRecurringExpenseForm.ts
@@ -1,0 +1,120 @@
+import { type SubmitEvent, useCallback, useEffect, useState } from "react"
+import { useNavigate } from "react-router"
+
+import { useConfirmDialog } from "../../common/components/ConfirmDialog"
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type {
+  CategoryResponse,
+  RecurringExpenseCreate,
+  RecurringExpenseUpdate,
+} from "../../common/libs/types"
+import { FREQUENCY_OPTIONS, matchFrequency, todayJst } from "../libs/recurringFrequency"
+
+/** 定期支払の新規/編集フォームの state とハンドラ。uuid 指定時は edit モード。 */
+export const useRecurringExpenseForm = (uuid: string | undefined) => {
+  const navigate = useNavigate()
+  const isEdit = Boolean(uuid)
+
+  const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+  const { dialogRef, open: openDeleteDialog } = useConfirmDialog()
+
+  const [name, setName] = useState("")
+  const [amount, setAmount] = useState("")
+  const [frequencyKey, setFrequencyKey] = useState("monthly")
+  const [startDate, setStartDate] = useState(todayJst)
+  const [categoryUuid, setCategoryUuid] = useState("")
+
+  const fetchData = useCallback(async () => {
+    try {
+      const cats = await api.getCategories()
+      setCategories(cats)
+      if (uuid) {
+        const r = await api.getRecurringExpense(uuid)
+        setName(r.name)
+        setAmount(r.amount.toLocaleString())
+        setFrequencyKey(matchFrequency(r.interval_unit, r.interval_count))
+        setStartDate(r.start_date)
+        setCategoryUuid(r.category.uuid)
+      } else if (cats.length > 0) {
+        setCategoryUuid(cats[0].uuid)
+      }
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [uuid])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+    const freq = FREQUENCY_OPTIONS.find((f) => f.key === frequencyKey)
+    if (!freq) {
+      setError("Invalid frequency")
+      setLoading(false)
+      return
+    }
+    const payload = {
+      name,
+      amount: Number(amount.replace(/,/g, "")),
+      interval_unit: freq.unit,
+      interval_count: freq.count,
+      start_date: startDate,
+      category_uuid: categoryUuid,
+    }
+    try {
+      if (isEdit && uuid) {
+        await api.updateRecurringExpense(uuid, payload satisfies RecurringExpenseUpdate)
+      } else {
+        await api.createRecurringExpense(payload satisfies RecurringExpenseCreate)
+      }
+      navigate("/expense/recurring")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to save"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!uuid) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.deleteRecurringExpense(uuid)
+      dialogRef.current?.close()
+      navigate("/expense/recurring")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to delete"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    isEdit,
+    categories,
+    error,
+    loading,
+    dialogRef,
+    openDeleteDialog,
+    name,
+    setName,
+    amount,
+    setAmount,
+    frequencyKey,
+    setFrequencyKey,
+    startDate,
+    setStartDate,
+    categoryUuid,
+    setCategoryUuid,
+    handleSubmit,
+    handleDelete,
+  }
+}

--- a/frontend/src/expense-recurring/hooks/useRecurringList.ts
+++ b/frontend/src/expense-recurring/hooks/useRecurringList.ts
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type { RecurringExpenseDueResponse, RecurringExpenseResponse } from "../../common/libs/types"
+import { FREQUENCY_OPTIONS, monthlyEquivalent } from "../libs/recurringFrequency"
+
+const groupKeyOf = (r: RecurringExpenseResponse): string | null =>
+  FREQUENCY_OPTIONS.find((g) => g.unit === r.interval_unit && g.count === r.interval_count)?.key ??
+  null
+
+/** 定期支払一覧と due (期日到来分) のデータ取得 + 月次合計 + グループ化を提供。 */
+export const useRecurringList = () => {
+  const [items, setItems] = useState<RecurringExpenseResponse[]>([])
+  const [due, setDue] = useState<RecurringExpenseDueResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [list, dueList] = await Promise.all([
+        api.getRecurringExpenses(),
+        api.getRecurringExpenseDue(),
+      ])
+      setItems(list)
+      setDue(dueList)
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const totalMonthly = useMemo(
+    () =>
+      items.reduce(
+        (sum, r) => sum + monthlyEquivalent(r.amount, r.interval_unit, r.interval_count),
+        0,
+      ),
+    [items],
+  )
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, RecurringExpenseResponse[]>()
+    for (const g of FREQUENCY_OPTIONS) {
+      map.set(g.key, [])
+    }
+    for (const r of items) {
+      const k = groupKeyOf(r)
+      if (k) map.get(k)?.push(r)
+    }
+    return map
+  }, [items])
+
+  const handleRecord = async (uuid: string, missedCount: number) => {
+    setError("")
+    setLoading(true)
+    try {
+      await api.recordRecurringExpense(uuid, { count: missedCount })
+      await fetchData()
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to record"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { items, due, error, loading, totalMonthly, grouped, handleRecord }
+}

--- a/frontend/src/expense-recurring/libs/recurringFrequency.ts
+++ b/frontend/src/expense-recurring/libs/recurringFrequency.ts
@@ -1,0 +1,45 @@
+import type { IntervalUnit } from "../../common/libs/types"
+
+export interface FrequencyOption {
+  key: string
+  label: string
+  unit: IntervalUnit
+  count: number
+}
+
+export const FREQUENCY_OPTIONS: FrequencyOption[] = [
+  { key: "weekly", label: "Weekly", unit: "WEEK", count: 1 },
+  { key: "biweekly", label: "Every 2 wk", unit: "WEEK", count: 2 },
+  { key: "monthly", label: "Monthly", unit: "MONTH", count: 1 },
+  { key: "quarterly", label: "Quarterly", unit: "MONTH", count: 3 },
+  { key: "yearly", label: "Yearly", unit: "MONTH", count: 12 },
+]
+
+export const matchFrequency = (unit: IntervalUnit, count: number): string =>
+  FREQUENCY_OPTIONS.find((f) => f.unit === unit && f.count === count)?.key ?? "monthly"
+
+/** JST 今日の YYYY-MM-DD を返す。OS タイムゾーン非依存。 */
+export const todayJst = (): string => {
+  const now = new Date()
+  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
+  return jst.toISOString().slice(0, 10)
+}
+
+export const PERIOD_LABEL: Record<string, string> = {
+  weekly: "/ wk",
+  biweekly: "/ 2wk",
+  monthly: "/ mo",
+  quarterly: "/ 3mo",
+  yearly: "/ yr",
+}
+
+/** 月次概算合計を算出 (週次は約4.345倍、年次は1/12)。 */
+export const monthlyEquivalent = (amount: number, unit: IntervalUnit, count: number): number => {
+  if (unit === "WEEK") {
+    return Math.round((amount * 4.345) / count)
+  }
+  return Math.round(amount / count)
+}
+
+export const groupOf = (unit: IntervalUnit, count: number): FrequencyOption | null =>
+  FREQUENCY_OPTIONS.find((g) => g.unit === unit && g.count === count) ?? null

--- a/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseEditPage.tsx
@@ -1,194 +1,30 @@
-import { type SubmitEvent, useCallback, useEffect, useState } from "react"
 import { useNavigate, useParams } from "react-router"
 
-import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type {
-  CategoryResponse,
-  IntervalUnit,
-  RecurringExpenseCreate,
-  RecurringExpenseUpdate,
-} from "../../common/libs/types"
-
-interface FrequencyOption {
-  key: string
-  label: string
-  unit: IntervalUnit
-  count: number
-}
-
-const FREQUENCY_OPTIONS: FrequencyOption[] = [
-  { key: "weekly", label: "Weekly", unit: "WEEK", count: 1 },
-  { key: "biweekly", label: "Every 2 wk", unit: "WEEK", count: 2 },
-  { key: "monthly", label: "Monthly", unit: "MONTH", count: 1 },
-  { key: "quarterly", label: "Quarterly", unit: "MONTH", count: 3 },
-  { key: "yearly", label: "Yearly", unit: "MONTH", count: 12 },
-]
-
-const matchFrequency = (unit: IntervalUnit, count: number): string =>
-  FREQUENCY_OPTIONS.find((f) => f.unit === unit && f.count === count)?.key ?? "monthly"
-
-const todayJst = (): string => {
-  const now = new Date()
-  const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
-  return jst.toISOString().slice(0, 10)
-}
+import { ConfirmDialog } from "../../common/components/ConfirmDialog"
+import { RecurringCategoryPicker } from "../components/RecurringCategoryPicker"
+import { RecurringFormActions } from "../components/RecurringFormActions"
+import { RecurringFrequencyPicker } from "../components/RecurringFrequencyPicker"
+import { RecurringNameAmountFields } from "../components/RecurringNameAmountFields"
+import { useRecurringExpenseForm } from "../hooks/useRecurringExpenseForm"
 
 export const RecurringExpenseEditPage = () => {
   const navigate = useNavigate()
   const { uuid } = useParams<{ uuid: string }>()
-  const isEdit = Boolean(uuid)
-
-  const [categories, setCategories] = useState<CategoryResponse[]>([])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-  const { dialogRef, open: openDialog } = useConfirmDialog()
-
-  const [name, setName] = useState("")
-  const [amount, setAmount] = useState("")
-  const [frequencyKey, setFrequencyKey] = useState("monthly")
-  const [startDate, setStartDate] = useState(todayJst)
-  const [categoryUuid, setCategoryUuid] = useState("")
-
-  const fetchData = useCallback(async () => {
-    try {
-      const cats = await api.getCategories()
-      setCategories(cats)
-      if (uuid) {
-        const r = await api.getRecurringExpense(uuid)
-        setName(r.name)
-        setAmount(r.amount.toLocaleString())
-        setFrequencyKey(matchFrequency(r.interval_unit, r.interval_count))
-        setStartDate(r.start_date)
-        setCategoryUuid(r.category.uuid)
-      } else if (cats.length > 0) {
-        setCategoryUuid(cats[0].uuid)
-      }
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to fetch data"))
-    }
-  }, [uuid])
-
-  useEffect(() => {
-    fetchData()
-  }, [fetchData])
-
-  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    setError("")
-    setLoading(true)
-    const freq = FREQUENCY_OPTIONS.find((f) => f.key === frequencyKey)
-    if (!freq) {
-      setError("Invalid frequency")
-      setLoading(false)
-      return
-    }
-    try {
-      if (isEdit && uuid) {
-        const data: RecurringExpenseUpdate = {
-          name,
-          amount: Number(amount.replace(/,/g, "")),
-          interval_unit: freq.unit,
-          interval_count: freq.count,
-          start_date: startDate,
-          category_uuid: categoryUuid,
-        }
-        await api.updateRecurringExpense(uuid, data)
-      } else {
-        const data: RecurringExpenseCreate = {
-          name,
-          amount: Number(amount.replace(/,/g, "")),
-          interval_unit: freq.unit,
-          interval_count: freq.count,
-          start_date: startDate,
-          category_uuid: categoryUuid,
-        }
-        await api.createRecurringExpense(data)
-      }
-      navigate("/expense/recurring")
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to save"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleDelete = async () => {
-    if (!uuid) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.deleteRecurringExpense(uuid)
-      dialogRef.current?.close()
-      navigate("/expense/recurring")
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to delete"))
-    } finally {
-      setLoading(false)
-    }
-  }
+  const form = useRecurringExpenseForm(uuid)
 
   return (
-    <form onSubmit={handleSubmit} className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
-      {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+    <form onSubmit={form.handleSubmit} className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
+      {form.error && <p className="text-sm text-red-600 dark:text-red-400">{form.error}</p>}
 
-      {/* Name + amount card */}
-      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
-        <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-name">
-          Name this recurring
-        </label>
-        <input
-          id="recurring-name"
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          required
-          maxLength={50}
-          placeholder="House cleaner"
-          className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-lg outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
-        />
-        <div className="mt-4 flex items-baseline gap-1">
-          <span className="text-2xl text-gray-400">¥</span>
-          <input
-            id="recurring-amount"
-            type="text"
-            inputMode="numeric"
-            value={amount}
-            onChange={(e) => {
-              const raw = e.target.value.replace(/[^0-9]/g, "")
-              setAmount(raw ? Number(raw).toLocaleString() : "")
-            }}
-            required
-            placeholder="0"
-            className="flex-1 border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 text-2xl outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
-          />
-        </div>
-      </div>
+      <RecurringNameAmountFields
+        name={form.name}
+        amount={form.amount}
+        onNameChange={form.setName}
+        onAmountChange={form.setAmount}
+      />
 
-      {/* Frequency */}
-      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
-        <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">How often</div>
-        <div className="flex flex-wrap gap-2">
-          {FREQUENCY_OPTIONS.map((f) => (
-            <button
-              key={f.key}
-              type="button"
-              onClick={() => setFrequencyKey(f.key)}
-              className={`rounded-full px-4 py-2 text-sm transition-colors ${
-                frequencyKey === f.key
-                  ? "bg-primary text-white"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-              }`}
-            >
-              {f.label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <RecurringFrequencyPicker selectedKey={form.frequencyKey} onChange={form.setFrequencyKey} />
 
-      {/* Start date */}
       <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
         <label className="text-xs text-gray-500 dark:text-gray-400" htmlFor="recurring-start">
           Start date
@@ -196,75 +32,33 @@ export const RecurringExpenseEditPage = () => {
         <input
           id="recurring-start"
           type="date"
-          value={startDate}
-          onChange={(e) => setStartDate(e.target.value)}
+          value={form.startDate}
+          onChange={(e) => form.setStartDate(e.target.value)}
           required
           className="mt-1 w-full border-x-0 border-t-0 border-b border-gray-200 bg-transparent py-2 outline-none focus:border-primary dark:border-gray-700 dark:text-gray-100"
         />
       </div>
 
-      {/* Category */}
-      <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
-        <div className="mb-3 text-xs text-gray-500 dark:text-gray-400">Category</div>
-        <div className="flex flex-wrap gap-2">
-          {categories.map((c) => (
-            <button
-              key={c.uuid}
-              type="button"
-              onClick={() => setCategoryUuid(c.uuid)}
-              className={`rounded-full px-4 py-2 text-sm transition-colors ${
-                categoryUuid === c.uuid
-                  ? "bg-primary text-white"
-                  : "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
-              }`}
-            >
-              <span className="mr-1">{categoryGlyph(c)}</span>
-              {c.name}
-            </button>
-          ))}
-        </div>
-        {categories.length === 0 && (
-          <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
-            Create a category first from /category
-          </p>
-        )}
-      </div>
+      <RecurringCategoryPicker
+        categories={form.categories}
+        selectedUuid={form.categoryUuid}
+        onChange={form.setCategoryUuid}
+      />
 
-      {/* Actions */}
-      <div className="flex flex-col gap-3">
-        <button
-          type="submit"
-          disabled={loading || !categoryUuid}
-          className="rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover disabled:opacity-50"
-        >
-          {loading ? "Saving..." : isEdit ? "Save" : "Create"}
-        </button>
-        <button
-          type="button"
-          onClick={() => navigate("/expense/recurring")}
-          disabled={loading}
-          className="rounded-2xl border border-gray-200 py-3 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-        >
-          Cancel
-        </button>
-        {isEdit && (
-          <button
-            type="button"
-            onClick={openDialog}
-            disabled={loading}
-            className="mt-4 rounded-2xl py-3 text-sm text-red-600 hover:bg-red-50 disabled:opacity-50 dark:text-red-400 dark:hover:bg-red-900/20"
-          >
-            Stop this recurring
-          </button>
-        )}
-      </div>
+      <RecurringFormActions
+        isEdit={form.isEdit}
+        loading={form.loading}
+        canSubmit={Boolean(form.categoryUuid)}
+        onCancel={() => navigate("/expense/recurring")}
+        onOpenDelete={form.openDeleteDialog}
+      />
 
       <ConfirmDialog
-        message={`Stop "${name}"? Past records remain unchanged.`}
-        onConfirm={handleDelete}
+        message={`Stop "${form.name}"? Past records remain unchanged.`}
+        onConfirm={form.handleDelete}
         confirmText="Stop"
-        loading={loading}
-        dialogRef={dialogRef}
+        loading={form.loading}
+        dialogRef={form.dialogRef}
       />
     </form>
   )

--- a/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
+++ b/frontend/src/expense-recurring/pages/RecurringExpenseListPage.tsx
@@ -1,172 +1,23 @@
-import { ChevronRightIcon, PlusIcon } from "@radix-ui/react-icons"
-import { useCallback, useEffect, useMemo, useState } from "react"
-import { Link, useNavigate } from "react-router"
+import { PlusIcon } from "@radix-ui/react-icons"
+import { Link } from "react-router"
 
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type {
-  IntervalUnit,
-  RecurringExpenseDueResponse,
-  RecurringExpenseResponse,
-} from "../../common/libs/types"
-
-interface FrequencyGroup {
-  key: string
-  label: string
-  unit: IntervalUnit
-  count: number
-}
-
-const FREQUENCY_GROUPS: FrequencyGroup[] = [
-  { key: "weekly", label: "Weekly", unit: "WEEK", count: 1 },
-  { key: "biweekly", label: "Every 2 wk", unit: "WEEK", count: 2 },
-  { key: "monthly", label: "Monthly", unit: "MONTH", count: 1 },
-  { key: "quarterly", label: "Quarterly", unit: "MONTH", count: 3 },
-  { key: "yearly", label: "Yearly", unit: "MONTH", count: 12 },
-]
-
-const PERIOD_LABEL: Record<string, string> = {
-  weekly: "/ wk",
-  biweekly: "/ 2wk",
-  monthly: "/ mo",
-  quarterly: "/ 3mo",
-  yearly: "/ yr",
-}
-
-/** 月次概算合計を算出 (週次は約4.345倍、年次は1/12) */
-const monthlyEquivalent = (r: RecurringExpenseResponse): number => {
-  if (r.interval_unit === "WEEK") {
-    return Math.round((r.amount * 4.345) / r.interval_count)
-  }
-  return Math.round(r.amount / r.interval_count)
-}
-
-const formatAmount = (n: number): string => n.toLocaleString("en-US")
-
-const formatDate = (iso: string): string => {
-  const d = new Date(`${iso}T00:00:00`)
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-const groupOf = (r: RecurringExpenseResponse): FrequencyGroup | null =>
-  FREQUENCY_GROUPS.find((g) => g.unit === r.interval_unit && g.count === r.interval_count) ?? null
-
-/** 次回予定日を派生算出 (recorded_count はサーバ側のみ把握なので簡易表示として start_date 起点) */
-const nextDueOf = (
-  r: RecurringExpenseResponse,
-  due: RecurringExpenseDueResponse[],
-): string | null => {
-  const d = due.find((x) => x.uuid === r.uuid)
-  if (d && d.missed_dates.length > 0) {
-    return d.missed_dates[0]
-  }
-  return null
-}
+import { RecurringDueList } from "../components/RecurringDueList"
+import { RecurringFrequencyGroup } from "../components/RecurringFrequencyGroup"
+import { RecurringSummaryCard } from "../components/RecurringSummaryCard"
+import { useRecurringList } from "../hooks/useRecurringList"
+import { FREQUENCY_OPTIONS } from "../libs/recurringFrequency"
 
 export const RecurringExpenseListPage = () => {
-  const navigate = useNavigate()
-  const [items, setItems] = useState<RecurringExpenseResponse[]>([])
-  const [due, setDue] = useState<RecurringExpenseDueResponse[]>([])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-
-  const fetchData = useCallback(async () => {
-    try {
-      const [list, dueList] = await Promise.all([
-        api.getRecurringExpenses(),
-        api.getRecurringExpenseDue(),
-      ])
-      setItems(list)
-      setDue(dueList)
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to fetch data"))
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchData()
-  }, [fetchData])
-
-  const totalMonthly = useMemo(
-    () => items.reduce((sum, r) => sum + monthlyEquivalent(r), 0),
-    [items],
-  )
-
-  const grouped = useMemo(() => {
-    const map = new Map<string, RecurringExpenseResponse[]>()
-    for (const g of FREQUENCY_GROUPS) {
-      map.set(g.key, [])
-    }
-    for (const r of items) {
-      const g = groupOf(r)
-      if (g) {
-        map.get(g.key)?.push(r)
-      }
-    }
-    return map
-  }, [items])
-
-  const handleRecord = async (uuid: string, missedCount: number) => {
-    setError("")
-    setLoading(true)
-    try {
-      await api.recordRecurringExpense(uuid, { count: missedCount })
-      await fetchData()
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to record"))
-    } finally {
-      setLoading(false)
-    }
-  }
+  const { items, due, error, loading, totalMonthly, grouped, handleRecord } = useRecurringList()
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-6 px-6 pb-6">
       {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
 
-      {/* Summary */}
-      <div className="rounded-2xl bg-white p-6 shadow-sm dark:bg-gray-800">
-        <div className="text-xs text-gray-500 dark:text-gray-400">Every month</div>
-        <div className="mt-1 text-3xl font-light tracking-tight">¥{formatAmount(totalMonthly)}</div>
-        <div className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          {items.length} {items.length === 1 ? "recurring" : "recurrings"}
-        </div>
-      </div>
+      <RecurringSummaryCard totalMonthly={totalMonthly} count={items.length} />
 
-      {/* Coming up (due payments) */}
-      {due.length > 0 && (
-        <div className="rounded-2xl bg-white p-5 shadow-sm dark:bg-gray-800">
-          <div className="mb-3 text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400">
-            Coming up
-          </div>
-          <div className="flex flex-col gap-3">
-            {due.map((d) => (
-              <button
-                key={d.uuid}
-                type="button"
-                onClick={() => handleRecord(d.uuid, d.missed_count)}
-                disabled={loading}
-                className="flex items-center gap-3 rounded-xl bg-gray-50 px-4 py-3 text-left hover:bg-gray-100 disabled:opacity-50 dark:bg-gray-700 dark:hover:bg-gray-600"
-              >
-                <div className="flex flex-1 flex-col">
-                  <div className="text-sm font-medium">{d.name}</div>
-                  <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                    {d.missed_count > 1
-                      ? `${d.missed_count} unrecorded · oldest ${formatDate(d.missed_dates[0])}`
-                      : `due ${formatDate(d.missed_dates[0])}`}
-                  </div>
-                </div>
-                <div className="text-right">
-                  <div className="text-sm font-medium">¥{formatAmount(d.amount)}</div>
-                  <div className="mt-0.5 text-xs text-primary">Tap to record</div>
-                </div>
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
+      <RecurringDueList due={due} loading={loading} onRecord={handleRecord} />
 
-      {/* Add button */}
       <Link
         to="/expense/recurring/new"
         className="flex items-center justify-center gap-2 rounded-2xl bg-primary py-3 text-sm font-medium text-white hover:bg-primary-hover"
@@ -175,59 +26,9 @@ export const RecurringExpenseListPage = () => {
         Add recurring
       </Link>
 
-      {/* Grouped list */}
-      {FREQUENCY_GROUPS.map((g) => {
-        const list = grouped.get(g.key) ?? []
-        if (list.length === 0) return null
-        const groupTotal = list.reduce((sum, r) => sum + monthlyEquivalent(r), 0)
-        return (
-          <div
-            key={g.key}
-            className="overflow-hidden rounded-2xl bg-white shadow-sm dark:bg-gray-800"
-          >
-            <div className="flex items-center justify-between px-5 py-3 text-xs font-medium text-gray-500 dark:text-gray-400">
-              <span>{g.label}</span>
-              <span>
-                {list.length} · ¥{formatAmount(groupTotal)}/mo
-              </span>
-            </div>
-            <div className="divide-y divide-gray-100 dark:divide-gray-700">
-              {list.map((r) => {
-                const next = nextDueOf(r, due)
-                return (
-                  <button
-                    key={r.uuid}
-                    type="button"
-                    onClick={() => navigate(`/expense/recurring/${r.uuid}`)}
-                    className="flex w-full items-center gap-3 px-5 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700"
-                  >
-                    <div className="flex flex-1 flex-col">
-                      <div className="text-sm font-medium">{r.name}</div>
-                      <div className="mt-0.5 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
-                        <span>{categoryGlyph(r.category)}</span>
-                        <span>{r.category.name}</span>
-                        {next && (
-                          <>
-                            <span>·</span>
-                            <span>next {formatDate(next)}</span>
-                          </>
-                        )}
-                      </div>
-                    </div>
-                    <div className="text-right">
-                      <div className="text-sm font-medium">¥{formatAmount(r.amount)}</div>
-                      <div className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">
-                        {PERIOD_LABEL[g.key]}
-                      </div>
-                    </div>
-                    <ChevronRightIcon className="size-4 text-gray-300 dark:text-gray-600" />
-                  </button>
-                )
-              })}
-            </div>
-          </div>
-        )
-      })}
+      {FREQUENCY_OPTIONS.map((g) => (
+        <RecurringFrequencyGroup key={g.key} group={g} items={grouped.get(g.key) ?? []} due={due} />
+      ))}
 
       {items.length === 0 && (
         <p className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">

--- a/frontend/src/expense/components/ExpenseAmountInput.tsx
+++ b/frontend/src/expense/components/ExpenseAmountInput.tsx
@@ -1,0 +1,31 @@
+interface ExpenseAmountInputProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export const ExpenseAmountInput = ({ value, onChange }: ExpenseAmountInputProps) => {
+  const handle = (raw: string) => {
+    const digits = raw.replace(/[^0-9]/g, "")
+    onChange(digits ? Number(digits).toLocaleString() : "")
+  }
+
+  return (
+    <div className="px-5 pt-5 text-center">
+      <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        What did this cost you
+      </div>
+      <div className="mt-2 flex items-baseline justify-center gap-1">
+        <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => handle(e.target.value)}
+          required
+          placeholder="0"
+          className="w-44 bg-transparent text-center text-5xl font-bold tracking-tighter tabular-nums outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/expense/components/ExpenseCategoryChips.tsx
+++ b/frontend/src/expense/components/ExpenseCategoryChips.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from "react-router"
+
+import { categoryGlyph } from "../../common/libs/category"
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface ExpenseCategoryChipsProps {
+  categories: CategoryResponse[]
+  selectedUuid: string | null
+  onSelect: (uuid: string | null) => void
+}
+
+export const ExpenseCategoryChips = ({
+  categories,
+  selectedUuid,
+  onSelect,
+}: ExpenseCategoryChipsProps) => {
+  const navigate = useNavigate()
+  if (categories.length === 0) return null
+
+  return (
+    <div className="px-4 pt-4">
+      <div className="flex flex-wrap gap-2">
+        {categories.map((c) => {
+          const active = selectedUuid === c.uuid
+          return (
+            <button
+              key={c.uuid}
+              type="button"
+              onClick={() => onSelect(active ? null : c.uuid)}
+              className={`flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-xs font-semibold ${
+                active
+                  ? "border-primary bg-primary text-white"
+                  : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+              }`}
+            >
+              <span>{categoryGlyph(c)}</span>
+              <span>{c.name}</span>
+            </button>
+          )
+        })}
+        <button
+          type="button"
+          onClick={() => navigate("/category/new")}
+          className="flex items-center rounded-2xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
+        >
+          + Category
+        </button>
+      </div>
+      {!selectedUuid && (
+        <p className="px-1 pt-2 text-[11px] text-gray-400 dark:text-gray-500">
+          No category — saved without one.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/expense/components/ExpenseDateTimeInput.tsx
+++ b/frontend/src/expense/components/ExpenseDateTimeInput.tsx
@@ -1,0 +1,19 @@
+interface ExpenseDateTimeInputProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export const ExpenseDateTimeInput = ({ value, onChange }: ExpenseDateTimeInputProps) => (
+  <div className="px-5 pt-5 text-center">
+    <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+      When
+    </div>
+    <input
+      type="datetime-local"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      required
+      className="mt-1 bg-transparent text-center text-sm font-medium tabular-nums outline-none dark:text-gray-100"
+    />
+  </div>
+)

--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -1,9 +1,11 @@
-import { Cross2Icon } from "@radix-ui/react-icons"
 import { useEffect, useRef, useState } from "react"
 
-import { categoryGlyph } from "../../common/libs/category"
 import type { CategoryResponse } from "../../common/libs/types"
 import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
+import { FilterSheetAmountSection } from "./FilterSheetAmountSection"
+import { FilterSheetCategorySection } from "./FilterSheetCategorySection"
+import { FilterSheetHeader } from "./FilterSheetHeader"
+import { FilterSheetSearchSection } from "./FilterSheetSearchSection"
 
 interface ExpenseFilterSheetProps {
   open: boolean
@@ -57,132 +59,26 @@ export const ExpenseFilterSheet = ({
       className="m-0 h-full max-h-none w-full max-w-none bg-gray-50 text-gray-900 backdrop:bg-black/30 dark:bg-gray-900 dark:text-gray-100"
     >
       <div className="flex h-full flex-col">
-        <div className="flex shrink-0 items-center justify-between border-b border-gray-100 px-4 py-3 dark:border-gray-700">
-          <button type="button" onClick={onClose} className="text-sm font-medium text-primary">
-            Cancel
-          </button>
-          <h2 className="text-sm font-semibold">Filter expenses</h2>
-          <button type="button" onClick={apply} className="text-sm font-bold text-primary">
-            Apply
-          </button>
-        </div>
+        <FilterSheetHeader onCancel={onClose} onApply={apply} />
 
         <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-5 py-5 pb-24">
-          <section>
-            <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-              Search
-            </h3>
-            <div className="relative">
-              <input
-                type="text"
-                value={draft.q}
-                onChange={(e) => setDraft({ ...draft, q: e.target.value })}
-                placeholder="Name…"
-                className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-              />
-              {draft.q && (
-                <button
-                  type="button"
-                  onClick={() => setDraft({ ...draft, q: "" })}
-                  className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400"
-                  aria-label="Clear"
-                >
-                  <Cross2Icon className="size-3.5" />
-                </button>
-              )}
-            </div>
-          </section>
-
-          {categories.length > 0 && (
-            <section>
-              <div className="mb-2 flex items-center justify-between">
-                <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-                  Categories
-                </h3>
-                {draft.categoryUuids.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setDraft({ ...draft, categoryUuids: [] })}
-                    className="text-[11px] text-gray-400"
-                  >
-                    clear
-                  </button>
-                )}
-              </div>
-              <div className="flex flex-wrap gap-2">
-                {categories.map((c) => {
-                  const on = draft.categoryUuids.includes(c.uuid)
-                  return (
-                    <button
-                      key={c.uuid}
-                      type="button"
-                      onClick={() => toggleCategory(c.uuid)}
-                      className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold ${
-                        on
-                          ? "border-primary bg-primary text-white"
-                          : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
-                      }`}
-                    >
-                      <span>{categoryGlyph(c)}</span>
-                      <span>{c.name}</span>
-                    </button>
-                  )
-                })}
-              </div>
-            </section>
-          )}
-
-          <section>
-            <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-              Amount
-            </h3>
-            <div className="flex items-center gap-2">
-              <div className="flex flex-1 items-center gap-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800">
-                <span className="text-gray-400">¥</span>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  placeholder="min"
-                  value={draft.min || ""}
-                  onChange={(e) => setDraft({ ...draft, min: Number(e.target.value) || 0 })}
-                  className="w-full bg-transparent outline-none dark:text-gray-100"
-                />
-              </div>
-              <span className="text-gray-400">—</span>
-              <div className="flex flex-1 items-center gap-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800">
-                <span className="text-gray-400">¥</span>
-                <input
-                  type="number"
-                  inputMode="numeric"
-                  placeholder="max"
-                  value={draft.max || ""}
-                  onChange={(e) => setDraft({ ...draft, max: Number(e.target.value) || 0 })}
-                  className="w-full bg-transparent outline-none dark:text-gray-100"
-                />
-              </div>
-            </div>
-            <div className="mt-2 flex gap-2">
-              {(
-                [
-                  [0, 1000],
-                  [1000, 5000],
-                  [5000, 20000],
-                  [20000, 0],
-                ] as const
-              ).map(([lo, hi]) => (
-                <button
-                  key={`${lo}-${hi}`}
-                  type="button"
-                  onClick={() => setDraft({ ...draft, min: lo, max: hi })}
-                  className="flex-1 rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-[11px] font-semibold text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
-                >
-                  {hi
-                    ? `¥${lo.toLocaleString()}–${hi.toLocaleString()}`
-                    : `¥${lo.toLocaleString()}+`}
-                </button>
-              ))}
-            </div>
-          </section>
+          <FilterSheetSearchSection
+            value={draft.q}
+            onChange={(v) => setDraft({ ...draft, q: v })}
+          />
+          <FilterSheetCategorySection
+            categories={categories}
+            selectedUuids={draft.categoryUuids}
+            onToggle={toggleCategory}
+            onClear={() => setDraft({ ...draft, categoryUuids: [] })}
+          />
+          <FilterSheetAmountSection
+            min={draft.min}
+            max={draft.max}
+            onMinChange={(v) => setDraft({ ...draft, min: v })}
+            onMaxChange={(v) => setDraft({ ...draft, max: v })}
+            onPreset={(min, max) => setDraft({ ...draft, min, max })}
+          />
 
           <button
             type="button"

--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -1,89 +1,24 @@
-import { Cross2Icon, MagnifyingGlassIcon, MixerHorizontalIcon } from "@radix-ui/react-icons"
-import { useMemo, useState } from "react"
-import { useNavigate } from "react-router"
+import { useState } from "react"
 
-import { categoryGlyph } from "../../common/libs/category"
-import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
-import {
-  applyFilter,
-  defaultFilter,
-  type ExpenseFilter,
-  filterCount,
-  SCOPE_OPTIONS,
-} from "../libs/expenseFilter"
+import type { ExpenseResponse } from "../../common/libs/types"
+import { useFilteredExpenses } from "../hooks/useFilteredExpenses"
+import { defaultFilter, type ExpenseFilter, filterCount } from "../libs/expenseFilter"
 import { ExpenseFilterChips } from "./ExpenseFilterChips"
 import { ExpenseFilterSheet } from "./ExpenseFilterSheet"
-
-const pad = (n: number) => String(n).padStart(2, "0")
-
-const dateKey = (iso: string): string => {
-  const d = new Date(iso)
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-}
-
-const dateLabel = (key: string): string => {
-  const [y, m, day] = key.split("-").map(Number)
-  return new Date(y, m - 1, day).toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-const timeLabel = (iso: string): string => {
-  const d = new Date(iso)
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
+import { ExpenseListDayGroup } from "./ExpenseListDayGroup"
+import { ExpenseListScopeChips } from "./ExpenseListScopeChips"
+import { ExpenseListSearchBar } from "./ExpenseListSearchBar"
 
 interface ExpenseListProps {
   expenses: ExpenseResponse[]
   initialFilter?: ExpenseFilter
 }
 
-interface DayGroup {
-  key: string
-  label: string
-  items: ExpenseResponse[]
-  total: number
-}
-
 export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
-  const navigate = useNavigate()
   const [filter, setFilter] = useState<ExpenseFilter>(initialFilter ?? defaultFilter())
   const [sheetOpen, setSheetOpen] = useState(false)
-
-  const usedCategories = useMemo<CategoryResponse[]>(() => {
-    const map = new Map<string, CategoryResponse>()
-    for (const e of expenses) {
-      for (const c of e.categories) {
-        if (!map.has(c.uuid)) map.set(c.uuid, c)
-      }
-    }
-    return [...map.values()].toSorted((a, b) => a.position - b.position)
-  }, [expenses])
-
-  const filtered = useMemo(() => applyFilter(expenses, filter), [expenses, filter])
-
-  const groups = useMemo<DayGroup[]>(() => {
-    const sorted = [...filtered].toSorted(
-      (a, b) => new Date(b.expensed_at).getTime() - new Date(a.expensed_at).getTime(),
-    )
-    const map = new Map<string, ExpenseResponse[]>()
-    for (const e of sorted) {
-      const k = dateKey(e.expensed_at)
-      const list = map.get(k)
-      if (list) {
-        list.push(e)
-      } else {
-        map.set(k, [e])
-      }
-    }
-    return [...map.entries()].map(([key, items]) => ({
-      key,
-      label: dateLabel(key),
-      items,
-      total: items.reduce((sum, e) => sum + e.amount, 0),
-    }))
-  }, [filtered])
-
+  const { usedCategories, filtered, groups, total } = useFilteredExpenses(expenses, filter)
   const fcount = filterCount(filter)
-  const total = useMemo(() => filtered.reduce((sum, e) => sum + e.amount, 0), [filtered])
 
   return (
     <>
@@ -94,65 +29,17 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
         <span className="text-2xl font-bold tabular-nums">¥{total.toLocaleString()}</span>
       </div>
 
-      <div className="flex shrink-0 items-center gap-2 pt-3">
-        <div className="flex flex-1 items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
-          <MagnifyingGlassIcon className="size-4 shrink-0 text-gray-400" />
-          <input
-            type="text"
-            value={filter.q}
-            onChange={(e) => setFilter({ ...filter, q: e.target.value })}
-            placeholder="Search expenses…"
-            className="w-full bg-transparent text-sm outline-none placeholder:text-gray-400 dark:text-gray-100"
-          />
-          {filter.q && (
-            <button
-              type="button"
-              onClick={() => setFilter({ ...filter, q: "" })}
-              aria-label="Clear search"
-              className="shrink-0 text-gray-400"
-            >
-              <Cross2Icon className="size-3.5" />
-            </button>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={() => setSheetOpen(true)}
-          aria-label="Filter"
-          className={`relative flex size-10 shrink-0 items-center justify-center rounded-xl border ${
-            fcount > 0
-              ? "border-primary bg-primary text-white"
-              : "border-gray-200 bg-white text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
-          }`}
-        >
-          <MixerHorizontalIcon className="size-4" />
-          {fcount > 0 && (
-            <span className="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white ring-2 ring-gray-50 dark:ring-gray-900">
-              {fcount}
-            </span>
-          )}
-        </button>
-      </div>
+      <ExpenseListSearchBar
+        query={filter.q}
+        filterCount={fcount}
+        onQueryChange={(v) => setFilter({ ...filter, q: v })}
+        onOpenFilter={() => setSheetOpen(true)}
+      />
 
-      <div className="flex shrink-0 gap-1.5 pt-2">
-        {SCOPE_OPTIONS.map((s) => {
-          const on = filter.scope === s.k
-          return (
-            <button
-              key={s.k}
-              type="button"
-              onClick={() => setFilter({ ...filter, scope: s.k })}
-              className={`rounded-full px-3 py-1 text-xs font-semibold ${
-                on
-                  ? "bg-primary text-white"
-                  : "border border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400"
-              }`}
-            >
-              {s.short}
-            </button>
-          )
-        })}
-      </div>
+      <ExpenseListScopeChips
+        scope={filter.scope}
+        onChange={(scope) => setFilter({ ...filter, scope })}
+      />
 
       <ExpenseFilterChips
         filter={filter}
@@ -168,39 +55,7 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
       ) : (
         <div className="mt-4 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-2">
           {groups.map((g) => (
-            <section key={g.key}>
-              <div className="mb-1.5 flex items-baseline justify-between px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-                <h2>{g.label}</h2>
-                <span className="tabular-nums">¥{g.total.toLocaleString()}</span>
-              </div>
-              <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
-                {g.items.map((e) => {
-                  const c = e.categories[0]
-                  return (
-                    <li key={e.uuid}>
-                      <button
-                        type="button"
-                        onClick={() => navigate(`/expense/${e.uuid}`)}
-                        className="flex w-full items-center gap-3 px-3.5 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50"
-                      >
-                        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base dark:bg-gray-700">
-                          {c ? categoryGlyph(c) : "·"}
-                        </span>
-                        <div className="flex min-w-0 flex-1 flex-col">
-                          <span className="truncate text-sm font-medium">{e.name}</span>
-                          <span className="truncate text-[11px] text-gray-400 dark:text-gray-500">
-                            {c ? c.name : "Uncategorized"} · {timeLabel(e.expensed_at)}
-                          </span>
-                        </div>
-                        <span className="shrink-0 text-sm font-semibold tabular-nums">
-                          ¥{e.amount.toLocaleString()}
-                        </span>
-                      </button>
-                    </li>
-                  )
-                })}
-              </ul>
-            </section>
+            <ExpenseListDayGroup key={g.key} label={g.label} total={g.total} items={g.items} />
           ))}
         </div>
       )}

--- a/frontend/src/expense/components/ExpenseListDayGroup.tsx
+++ b/frontend/src/expense/components/ExpenseListDayGroup.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from "react-router"
+
+import { categoryGlyph } from "../../common/libs/category"
+import type { ExpenseResponse } from "../../common/libs/types"
+
+const pad = (n: number) => String(n).padStart(2, "0")
+
+const timeLabel = (iso: string): string => {
+  const d = new Date(iso)
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+interface ExpenseListDayGroupProps {
+  label: string
+  total: number
+  items: ExpenseResponse[]
+}
+
+export const ExpenseListDayGroup = ({ label, total, items }: ExpenseListDayGroupProps) => {
+  const navigate = useNavigate()
+  return (
+    <section>
+      <div className="mb-1.5 flex items-baseline justify-between px-1 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        <h2>{label}</h2>
+        <span className="tabular-nums">¥{total.toLocaleString()}</span>
+      </div>
+      <ul className="divide-y divide-gray-100 overflow-hidden rounded-2xl border border-gray-100 bg-white dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800">
+        {items.map((e) => {
+          const c = e.categories[0]
+          return (
+            <li key={e.uuid}>
+              <button
+                type="button"
+                onClick={() => navigate(`/expense/${e.uuid}`)}
+                className="flex w-full items-center gap-3 px-3.5 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-700/50"
+              >
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-base dark:bg-gray-700">
+                  {c ? categoryGlyph(c) : "·"}
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-sm font-medium">{e.name}</span>
+                  <span className="truncate text-[11px] text-gray-400 dark:text-gray-500">
+                    {c ? c.name : "Uncategorized"} · {timeLabel(e.expensed_at)}
+                  </span>
+                </div>
+                <span className="shrink-0 text-sm font-semibold tabular-nums">
+                  ¥{e.amount.toLocaleString()}
+                </span>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/expense/components/ExpenseListScopeChips.tsx
+++ b/frontend/src/expense/components/ExpenseListScopeChips.tsx
@@ -1,0 +1,28 @@
+import { type FilterScope, SCOPE_OPTIONS } from "../libs/expenseFilter"
+
+interface ExpenseListScopeChipsProps {
+  scope: FilterScope
+  onChange: (scope: FilterScope) => void
+}
+
+export const ExpenseListScopeChips = ({ scope, onChange }: ExpenseListScopeChipsProps) => (
+  <div className="flex shrink-0 gap-1.5 pt-2">
+    {SCOPE_OPTIONS.map((s) => {
+      const on = scope === s.k
+      return (
+        <button
+          key={s.k}
+          type="button"
+          onClick={() => onChange(s.k)}
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${
+            on
+              ? "bg-primary text-white"
+              : "border border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400"
+          }`}
+        >
+          {s.short}
+        </button>
+      )
+    })}
+  </div>
+)

--- a/frontend/src/expense/components/ExpenseListSearchBar.tsx
+++ b/frontend/src/expense/components/ExpenseListSearchBar.tsx
@@ -1,0 +1,55 @@
+import { Cross2Icon, MagnifyingGlassIcon, MixerHorizontalIcon } from "@radix-ui/react-icons"
+
+interface ExpenseListSearchBarProps {
+  query: string
+  filterCount: number
+  onQueryChange: (v: string) => void
+  onOpenFilter: () => void
+}
+
+export const ExpenseListSearchBar = ({
+  query,
+  filterCount,
+  onQueryChange,
+  onOpenFilter,
+}: ExpenseListSearchBarProps) => (
+  <div className="flex shrink-0 items-center gap-2 pt-3">
+    <div className="flex flex-1 items-center gap-2 rounded-xl border border-gray-200 bg-white px-3 py-2 dark:border-gray-700 dark:bg-gray-800">
+      <MagnifyingGlassIcon className="size-4 shrink-0 text-gray-400" />
+      <input
+        type="text"
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder="Search expenses…"
+        className="w-full bg-transparent text-sm outline-none placeholder:text-gray-400 dark:text-gray-100"
+      />
+      {query && (
+        <button
+          type="button"
+          onClick={() => onQueryChange("")}
+          aria-label="Clear search"
+          className="shrink-0 text-gray-400"
+        >
+          <Cross2Icon className="size-3.5" />
+        </button>
+      )}
+    </div>
+    <button
+      type="button"
+      onClick={onOpenFilter}
+      aria-label="Filter"
+      className={`relative flex size-10 shrink-0 items-center justify-center rounded-xl border ${
+        filterCount > 0
+          ? "border-primary bg-primary text-white"
+          : "border-gray-200 bg-white text-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400"
+      }`}
+    >
+      <MixerHorizontalIcon className="size-4" />
+      {filterCount > 0 && (
+        <span className="absolute -top-1.5 -right-1.5 flex size-4 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-white ring-2 ring-gray-50 dark:ring-gray-900">
+          {filterCount}
+        </span>
+      )}
+    </button>
+  </div>
+)

--- a/frontend/src/expense/components/ExpenseNameInput.tsx
+++ b/frontend/src/expense/components/ExpenseNameInput.tsx
@@ -1,0 +1,23 @@
+import { type Ref } from "react"
+
+interface ExpenseNameInputProps {
+  value: string
+  onChange: (v: string) => void
+  inputRef?: Ref<HTMLInputElement>
+}
+
+export const ExpenseNameInput = ({ value, onChange, inputRef }: ExpenseNameInputProps) => (
+  <div className="px-5 pt-3">
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      required
+      maxLength={100}
+      placeholder="What was this?"
+      className="w-full bg-transparent text-2xl font-bold tracking-tight outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
+    />
+    <div className="mt-2 h-px bg-gray-200 dark:bg-gray-700" />
+  </div>
+)

--- a/frontend/src/expense/components/FilterSheetAmountSection.tsx
+++ b/frontend/src/expense/components/FilterSheetAmountSection.tsx
@@ -1,0 +1,65 @@
+interface FilterSheetAmountSectionProps {
+  min: number
+  max: number
+  onMinChange: (v: number) => void
+  onMaxChange: (v: number) => void
+  onPreset: (min: number, max: number) => void
+}
+
+const PRESETS: ReadonlyArray<readonly [number, number]> = [
+  [0, 1000],
+  [1000, 5000],
+  [5000, 20000],
+  [20000, 0],
+]
+
+export const FilterSheetAmountSection = ({
+  min,
+  max,
+  onMinChange,
+  onMaxChange,
+  onPreset,
+}: FilterSheetAmountSectionProps) => (
+  <section>
+    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+      Amount
+    </h3>
+    <div className="flex items-center gap-2">
+      <div className="flex flex-1 items-center gap-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800">
+        <span className="text-gray-400">¥</span>
+        <input
+          type="number"
+          inputMode="numeric"
+          placeholder="min"
+          value={min || ""}
+          onChange={(e) => onMinChange(Number(e.target.value) || 0)}
+          className="w-full bg-transparent outline-none dark:text-gray-100"
+        />
+      </div>
+      <span className="text-gray-400">—</span>
+      <div className="flex flex-1 items-center gap-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800">
+        <span className="text-gray-400">¥</span>
+        <input
+          type="number"
+          inputMode="numeric"
+          placeholder="max"
+          value={max || ""}
+          onChange={(e) => onMaxChange(Number(e.target.value) || 0)}
+          className="w-full bg-transparent outline-none dark:text-gray-100"
+        />
+      </div>
+    </div>
+    <div className="mt-2 flex gap-2">
+      {PRESETS.map(([lo, hi]) => (
+        <button
+          key={`${lo}-${hi}`}
+          type="button"
+          onClick={() => onPreset(lo, hi)}
+          className="flex-1 rounded-lg border border-gray-200 bg-white px-2 py-1.5 text-[11px] font-semibold text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300"
+        >
+          {hi ? `¥${lo.toLocaleString()}–${hi.toLocaleString()}` : `¥${lo.toLocaleString()}+`}
+        </button>
+      ))}
+    </div>
+  </section>
+)

--- a/frontend/src/expense/components/FilterSheetCategorySection.tsx
+++ b/frontend/src/expense/components/FilterSheetCategorySection.tsx
@@ -1,0 +1,53 @@
+import { categoryGlyph } from "../../common/libs/category"
+import type { CategoryResponse } from "../../common/libs/types"
+
+interface FilterSheetCategorySectionProps {
+  categories: CategoryResponse[]
+  selectedUuids: string[]
+  onToggle: (uuid: string) => void
+  onClear: () => void
+}
+
+export const FilterSheetCategorySection = ({
+  categories,
+  selectedUuids,
+  onToggle,
+  onClear,
+}: FilterSheetCategorySectionProps) => {
+  if (categories.length === 0) return null
+
+  return (
+    <section>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+          Categories
+        </h3>
+        {selectedUuids.length > 0 && (
+          <button type="button" onClick={onClear} className="text-[11px] text-gray-400">
+            clear
+          </button>
+        )}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {categories.map((c) => {
+          const on = selectedUuids.includes(c.uuid)
+          return (
+            <button
+              key={c.uuid}
+              type="button"
+              onClick={() => onToggle(c.uuid)}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold ${
+                on
+                  ? "border-primary bg-primary text-white"
+                  : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+              }`}
+            >
+              <span>{categoryGlyph(c)}</span>
+              <span>{c.name}</span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/expense/components/FilterSheetHeader.tsx
+++ b/frontend/src/expense/components/FilterSheetHeader.tsx
@@ -1,0 +1,16 @@
+interface FilterSheetHeaderProps {
+  onCancel: () => void
+  onApply: () => void
+}
+
+export const FilterSheetHeader = ({ onCancel, onApply }: FilterSheetHeaderProps) => (
+  <div className="flex shrink-0 items-center justify-between border-b border-gray-100 px-4 py-3 dark:border-gray-700">
+    <button type="button" onClick={onCancel} className="text-sm font-medium text-primary">
+      Cancel
+    </button>
+    <h2 className="text-sm font-semibold">Filter expenses</h2>
+    <button type="button" onClick={onApply} className="text-sm font-bold text-primary">
+      Apply
+    </button>
+  </div>
+)

--- a/frontend/src/expense/components/FilterSheetSearchSection.tsx
+++ b/frontend/src/expense/components/FilterSheetSearchSection.tsx
@@ -1,0 +1,33 @@
+import { Cross2Icon } from "@radix-ui/react-icons"
+
+interface FilterSheetSearchSectionProps {
+  value: string
+  onChange: (v: string) => void
+}
+
+export const FilterSheetSearchSection = ({ value, onChange }: FilterSheetSearchSectionProps) => (
+  <section>
+    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+      Search
+    </h3>
+    <div className="relative">
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Name…"
+        className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400"
+          aria-label="Clear"
+        >
+          <Cross2Icon className="size-3.5" />
+        </button>
+      )}
+    </div>
+  </section>
+)

--- a/frontend/src/expense/components/InsightCategoryCard.tsx
+++ b/frontend/src/expense/components/InsightCategoryCard.tsx
@@ -1,0 +1,51 @@
+import { categoryGlyph } from "../../common/libs/category"
+import { type CategoryStat, fmtAmount } from "../libs/insightStats"
+
+interface InsightCategoryCardProps {
+  cats: CategoryStat[]
+}
+
+export const InsightCategoryCard = ({ cats }: InsightCategoryCardProps) => {
+  if (cats.length === 0) {
+    return (
+      <p className="py-2 text-sm text-gray-400 dark:text-gray-500">No expenses this month yet.</p>
+    )
+  }
+
+  const total = cats.reduce((s, c) => s + c.amount, 0)
+
+  return (
+    <>
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-bold tracking-tight tabular-nums">{fmtAmount(total)}</span>
+        <span className="text-sm text-gray-500 dark:text-gray-400">total</span>
+      </div>
+      <div className="mt-3 flex h-3.5 gap-0.5 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
+        {cats.map((c, i) => (
+          <div
+            key={c.category?.uuid ?? "__none__"}
+            style={{ width: `${c.pct}%`, opacity: 1 - i * 0.13 }}
+            className="bg-primary"
+          />
+        ))}
+      </div>
+      <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
+        {cats.map((c, i) => (
+          <div key={c.category?.uuid ?? "__none__"} className="flex items-center gap-2.5 py-2">
+            <div style={{ opacity: 1 - i * 0.13 }} className="size-2.5 rounded-sm bg-primary" />
+            <span className="text-sm">{c.category ? categoryGlyph(c.category) : "·"}</span>
+            <span className="flex-1 text-sm font-medium">
+              {c.category ? c.category.name : "Uncategorized"}
+            </span>
+            <span className="text-[11px] text-gray-400 tabular-nums dark:text-gray-500">
+              {fmtAmount(c.amount)}
+            </span>
+            <span className="min-w-10 text-right text-sm font-bold tabular-nums">
+              {Math.round(c.pct)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/expense/components/InsightSection.tsx
+++ b/frontend/src/expense/components/InsightSection.tsx
@@ -1,0 +1,25 @@
+interface InsightSectionProps {
+  title: string
+  children: React.ReactNode
+  /** カードのpadding。デフォルト p-5 */
+  padding?: string
+  className?: string
+}
+
+export const InsightSection = ({
+  title,
+  children,
+  padding = "p-5",
+  className = "",
+}: InsightSectionProps) => (
+  <div className={className}>
+    <div className="mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
+      {title}
+    </div>
+    <div
+      className={`${padding} rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800`}
+    >
+      {children}
+    </div>
+  </div>
+)

--- a/frontend/src/expense/components/InsightVibeCard.tsx
+++ b/frontend/src/expense/components/InsightVibeCard.tsx
@@ -1,0 +1,50 @@
+import type { VibeStat } from "../libs/insightStats"
+
+interface InsightVibeCardProps {
+  vibes: VibeStat[]
+}
+
+export const InsightVibeCard = ({ vibes }: InsightVibeCardProps) => {
+  const top = vibes[0]
+  if (!top) {
+    return (
+      <p className="py-2 text-sm text-gray-400 dark:text-gray-500">No vibe data this month yet.</p>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-bold tracking-tight tabular-nums">
+          {Math.round(top.pct)}%
+        </span>
+        <span className="text-sm text-gray-500 dark:text-gray-400">
+          was {top.label.toLowerCase()}
+        </span>
+      </div>
+      <div className="mt-3 flex h-3.5 gap-0.5 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
+        {vibes.map((v, i) => (
+          <div
+            key={v.key}
+            style={{ width: `${v.pct}%`, opacity: 1 - i * 0.18 }}
+            className="bg-primary"
+          />
+        ))}
+      </div>
+      <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
+        {vibes.map((v, i) => (
+          <div key={v.key} className="flex items-center gap-2.5 py-2">
+            <div style={{ opacity: 1 - i * 0.18 }} className="size-2.5 rounded-sm bg-primary" />
+            <span className="flex-1 text-sm font-medium">{v.label}</span>
+            <span className="text-[11px] text-gray-400 dark:text-gray-500">
+              {v.count} {v.count === 1 ? "time" : "times"}
+            </span>
+            <span className="min-w-9 text-right text-sm font-bold tabular-nums">
+              {Math.round(v.pct)}%
+            </span>
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/frontend/src/expense/components/InsightYearChart.tsx
+++ b/frontend/src/expense/components/InsightYearChart.tsx
@@ -1,3 +1,5 @@
+import { InsightYearChartSvg } from "./InsightYearChartSvg"
+
 export interface YearMonth {
   key: string
   label: string
@@ -16,13 +18,6 @@ export const InsightYearChart = ({ year }: InsightYearChartProps) => {
   const total = year.reduce((s, d) => s + d.amount, 0)
   const avg = Math.round(total / year.length)
   const peak = year.reduce((max, d) => (d.amount > max.amount ? d : max), year[0])
-  const W = 340
-  const H = 160
-  const pad = 24
-  const xAt = (i: number) => pad + (i / (year.length - 1)) * (W - pad * 2)
-  const yAt = (v: number) => H - 26 - (v / yMax) * (H - 50)
-  const linePath = year.map((d, i) => `${i === 0 ? "M" : "L"} ${xAt(i)} ${yAt(d.amount)}`).join(" ")
-  const areaPath = `${linePath} L ${xAt(year.length - 1)} ${H - 26} L ${pad} ${H - 26} Z`
 
   return (
     <div>
@@ -34,75 +29,7 @@ export const InsightYearChart = ({ year }: InsightYearChartProps) => {
           total · ¥{avg.toLocaleString()}/mo avg
         </span>
       </div>
-      <svg
-        width="100%"
-        viewBox={`0 0 ${W} ${H}`}
-        preserveAspectRatio="none"
-        className="mt-1.5 block"
-      >
-        <line
-          x1={pad}
-          x2={W - pad}
-          y1={yAt(avg)}
-          y2={yAt(avg)}
-          stroke="currentColor"
-          strokeWidth="0.5"
-          strokeDasharray="3 3"
-          opacity="0.3"
-        />
-        <path d={areaPath} fill="var(--color-primary)" fillOpacity="0.14" />
-        <path
-          d={linePath}
-          fill="none"
-          stroke="var(--color-primary)"
-          strokeWidth="1.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {year.map((d, i) => {
-          const cw = ((W - pad * 2) / year.length) * 0.55
-          const x = xAt(i) - cw / 2
-          const y = yAt(d.amount)
-          return (
-            <rect
-              key={i}
-              x={x}
-              y={y}
-              width={cw}
-              height={H - 26 - y}
-              fill="var(--color-primary)"
-              fillOpacity={d.current ? 0.85 : 0.28}
-              rx="2"
-            />
-          )
-        })}
-        {year.map((d, i) => (
-          <circle
-            key={`p${i}`}
-            cx={xAt(i)}
-            cy={yAt(d.amount)}
-            r={d.current ? 3.5 : 2}
-            fill={d.current ? "var(--color-primary)" : "#ffffff"}
-            stroke="var(--color-primary)"
-            strokeWidth="1.2"
-          />
-        ))}
-        {year.map((d, i) => (
-          <text
-            key={`l${i}`}
-            x={xAt(i)}
-            y={H - 8}
-            textAnchor="middle"
-            fontSize="9"
-            fill="currentColor"
-            opacity={d.current ? 1 : 0.5}
-            fontWeight={d.current ? 700 : 500}
-            fontFamily="inherit"
-          >
-            {d.label}
-          </text>
-        ))}
-      </svg>
+      <InsightYearChartSvg year={year} yMax={yMax} avg={avg} />
       <div className="flex items-center justify-between px-2 pt-1.5 text-[11px] text-gray-500 dark:text-gray-400">
         <span className="flex items-center gap-1.5">
           <span className="h-0.5 w-3.5 bg-primary opacity-50" />

--- a/frontend/src/expense/components/InsightYearChartSvg.tsx
+++ b/frontend/src/expense/components/InsightYearChartSvg.tsx
@@ -1,0 +1,81 @@
+import type { YearMonth } from "./InsightYearChart"
+
+interface InsightYearChartSvgProps {
+  year: YearMonth[]
+  yMax: number
+  avg: number
+}
+
+const W = 340
+const H = 160
+const PAD = 24
+
+export const InsightYearChartSvg = ({ year, yMax, avg }: InsightYearChartSvgProps) => {
+  const xAt = (i: number) => PAD + (i / (year.length - 1)) * (W - PAD * 2)
+  const yAt = (v: number) => H - 26 - (v / yMax) * (H - 50)
+  const linePath = year.map((d, i) => `${i === 0 ? "M" : "L"} ${xAt(i)} ${yAt(d.amount)}`).join(" ")
+  const areaPath = `${linePath} L ${xAt(year.length - 1)} ${H - 26} L ${PAD} ${H - 26} Z`
+  const cw = ((W - PAD * 2) / year.length) * 0.55
+
+  return (
+    <svg width="100%" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="mt-1.5 block">
+      <line
+        x1={PAD}
+        x2={W - PAD}
+        y1={yAt(avg)}
+        y2={yAt(avg)}
+        stroke="currentColor"
+        strokeWidth="0.5"
+        strokeDasharray="3 3"
+        opacity="0.3"
+      />
+      <path d={areaPath} fill="var(--color-primary)" fillOpacity="0.14" />
+      <path
+        d={linePath}
+        fill="none"
+        stroke="var(--color-primary)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {year.map((d, i) => (
+        <rect
+          key={i}
+          x={xAt(i) - cw / 2}
+          y={yAt(d.amount)}
+          width={cw}
+          height={H - 26 - yAt(d.amount)}
+          fill="var(--color-primary)"
+          fillOpacity={d.current ? 0.85 : 0.28}
+          rx="2"
+        />
+      ))}
+      {year.map((d, i) => (
+        <circle
+          key={`p${i}`}
+          cx={xAt(i)}
+          cy={yAt(d.amount)}
+          r={d.current ? 3.5 : 2}
+          fill={d.current ? "var(--color-primary)" : "#ffffff"}
+          stroke="var(--color-primary)"
+          strokeWidth="1.2"
+        />
+      ))}
+      {year.map((d, i) => (
+        <text
+          key={`l${i}`}
+          x={xAt(i)}
+          y={H - 8}
+          textAnchor="middle"
+          fontSize="9"
+          fill="currentColor"
+          opacity={d.current ? 1 : 0.5}
+          fontWeight={d.current ? 700 : 500}
+          fontFamily="inherit"
+        >
+          {d.label}
+        </text>
+      ))}
+    </svg>
+  )
+}

--- a/frontend/src/expense/components/TopMomentsList.tsx
+++ b/frontend/src/expense/components/TopMomentsList.tsx
@@ -1,0 +1,70 @@
+import { useNavigate } from "react-router"
+
+import { categoryGlyph } from "../../common/libs/category"
+import type { ExpenseResponse } from "../../common/libs/types"
+
+const pad = (n: number) => String(n).padStart(2, "0")
+
+const dayShort = (iso: string): string => {
+  const d = new Date(iso)
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+const timeLabel = (iso: string): string => {
+  const d = new Date(iso)
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+interface TopMomentsListProps {
+  expenses: ExpenseResponse[]
+}
+
+export const TopMomentsList = ({ expenses }: TopMomentsListProps) => {
+  const navigate = useNavigate()
+  if (expenses.length === 0) {
+    return (
+      <p className="shrink-0 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
+        No expenses yet
+      </p>
+    )
+  }
+
+  return (
+    <ul className="min-h-0 flex-1 divide-y divide-gray-100 overflow-y-auto pb-2 dark:divide-gray-700">
+      {expenses.map((e, i) => {
+        const c = e.categories[0]
+        const showDate =
+          i === 0 ||
+          new Date(expenses[i - 1].expensed_at).toDateString() !==
+            new Date(e.expensed_at).toDateString()
+        return (
+          <li key={e.uuid}>
+            <button
+              type="button"
+              onClick={() => navigate(`/expense/${e.uuid}`)}
+              className="grid w-full grid-cols-[46px_14px_1fr_auto] items-center gap-1.5 py-2 text-left"
+            >
+              <span
+                className={`text-[11px] font-semibold ${
+                  showDate ? "text-gray-500 dark:text-gray-400" : "text-transparent"
+                }`}
+              >
+                {dayShort(e.expensed_at)}
+              </span>
+              <span className="text-center text-[11px] text-gray-400 dark:text-gray-500">
+                {c ? categoryGlyph(c) : "·"}
+              </span>
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">{e.name}</div>
+                <div className="truncate text-[10px] text-gray-400 dark:text-gray-500">
+                  {c ? c.name : "Uncategorized"} · {timeLabel(e.expensed_at)}
+                </div>
+              </div>
+              <span className="text-sm font-medium tabular-nums">¥{e.amount.toLocaleString()}</span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/expense/components/TopMonthSummary.tsx
+++ b/frontend/src/expense/components/TopMonthSummary.tsx
@@ -1,0 +1,20 @@
+interface TopMonthSummaryProps {
+  total: number
+  perDay: number
+}
+
+export const TopMonthSummary = ({ total, perDay }: TopMonthSummaryProps) => (
+  <div className="mt-6 shrink-0 border-b border-gray-200 pb-4 dark:border-gray-700">
+    <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+      Burned this month
+    </div>
+    <div className="mt-2 flex items-baseline gap-2">
+      <span className="text-4xl font-bold tracking-tight tabular-nums">
+        ¥{total.toLocaleString()}
+      </span>
+      <span className="text-xs text-gray-400 dark:text-gray-500">
+        · ¥{perDay.toLocaleString()}/day
+      </span>
+    </div>
+  </div>
+)

--- a/frontend/src/expense/hooks/useExpenseCreateForm.ts
+++ b/frontend/src/expense/hooks/useExpenseCreateForm.ts
@@ -1,0 +1,82 @@
+import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "react"
+import { useNavigate } from "react-router"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type {
+  CategoryResponse,
+  VibeNecessity,
+  VibePlanning,
+  VibeSocial,
+} from "../../common/libs/types"
+
+/** 新規 expense 作成フォームの state とハンドラ。 */
+export const useExpenseCreateForm = () => {
+  const navigate = useNavigate()
+  const nameRef = useRef<HTMLInputElement>(null)
+  const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  const [name, setName] = useState("")
+  const [amount, setAmount] = useState("")
+  const [categoryUuid, setCategoryUuid] = useState<string | null>(null)
+  const [vibeSocial, setVibeSocial] = useState<VibeSocial | null>(null)
+  const [vibePlanning, setVibePlanning] = useState<VibePlanning | null>(null)
+  const [vibeNecessity, setVibeNecessity] = useState<VibeNecessity | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      setCategories(await api.getCategories())
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+    nameRef.current?.focus()
+  }, [fetchData])
+
+  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    setError("")
+    setLoading(true)
+    try {
+      await api.createExpense({
+        name,
+        amount: Number(amount.replace(/,/g, "")),
+        expensed_at: new Date().toISOString(),
+        category_uuid: categoryUuid,
+        vibe_social: vibeSocial,
+        vibe_planning: vibePlanning,
+        vibe_necessity: vibeNecessity,
+      })
+      navigate("/expense/monthly")
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to create"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    nameRef,
+    categories,
+    error,
+    loading,
+    name,
+    setName,
+    amount,
+    setAmount,
+    categoryUuid,
+    setCategoryUuid,
+    vibeSocial,
+    setVibeSocial,
+    vibePlanning,
+    setVibePlanning,
+    vibeNecessity,
+    setVibeNecessity,
+    handleSubmit,
+  }
+}

--- a/frontend/src/expense/hooks/useExpenseEditForm.ts
+++ b/frontend/src/expense/hooks/useExpenseEditForm.ts
@@ -1,0 +1,129 @@
+import { type SubmitEvent, useCallback, useEffect, useState } from "react"
+import { useNavigate } from "react-router"
+
+import { useConfirmDialog } from "../../common/components/ConfirmDialog"
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type {
+  CategoryResponse,
+  ExpenseResponse,
+  VibeNecessity,
+  VibePlanning,
+  VibeSocial,
+} from "../../common/libs/types"
+
+const pad = (n: number) => String(n).padStart(2, "0")
+
+const toLocalDatetime = (isoStr: string) => {
+  const d = new Date(isoStr)
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+
+interface FormState {
+  name: string
+  amount: string
+  expensedAt: string
+  categoryUuid: string | null
+  vibeSocial: VibeSocial | null
+  vibePlanning: VibePlanning | null
+  vibeNecessity: VibeNecessity | null
+}
+
+const initialForm: FormState = {
+  name: "",
+  amount: "",
+  expensedAt: "",
+  categoryUuid: null,
+  vibeSocial: null,
+  vibePlanning: null,
+  vibeNecessity: null,
+}
+
+/** 既存 expense の編集フォーム state とハンドラ。 */
+export const useExpenseEditForm = (uuid: string | undefined) => {
+  const navigate = useNavigate()
+  const [expense, setExpense] = useState<ExpenseResponse | null>(null)
+  const [categories, setCategories] = useState<CategoryResponse[]>([])
+  const [error, setError] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [form, setForm] = useState<FormState>(initialForm)
+  const { dialogRef, open: openDeleteDialog } = useConfirmDialog()
+
+  const fetchData = useCallback(async () => {
+    if (!uuid) return
+    try {
+      const [exp, cats] = await Promise.all([api.getExpense(uuid), api.getCategories()])
+      setExpense(exp)
+      setCategories(cats)
+      setForm({
+        name: exp.name,
+        amount: exp.amount.toLocaleString(),
+        expensedAt: toLocalDatetime(exp.expensed_at),
+        categoryUuid: exp.categories[0]?.uuid ?? null,
+        vibeSocial: exp.vibe_social,
+        vibePlanning: exp.vibe_planning,
+        vibeNecessity: exp.vibe_necessity,
+      })
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to load"))
+    }
+  }, [uuid])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const update = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleUpdate = async (e: SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!uuid) return
+    setError("")
+    setLoading(true)
+    try {
+      await api.updateExpense(uuid, {
+        name: form.name,
+        amount: Number(form.amount.replace(/,/g, "")),
+        expensed_at: new Date(form.expensedAt).toISOString(),
+        category_uuid: form.categoryUuid,
+        vibe_social: form.vibeSocial,
+        vibe_planning: form.vibePlanning,
+        vibe_necessity: form.vibeNecessity,
+      })
+      navigate(-1)
+    } catch (err) {
+      setError(getErrorMessage(err, "Update failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!uuid) return
+    setLoading(true)
+    try {
+      await api.deleteExpense(uuid)
+      dialogRef.current?.close()
+      navigate("/expense/monthly")
+    } catch (err) {
+      setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    expense,
+    categories,
+    error,
+    loading,
+    form,
+    update,
+    dialogRef,
+    openDeleteDialog,
+    handleUpdate,
+    handleDelete,
+  }
+}

--- a/frontend/src/expense/hooks/useFilteredExpenses.ts
+++ b/frontend/src/expense/hooks/useFilteredExpenses.ts
@@ -1,0 +1,61 @@
+import { useMemo } from "react"
+
+import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+import { applyFilter, type ExpenseFilter } from "../libs/expenseFilter"
+
+const pad = (n: number) => String(n).padStart(2, "0")
+
+const dateKey = (iso: string): string => {
+  const d = new Date(iso)
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+const dateLabel = (key: string): string => {
+  const [y, m, day] = key.split("-").map(Number)
+  return new Date(y, m - 1, day).toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+export interface DayGroup {
+  key: string
+  label: string
+  items: ExpenseResponse[]
+  total: number
+}
+
+/** filter 適用 → 日付別グループ化 + 合計を一括算出。 */
+export const useFilteredExpenses = (expenses: ExpenseResponse[], filter: ExpenseFilter) => {
+  const usedCategories = useMemo<CategoryResponse[]>(() => {
+    const map = new Map<string, CategoryResponse>()
+    for (const e of expenses) {
+      for (const c of e.categories) {
+        if (!map.has(c.uuid)) map.set(c.uuid, c)
+      }
+    }
+    return [...map.values()].toSorted((a, b) => a.position - b.position)
+  }, [expenses])
+
+  const filtered = useMemo(() => applyFilter(expenses, filter), [expenses, filter])
+
+  const groups = useMemo<DayGroup[]>(() => {
+    const sorted = [...filtered].toSorted(
+      (a, b) => new Date(b.expensed_at).getTime() - new Date(a.expensed_at).getTime(),
+    )
+    const map = new Map<string, ExpenseResponse[]>()
+    for (const e of sorted) {
+      const k = dateKey(e.expensed_at)
+      const list = map.get(k)
+      if (list) list.push(e)
+      else map.set(k, [e])
+    }
+    return [...map.entries()].map(([key, items]) => ({
+      key,
+      label: dateLabel(key),
+      items,
+      total: items.reduce((sum, e) => sum + e.amount, 0),
+    }))
+  }, [filtered])
+
+  const total = useMemo(() => filtered.reduce((sum, e) => sum + e.amount, 0), [filtered])
+
+  return { usedCategories, filtered, groups, total }
+}

--- a/frontend/src/expense/hooks/useTopMonth.ts
+++ b/frontend/src/expense/hooks/useTopMonth.ts
@@ -1,0 +1,47 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import type { ExpenseResponse } from "../../common/libs/types"
+
+/** Top 画面の今月分データ取得 + ヒートマップ用 totals + 集計を提供。 */
+export const useTopMonth = (year: number, month: number, today: number, daysInMonth: number) => {
+  const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
+  const [error, setError] = useState("")
+
+  const fetchData = useCallback(async () => {
+    try {
+      setExpenses(await api.getExpenses(year, month))
+    } catch (err) {
+      setError(getErrorMessage(err, "Failed to fetch data"))
+    }
+  }, [year, month])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const totals = useMemo(() => {
+    const arr: number[] = Array.from({ length: daysInMonth }, () => 0)
+    for (const e of expenses) {
+      const d = new Date(e.expensed_at)
+      if (d.getFullYear() === year && d.getMonth() === month - 1) {
+        arr[d.getDate() - 1] += e.amount
+      }
+    }
+    return arr
+  }, [expenses, year, month, daysInMonth])
+
+  const total = useMemo(() => expenses.reduce((sum, e) => sum + e.amount, 0), [expenses])
+  const perDay = today > 0 ? Math.round(total / today) : 0
+
+  const monthExpenses = useMemo(
+    () =>
+      [...expenses].toSorted(
+        (a, b) => new Date(b.expensed_at).getTime() - new Date(a.expensed_at).getTime(),
+      ),
+    [expenses],
+  )
+
+  return { error, totals, total, perDay, monthExpenses }
+}

--- a/frontend/src/expense/libs/insightStats.ts
+++ b/frontend/src/expense/libs/insightStats.ts
@@ -1,0 +1,95 @@
+import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
+import type { YearMonth } from "../components/InsightYearChart"
+
+const VIBE_LABELS: { key: string; label: string; field: keyof ExpenseResponse }[] = [
+  { key: "ROUTINE", label: "Routine", field: "vibe_planning" },
+  { key: "SPONTANEOUS", label: "Spontaneous", field: "vibe_planning" },
+  { key: "NEEDED", label: "Needed it", field: "vibe_necessity" },
+  { key: "WANTED", label: "Wanted it", field: "vibe_necessity" },
+  { key: "SOLO", label: "Solo", field: "vibe_social" },
+  { key: "WITH_SOMEONE", label: "With someone", field: "vibe_social" },
+]
+
+export interface VibeStat {
+  key: string
+  label: string
+  count: number
+  pct: number
+}
+
+export interface CategoryStat {
+  category: CategoryResponse | null
+  amount: number
+  pct: number
+}
+
+export const monthLabel = (year: number, month: number): string =>
+  new Date(year, month - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" })
+
+export const fmtAmount = (n: number): string => `¥${Math.round(n).toLocaleString()}`
+
+export const computeVibes = (expenses: ExpenseResponse[]): VibeStat[] => {
+  const counts = new Map<string, number>()
+  for (const e of expenses) {
+    for (const { key, field } of VIBE_LABELS) {
+      if (e[field] === key) {
+        counts.set(key, (counts.get(key) ?? 0) + 1)
+      }
+    }
+  }
+  const total = [...counts.values()].reduce((s, n) => s + n, 0)
+  return VIBE_LABELS.map(({ key, label }) => {
+    const count = counts.get(key) ?? 0
+    return { key, label, count, pct: total > 0 ? (count / total) * 100 : 0 }
+  })
+    .filter((v) => v.count > 0)
+    .toSorted((a, b) => b.count - a.count)
+}
+
+export const computeCategories = (expenses: ExpenseResponse[]): CategoryStat[] => {
+  const map = new Map<string, { category: CategoryResponse | null; amount: number }>()
+  for (const e of expenses) {
+    if (e.categories.length === 0) {
+      const entry = map.get("__none__") ?? { category: null, amount: 0 }
+      entry.amount += e.amount
+      map.set("__none__", entry)
+    } else {
+      for (const c of e.categories) {
+        const entry = map.get(c.uuid) ?? { category: c, amount: 0 }
+        entry.amount += e.amount
+        map.set(c.uuid, entry)
+      }
+    }
+  }
+  const total = [...map.values()].reduce((s, x) => s + x.amount, 0)
+  return [...map.values()]
+    .map(({ category, amount }) => ({
+      category,
+      amount,
+      pct: total > 0 ? (amount / total) * 100 : 0,
+    }))
+    .toSorted((a, b) => b.amount - a.amount)
+}
+
+export const computeYear = (expenses: ExpenseResponse[]): YearMonth[] => {
+  const now = new Date()
+  const months: YearMonth[] = []
+  for (let i = 11; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    months.push({
+      key: `${d.getFullYear()}-${d.getMonth() + 1}`,
+      label: d.toLocaleDateString("en-US", { month: "short" }),
+      year: d.getFullYear(),
+      month: d.getMonth() + 1,
+      amount: 0,
+      current: i === 0,
+    })
+  }
+  for (const e of expenses) {
+    const d = new Date(e.expensed_at)
+    const k = `${d.getFullYear()}-${d.getMonth() + 1}`
+    const target = months.find((m) => m.key === k)
+    if (target) target.amount += e.amount
+  }
+  return months
+}

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -1,113 +1,28 @@
 import { TrashIcon } from "@radix-ui/react-icons"
-import { type SubmitEvent, useCallback, useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router"
+import { useParams } from "react-router"
 
-import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type {
-  CategoryResponse,
-  ExpenseResponse,
-  VibeNecessity,
-  VibePlanning,
-  VibeSocial,
-} from "../../common/libs/types"
+import { ConfirmDialog } from "../../common/components/ConfirmDialog"
+import { ExpenseAmountInput } from "../components/ExpenseAmountInput"
+import { ExpenseCategoryChips } from "../components/ExpenseCategoryChips"
+import { ExpenseDateTimeInput } from "../components/ExpenseDateTimeInput"
+import { ExpenseNameInput } from "../components/ExpenseNameInput"
 import { VibePicker } from "../components/VibePicker"
-
-const pad = (n: number) => String(n).padStart(2, "0")
-
-const toLocalDatetime = (isoStr: string) => {
-  const d = new Date(isoStr)
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
+import { useExpenseEditForm } from "../hooks/useExpenseEditForm"
 
 export const ExpenseDetailPage = () => {
   const { uuid } = useParams<{ uuid: string }>()
-  const navigate = useNavigate()
-
-  const [expense, setExpense] = useState<ExpenseResponse | null>(null)
-  const [categories, setCategories] = useState<CategoryResponse[]>([])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-
-  const [form, setForm] = useState({
-    name: "",
-    amount: "",
-    expensedAt: "",
-    categoryUuid: null as string | null,
-    vibeSocial: null as VibeSocial | null,
-    vibePlanning: null as VibePlanning | null,
-    vibeNecessity: null as VibeNecessity | null,
-  })
-
-  const fetchData = useCallback(async () => {
-    if (!uuid) return
-    try {
-      const [exp, cats] = await Promise.all([api.getExpense(uuid), api.getCategories()])
-      setExpense(exp)
-      setCategories(cats)
-      setForm({
-        name: exp.name,
-        amount: exp.amount.toLocaleString(),
-        expensedAt: toLocalDatetime(exp.expensed_at),
-        categoryUuid: exp.categories[0]?.uuid ?? null,
-        vibeSocial: exp.vibe_social,
-        vibePlanning: exp.vibe_planning,
-        vibeNecessity: exp.vibe_necessity,
-      })
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to load"))
-    }
-  }, [uuid])
-
-  useEffect(() => {
-    fetchData()
-  }, [fetchData])
-
-  const handleAmountChange = (raw: string) => {
-    const digits = raw.replace(/[^0-9]/g, "")
-    setForm((prev) => ({ ...prev, amount: digits ? Number(digits).toLocaleString() : "" }))
-  }
-
-  const handleUpdate = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (!uuid) return
-    setError("")
-    setLoading(true)
-    try {
-      await api.updateExpense(uuid, {
-        name: form.name,
-        amount: Number(form.amount.replace(/,/g, "")),
-        expensed_at: new Date(form.expensedAt).toISOString(),
-        category_uuid: form.categoryUuid,
-        vibe_social: form.vibeSocial,
-        vibe_planning: form.vibePlanning,
-        vibe_necessity: form.vibeNecessity,
-      })
-      navigate(-1)
-    } catch (err) {
-      setError(getErrorMessage(err, "Update failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const { dialogRef, open: openDeleteDialog } = useConfirmDialog()
-
-  const handleDelete = async () => {
-    if (!uuid) return
-    setLoading(true)
-    try {
-      await api.deleteExpense(uuid)
-      dialogRef.current?.close()
-      navigate("/expense/monthly")
-    } catch (err) {
-      setError(getErrorMessage(err, "Delete failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
+  const {
+    expense,
+    categories,
+    error,
+    loading,
+    form,
+    update,
+    dialogRef,
+    openDeleteDialog,
+    handleUpdate,
+    handleDelete,
+  } = useExpenseEditForm(uuid)
 
   if (!expense && !error) {
     return null
@@ -129,100 +44,22 @@ export const ExpenseDetailPage = () => {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <div className="px-5 pt-3">
-          <input
-            type="text"
-            value={form.name}
-            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-            required
-            maxLength={100}
-            placeholder="What was this?"
-            className="w-full bg-transparent text-2xl font-bold tracking-tight outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
-          />
-          <div className="mt-2 h-px bg-gray-200 dark:bg-gray-700" />
-        </div>
-
-        <div className="px-5 pt-5 text-center">
-          <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-            What did this cost you
-          </div>
-          <div className="mt-2 flex items-baseline justify-center gap-1">
-            <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
-            <input
-              type="text"
-              inputMode="numeric"
-              value={form.amount}
-              onChange={(e) => handleAmountChange(e.target.value)}
-              required
-              placeholder="0"
-              className="w-44 bg-transparent text-center text-5xl font-bold tracking-tighter tabular-nums outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
-            />
-          </div>
-        </div>
-
-        <div className="px-5 pt-5 text-center">
-          <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-            When
-          </div>
-          <input
-            type="datetime-local"
-            value={form.expensedAt}
-            onChange={(e) => setForm((prev) => ({ ...prev, expensedAt: e.target.value }))}
-            required
-            className="mt-1 bg-transparent text-center text-sm font-medium tabular-nums outline-none dark:text-gray-100"
-          />
-        </div>
-
-        {categories.length > 0 && (
-          <div className="px-4 pt-4">
-            <div className="flex flex-wrap gap-2">
-              {categories.map((c) => {
-                const active = form.categoryUuid === c.uuid
-                return (
-                  <button
-                    key={c.uuid}
-                    type="button"
-                    onClick={() =>
-                      setForm((prev) => ({
-                        ...prev,
-                        categoryUuid: prev.categoryUuid === c.uuid ? null : c.uuid,
-                      }))
-                    }
-                    className={`flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-xs font-semibold ${
-                      active
-                        ? "border-primary bg-primary text-white"
-                        : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
-                    }`}
-                  >
-                    <span>{categoryGlyph(c)}</span>
-                    <span>{c.name}</span>
-                  </button>
-                )
-              })}
-              <button
-                type="button"
-                onClick={() => navigate("/category/new")}
-                className="flex items-center rounded-2xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
-              >
-                + Category
-              </button>
-            </div>
-            {!form.categoryUuid && (
-              <p className="px-1 pt-2 text-[11px] text-gray-400 dark:text-gray-500">
-                No category — saved without one.
-              </p>
-            )}
-          </div>
-        )}
-
+        <ExpenseNameInput value={form.name} onChange={(v) => update("name", v)} />
+        <ExpenseAmountInput value={form.amount} onChange={(v) => update("amount", v)} />
+        <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
+        <ExpenseCategoryChips
+          categories={categories}
+          selectedUuid={form.categoryUuid}
+          onSelect={(v) => update("categoryUuid", v)}
+        />
         <div className="px-4 pt-5 pb-4">
           <VibePicker
             social={form.vibeSocial}
             planning={form.vibePlanning}
             necessity={form.vibeNecessity}
-            onSocialChange={(v) => setForm((prev) => ({ ...prev, vibeSocial: v }))}
-            onPlanningChange={(v) => setForm((prev) => ({ ...prev, vibePlanning: v }))}
-            onNecessityChange={(v) => setForm((prev) => ({ ...prev, vibeNecessity: v }))}
+            onSocialChange={(v) => update("vibeSocial", v)}
+            onPlanningChange={(v) => update("vibePlanning", v)}
+            onNecessityChange={(v) => update("vibeNecessity", v)}
           />
         </div>
       </div>

--- a/frontend/src/expense/pages/ExpenseInsightPage.tsx
+++ b/frontend/src/expense/pages/ExpenseInsightPage.tsx
@@ -1,103 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
 import { getErrorMessage } from "../../common/libs/client"
-import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
-import { InsightYearChart, type YearMonth } from "../components/InsightYearChart"
-
-const VIBE_LABELS: { key: string; label: string; field: keyof ExpenseResponse }[] = [
-  { key: "ROUTINE", label: "Routine", field: "vibe_planning" },
-  { key: "SPONTANEOUS", label: "Spontaneous", field: "vibe_planning" },
-  { key: "NEEDED", label: "Needed it", field: "vibe_necessity" },
-  { key: "WANTED", label: "Wanted it", field: "vibe_necessity" },
-  { key: "SOLO", label: "Solo", field: "vibe_social" },
-  { key: "WITH_SOMEONE", label: "With someone", field: "vibe_social" },
-]
-
-const monthLabel = (year: number, month: number): string =>
-  new Date(year, month - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" })
-
-const fmtAmount = (n: number): string => `¥${Math.round(n).toLocaleString()}`
-
-interface VibeStat {
-  key: string
-  label: string
-  count: number
-  pct: number
-}
-
-interface CategoryStat {
-  category: CategoryResponse | null
-  amount: number
-  pct: number
-}
-
-const computeVibes = (expenses: ExpenseResponse[]): VibeStat[] => {
-  const counts = new Map<string, number>()
-  for (const e of expenses) {
-    for (const { key, field } of VIBE_LABELS) {
-      if (e[field] === key) {
-        counts.set(key, (counts.get(key) ?? 0) + 1)
-      }
-    }
-  }
-  const total = [...counts.values()].reduce((s, n) => s + n, 0)
-  return VIBE_LABELS.map(({ key, label }) => {
-    const count = counts.get(key) ?? 0
-    return { key, label, count, pct: total > 0 ? (count / total) * 100 : 0 }
-  })
-    .filter((v) => v.count > 0)
-    .toSorted((a, b) => b.count - a.count)
-}
-
-const computeCategories = (expenses: ExpenseResponse[]): CategoryStat[] => {
-  const map = new Map<string, { category: CategoryResponse | null; amount: number }>()
-  for (const e of expenses) {
-    if (e.categories.length === 0) {
-      const entry = map.get("__none__") ?? { category: null, amount: 0 }
-      entry.amount += e.amount
-      map.set("__none__", entry)
-    } else {
-      for (const c of e.categories) {
-        const entry = map.get(c.uuid) ?? { category: c, amount: 0 }
-        entry.amount += e.amount
-        map.set(c.uuid, entry)
-      }
-    }
-  }
-  const total = [...map.values()].reduce((s, x) => s + x.amount, 0)
-  return [...map.values()]
-    .map(({ category, amount }) => ({
-      category,
-      amount,
-      pct: total > 0 ? (amount / total) * 100 : 0,
-    }))
-    .toSorted((a, b) => b.amount - a.amount)
-}
-
-const computeYear = (expenses: ExpenseResponse[]): YearMonth[] => {
-  const now = new Date()
-  const months: YearMonth[] = []
-  for (let i = 11; i >= 0; i--) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
-    months.push({
-      key: `${d.getFullYear()}-${d.getMonth() + 1}`,
-      label: d.toLocaleDateString("en-US", { month: "short" }),
-      year: d.getFullYear(),
-      month: d.getMonth() + 1,
-      amount: 0,
-      current: i === 0,
-    })
-  }
-  for (const e of expenses) {
-    const d = new Date(e.expensed_at)
-    const k = `${d.getFullYear()}-${d.getMonth() + 1}`
-    const target = months.find((m) => m.key === k)
-    if (target) target.amount += e.amount
-  }
-  return months
-}
+import type { ExpenseResponse } from "../../common/libs/types"
+import { InsightCategoryCard } from "../components/InsightCategoryCard"
+import { InsightSection } from "../components/InsightSection"
+import { InsightVibeCard } from "../components/InsightVibeCard"
+import { InsightYearChart } from "../components/InsightYearChart"
+import { computeCategories, computeVibes, computeYear, monthLabel } from "../libs/insightStats"
 
 export const ExpenseInsightPage = () => {
   const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
@@ -132,9 +42,6 @@ export const ExpenseInsightPage = () => {
   const cats = useMemo(() => computeCategories(thisMonth), [thisMonth])
   const yearMonths = useMemo(() => computeYear(expenses), [expenses])
 
-  const catTotal = cats.reduce((s, c) => s + c.amount, 0)
-  const topVibe = vibes[0]
-
   return (
     <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
       {error && (
@@ -151,113 +58,18 @@ export const ExpenseInsightPage = () => {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-5 pb-8">
-        <div className="mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
-          Why you spent
-        </div>
-        <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
-          {topVibe ? (
-            <>
-              <div className="flex items-baseline gap-2">
-                <span className="text-3xl font-bold tracking-tight tabular-nums">
-                  {Math.round(topVibe.pct)}%
-                </span>
-                <span className="text-sm text-gray-500 dark:text-gray-400">
-                  was {topVibe.label.toLowerCase()}
-                </span>
-              </div>
-              <div className="mt-3 flex h-3.5 gap-0.5 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
-                {vibes.map((v, i) => (
-                  <div
-                    key={v.key}
-                    style={{ width: `${v.pct}%`, opacity: 1 - i * 0.18 }}
-                    className="bg-primary"
-                  />
-                ))}
-              </div>
-              <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
-                {vibes.map((v, i) => (
-                  <div key={v.key} className="flex items-center gap-2.5 py-2">
-                    <div
-                      style={{ opacity: 1 - i * 0.18 }}
-                      className="size-2.5 rounded-sm bg-primary"
-                    />
-                    <span className="flex-1 text-sm font-medium">{v.label}</span>
-                    <span className="text-[11px] text-gray-400 dark:text-gray-500">
-                      {v.count} {v.count === 1 ? "time" : "times"}
-                    </span>
-                    <span className="min-w-9 text-right text-sm font-bold tabular-nums">
-                      {Math.round(v.pct)}%
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <p className="py-2 text-sm text-gray-400 dark:text-gray-500">
-              No vibe data this month yet.
-            </p>
-          )}
-        </div>
+      <div className="flex flex-1 flex-col gap-6 overflow-y-auto px-5 pb-8">
+        <InsightSection title="Why you spent">
+          <InsightVibeCard vibes={vibes} />
+        </InsightSection>
 
-        <div className="mt-6 mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
-          This month by category
-        </div>
-        <div className="rounded-2xl border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800">
-          {cats.length > 0 ? (
-            <>
-              <div className="flex items-baseline gap-2">
-                <span className="text-3xl font-bold tracking-tight tabular-nums">
-                  {fmtAmount(catTotal)}
-                </span>
-                <span className="text-sm text-gray-500 dark:text-gray-400">total</span>
-              </div>
-              <div className="mt-3 flex h-3.5 gap-0.5 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
-                {cats.map((c, i) => (
-                  <div
-                    key={c.category?.uuid ?? "__none__"}
-                    style={{ width: `${c.pct}%`, opacity: 1 - i * 0.13 }}
-                    className="bg-primary"
-                  />
-                ))}
-              </div>
-              <div className="mt-3 divide-y divide-gray-100 dark:divide-gray-700">
-                {cats.map((c, i) => (
-                  <div
-                    key={c.category?.uuid ?? "__none__"}
-                    className="flex items-center gap-2.5 py-2"
-                  >
-                    <div
-                      style={{ opacity: 1 - i * 0.13 }}
-                      className="size-2.5 rounded-sm bg-primary"
-                    />
-                    <span className="text-sm">{c.category ? categoryGlyph(c.category) : "·"}</span>
-                    <span className="flex-1 text-sm font-medium">
-                      {c.category ? c.category.name : "Uncategorized"}
-                    </span>
-                    <span className="text-[11px] text-gray-400 tabular-nums dark:text-gray-500">
-                      {fmtAmount(c.amount)}
-                    </span>
-                    <span className="min-w-10 text-right text-sm font-bold tabular-nums">
-                      {Math.round(c.pct)}%
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : (
-            <p className="py-2 text-sm text-gray-400 dark:text-gray-500">
-              No expenses this month yet.
-            </p>
-          )}
-        </div>
+        <InsightSection title="This month by category">
+          <InsightCategoryCard cats={cats} />
+        </InsightSection>
 
-        <div className="mt-6 mb-2.5 px-1 text-[10px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
-          Last 12 months
-        </div>
-        <div className="rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <InsightSection title="Last 12 months" padding="p-4">
           <InsightYearChart year={yearMonths} />
-        </div>
+        </InsightSection>
       </div>
     </div>
   )

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -1,74 +1,15 @@
-import { type SubmitEvent, useCallback, useEffect, useRef, useState } from "react"
-import { useNavigate } from "react-router"
-
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type {
-  CategoryResponse,
-  VibeNecessity,
-  VibePlanning,
-  VibeSocial,
-} from "../../common/libs/types"
+import { ExpenseAmountInput } from "../components/ExpenseAmountInput"
+import { ExpenseCategoryChips } from "../components/ExpenseCategoryChips"
+import { ExpenseNameInput } from "../components/ExpenseNameInput"
 import { VibePicker } from "../components/VibePicker"
+import { useExpenseCreateForm } from "../hooks/useExpenseCreateForm"
 
 export const ExpensesPage = () => {
-  const navigate = useNavigate()
-  const nameRef = useRef<HTMLInputElement>(null)
-  const [categories, setCategories] = useState<CategoryResponse[]>([])
-  const [error, setError] = useState("")
-  const [loading, setLoading] = useState(false)
-
-  const [name, setName] = useState("")
-  const [amount, setAmount] = useState("")
-  const [categoryUuid, setCategoryUuid] = useState<string | null>(null)
-  const [vibeSocial, setVibeSocial] = useState<VibeSocial | null>(null)
-  const [vibePlanning, setVibePlanning] = useState<VibePlanning | null>(null)
-  const [vibeNecessity, setVibeNecessity] = useState<VibeNecessity | null>(null)
-
-  const fetchData = useCallback(async () => {
-    try {
-      setCategories(await api.getCategories())
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to fetch data"))
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchData()
-    nameRef.current?.focus()
-  }, [fetchData])
-
-  const handleAmountChange = (raw: string) => {
-    const digits = raw.replace(/[^0-9]/g, "")
-    setAmount(digits ? Number(digits).toLocaleString() : "")
-  }
-
-  const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    setError("")
-    setLoading(true)
-    try {
-      await api.createExpense({
-        name,
-        amount: Number(amount.replace(/,/g, "")),
-        expensed_at: new Date().toISOString(),
-        category_uuid: categoryUuid,
-        vibe_social: vibeSocial,
-        vibe_planning: vibePlanning,
-        vibe_necessity: vibeNecessity,
-      })
-      navigate("/expense/monthly")
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to create"))
-    } finally {
-      setLoading(false)
-    }
-  }
+  const f = useExpenseCreateForm()
 
   return (
     <form
-      onSubmit={handleSubmit}
+      onSubmit={f.handleSubmit}
       className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
       <div className="flex shrink-0 justify-center px-4 pt-8 pb-2">
@@ -77,88 +18,26 @@ export const ExpensesPage = () => {
         </span>
       </div>
 
-      {error && (
-        <p className="mx-5 shrink-0 pb-1 text-sm text-red-600 dark:text-red-400">{error}</p>
+      {f.error && (
+        <p className="mx-5 shrink-0 pb-1 text-sm text-red-600 dark:text-red-400">{f.error}</p>
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <div className="px-5 pt-3">
-          <input
-            ref={nameRef}
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            maxLength={100}
-            placeholder="What was this?"
-            className="w-full bg-transparent text-2xl font-bold tracking-tight outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
-          />
-          <div className="mt-2 h-px bg-gray-200 dark:bg-gray-700" />
-        </div>
-
-        <div className="px-5 pt-5 text-center">
-          <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-            What did this cost you
-          </div>
-          <div className="mt-2 flex items-baseline justify-center gap-1">
-            <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
-            <input
-              type="text"
-              inputMode="numeric"
-              value={amount}
-              onChange={(e) => handleAmountChange(e.target.value)}
-              required
-              placeholder="0"
-              className="w-44 bg-transparent text-center text-5xl font-bold tracking-tighter tabular-nums outline-none placeholder:text-gray-300 dark:text-gray-100 dark:placeholder:text-gray-600"
-            />
-          </div>
-        </div>
-
-        {categories.length > 0 && (
-          <div className="px-4 pt-4">
-            <div className="flex flex-wrap gap-2">
-              {categories.map((c) => {
-                const active = categoryUuid === c.uuid
-                return (
-                  <button
-                    key={c.uuid}
-                    type="button"
-                    onClick={() => setCategoryUuid(active ? null : c.uuid)}
-                    className={`flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-xs font-semibold ${
-                      active
-                        ? "border-primary bg-primary text-white"
-                        : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
-                    }`}
-                  >
-                    <span>{categoryGlyph(c)}</span>
-                    <span>{c.name}</span>
-                  </button>
-                )
-              })}
-              <button
-                type="button"
-                onClick={() => navigate("/category/new")}
-                className="flex items-center rounded-2xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
-              >
-                + Category
-              </button>
-            </div>
-            {!categoryUuid && (
-              <p className="px-1 pt-2 text-[11px] text-gray-400 dark:text-gray-500">
-                No category — saved without one.
-              </p>
-            )}
-          </div>
-        )}
-
+        <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
+        <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
+        <ExpenseCategoryChips
+          categories={f.categories}
+          selectedUuid={f.categoryUuid}
+          onSelect={f.setCategoryUuid}
+        />
         <div className="px-4 pt-5 pb-4">
           <VibePicker
-            social={vibeSocial}
-            planning={vibePlanning}
-            necessity={vibeNecessity}
-            onSocialChange={setVibeSocial}
-            onPlanningChange={setVibePlanning}
-            onNecessityChange={setVibeNecessity}
+            social={f.vibeSocial}
+            planning={f.vibePlanning}
+            necessity={f.vibeNecessity}
+            onSocialChange={f.setVibeSocial}
+            onPlanningChange={f.setVibePlanning}
+            onNecessityChange={f.setVibeNecessity}
           />
         </div>
       </div>
@@ -166,10 +45,10 @@ export const ExpensesPage = () => {
       <div className="shrink-0 px-4 pt-2 pb-3">
         <button
           type="submit"
-          disabled={loading || !name || !amount}
+          disabled={f.loading || !f.name || !f.amount}
           className="w-full rounded-2xl bg-primary px-4 py-4 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
         >
-          {loading ? "Saving…" : "Save expense"}
+          {f.loading ? "Saving…" : "Save expense"}
         </button>
       </div>
     </form>

--- a/frontend/src/expense/pages/TopPage.tsx
+++ b/frontend/src/expense/pages/TopPage.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router"
 
-import { api } from "../../common/libs/api"
-import { categoryGlyph } from "../../common/libs/category"
-import { getErrorMessage } from "../../common/libs/client"
-import type { ExpenseResponse } from "../../common/libs/types"
 import { TopHeatmap } from "../components/TopHeatmap"
+import { TopMomentsList } from "../components/TopMomentsList"
+import { TopMonthSummary } from "../components/TopMonthSummary"
+import { useTopMonth } from "../hooks/useTopMonth"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 
@@ -13,16 +11,6 @@ const monthLabel = (year: number, month: number): string =>
   new Date(year, month - 1, 1)
     .toLocaleDateString("en-US", { month: "long", year: "numeric" })
     .toUpperCase()
-
-const dayShort = (iso: string): string => {
-  const d = new Date(iso)
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-const timeLabel = (iso: string): string => {
-  const d = new Date(iso)
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
 
 export const TopPage = () => {
   const navigate = useNavigate()
@@ -32,41 +20,11 @@ export const TopPage = () => {
   const today = now.getDate()
   const daysInMonth = new Date(year, month, 0).getDate()
 
-  const [expenses, setExpenses] = useState<ExpenseResponse[]>([])
-  const [error, setError] = useState("")
-
-  const fetchData = useCallback(async () => {
-    try {
-      setExpenses(await api.getExpenses(year, month))
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to fetch data"))
-    }
-  }, [year, month])
-
-  useEffect(() => {
-    fetchData()
-  }, [fetchData])
-
-  const totals = useMemo(() => {
-    const arr: number[] = Array.from({ length: daysInMonth }, () => 0)
-    for (const e of expenses) {
-      const d = new Date(e.expensed_at)
-      if (d.getFullYear() === year && d.getMonth() === month - 1) {
-        arr[d.getDate() - 1] += e.amount
-      }
-    }
-    return arr
-  }, [expenses, year, month, daysInMonth])
-
-  const total = useMemo(() => expenses.reduce((sum, e) => sum + e.amount, 0), [expenses])
-  const perDay = today > 0 ? Math.round(total / today) : 0
-
-  const monthExpenses = useMemo(
-    () =>
-      [...expenses].toSorted(
-        (a, b) => new Date(b.expensed_at).getTime() - new Date(a.expensed_at).getTime(),
-      ),
-    [expenses],
+  const { error, totals, total, perDay, monthExpenses } = useTopMonth(
+    year,
+    month,
+    today,
+    daysInMonth,
   )
 
   return (
@@ -85,26 +43,11 @@ export const TopPage = () => {
           month={month}
           today={today}
           totals={totals}
-          onSelectDay={(day) => {
-            const dateKey = `${year}-${pad(month)}-${pad(day)}`
-            navigate(`/expense/monthly?date=${dateKey}`)
-          }}
+          onSelectDay={(day) => navigate(`/expense/monthly?date=${year}-${pad(month)}-${pad(day)}`)}
         />
       </div>
 
-      <div className="mt-6 shrink-0 border-b border-gray-200 pb-4 dark:border-gray-700">
-        <div className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-          Burned this month
-        </div>
-        <div className="mt-2 flex items-baseline gap-2">
-          <span className="text-4xl font-bold tracking-tight tabular-nums">
-            ¥{total.toLocaleString()}
-          </span>
-          <span className="text-xs text-gray-400 dark:text-gray-500">
-            · ¥{perDay.toLocaleString()}/day
-          </span>
-        </div>
-      </div>
+      <TopMonthSummary total={total} perDay={perDay} />
 
       <div className="mt-5 mb-1.5 flex shrink-0 items-baseline justify-between">
         <span className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
@@ -119,50 +62,7 @@ export const TopPage = () => {
         </button>
       </div>
 
-      {monthExpenses.length === 0 ? (
-        <p className="shrink-0 py-6 text-center text-sm text-gray-400 dark:text-gray-500">
-          No expenses yet
-        </p>
-      ) : (
-        <ul className="min-h-0 flex-1 divide-y divide-gray-100 overflow-y-auto pb-2 dark:divide-gray-700">
-          {monthExpenses.map((e, i) => {
-            const c = e.categories[0]
-            const showDate =
-              i === 0 ||
-              new Date(monthExpenses[i - 1].expensed_at).toDateString() !==
-                new Date(e.expensed_at).toDateString()
-            return (
-              <li key={e.uuid}>
-                <button
-                  type="button"
-                  onClick={() => navigate(`/expense/${e.uuid}`)}
-                  className="grid w-full grid-cols-[46px_14px_1fr_auto] items-center gap-1.5 py-2 text-left"
-                >
-                  <span
-                    className={`text-[11px] font-semibold ${
-                      showDate ? "text-gray-500 dark:text-gray-400" : "text-transparent"
-                    }`}
-                  >
-                    {dayShort(e.expensed_at)}
-                  </span>
-                  <span className="text-center text-[11px] text-gray-400 dark:text-gray-500">
-                    {c ? categoryGlyph(c) : "·"}
-                  </span>
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{e.name}</div>
-                    <div className="truncate text-[10px] text-gray-400 dark:text-gray-500">
-                      {c ? c.name : "Uncategorized"} · {timeLabel(e.expensed_at)}
-                    </div>
-                  </div>
-                  <span className="text-sm font-medium tabular-nums">
-                    ¥{e.amount.toLocaleString()}
-                  </span>
-                </button>
-              </li>
-            )
-          })}
-        </ul>
-      )}
+      <TopMomentsList expenses={monthExpenses} />
     </div>
   )
 }

--- a/frontend/src/setting/components/SettingsAccountSection.tsx
+++ b/frontend/src/setting/components/SettingsAccountSection.tsx
@@ -1,0 +1,54 @@
+import { ExitIcon, TrashIcon } from "@radix-ui/react-icons"
+
+import { SettingsSectionLabel } from "./SettingsSectionLabel"
+
+interface SettingsAccountSectionProps {
+  userName: string | undefined
+  loading: boolean
+  onLogout: () => void
+  onOpenDelete: () => void
+}
+
+export const SettingsAccountSection = ({
+  userName,
+  loading,
+  onLogout,
+  onOpenDelete,
+}: SettingsAccountSectionProps) => (
+  <div>
+    <SettingsSectionLabel>Account</SettingsSectionLabel>
+    <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+      <button
+        type="button"
+        onClick={onLogout}
+        className="flex w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40"
+      >
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
+          <ExitIcon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">Log out</div>
+          {userName && (
+            <div className="truncate text-[11px] text-gray-500 dark:text-gray-400">{userName}</div>
+          )}
+        </div>
+      </button>
+      <button
+        type="button"
+        onClick={onOpenDelete}
+        disabled={loading}
+        className="flex w-full items-center gap-3 border-t border-gray-100 px-4 py-3.5 text-left text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-gray-700 dark:text-red-400 dark:hover:bg-red-950/30"
+      >
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400">
+          <TrashIcon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold">Delete account</div>
+          <div className="truncate text-[11px] text-red-400/80 dark:text-red-300/60">
+            Permanently erase all expenses
+          </div>
+        </div>
+      </button>
+    </div>
+  </div>
+)

--- a/frontend/src/setting/components/SettingsDataSection.tsx
+++ b/frontend/src/setting/components/SettingsDataSection.tsx
@@ -1,0 +1,52 @@
+import { DownloadIcon, UploadIcon } from "@radix-ui/react-icons"
+
+import { SettingsRow, type SettingsRowAction } from "./SettingsRow"
+import { SettingsSectionLabel } from "./SettingsSectionLabel"
+
+interface SettingsDataSectionProps {
+  loading: boolean
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  onExport: () => void
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export const SettingsDataSection = ({
+  loading,
+  fileInputRef,
+  onExport,
+  onFileSelect,
+}: SettingsDataSectionProps) => {
+  const rows: SettingsRowAction[] = [
+    {
+      label: "Import data",
+      Icon: DownloadIcon,
+      onClick: () => fileInputRef.current?.click(),
+      accent: true,
+      disabled: loading,
+    },
+    {
+      label: "Export your data",
+      Icon: UploadIcon,
+      onClick: onExport,
+      accent: true,
+    },
+  ]
+
+  return (
+    <div>
+      <SettingsSectionLabel>Your data</SettingsSectionLabel>
+      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+        {rows.map((row, i) => (
+          <SettingsRow key={row.label} row={row} divided={i > 0} />
+        ))}
+      </div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".json"
+        onChange={onFileSelect}
+        className="hidden"
+      />
+    </div>
+  )
+}

--- a/frontend/src/setting/components/SettingsProfileHeader.tsx
+++ b/frontend/src/setting/components/SettingsProfileHeader.tsx
@@ -1,0 +1,71 @@
+import { CheckIcon, Pencil1Icon, ResetIcon } from "@radix-ui/react-icons"
+
+interface SettingsProfileHeaderProps {
+  name: string | undefined
+  editing: boolean
+  draftName: string
+  loading: boolean
+  onDraftChange: (v: string) => void
+  onStartEdit: () => void
+  onSave: () => void
+  onCancel: () => void
+}
+
+export const SettingsProfileHeader = ({
+  name,
+  editing,
+  draftName,
+  loading,
+  onDraftChange,
+  onStartEdit,
+  onSave,
+  onCancel,
+}: SettingsProfileHeaderProps) => {
+  const initial = (name ?? "?").charAt(0).toUpperCase()
+
+  return (
+    <div className="flex items-center gap-3.5 px-2 pt-2">
+      <div className="flex size-14 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xl font-bold dark:bg-gray-700">
+        {initial}
+      </div>
+      <div className="min-w-0 flex-1">
+        {editing ? (
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={draftName}
+              onChange={(e) => onDraftChange(e.target.value)}
+              maxLength={50}
+              className="min-w-0 flex-1 border-b border-gray-300 px-1 py-0.5 text-lg font-bold tracking-tight outline-none focus:border-primary dark:border-gray-600 dark:bg-transparent dark:text-gray-100"
+            />
+            <button
+              type="button"
+              onClick={onSave}
+              disabled={loading}
+              className="text-primary hover:text-primary-hover disabled:opacity-50"
+            >
+              <CheckIcon className="size-4" />
+            </button>
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={loading}
+              className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
+            >
+              <ResetIcon className="size-4" />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onStartEdit}
+            className="flex w-full items-center gap-2 text-left"
+          >
+            <span className="truncate text-xl font-bold tracking-tight">{name ?? "---"}</span>
+            <Pencil1Icon className="size-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/setting/components/SettingsThemePicker.tsx
+++ b/frontend/src/setting/components/SettingsThemePicker.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react"
+
+import { applyTheme, getStoredTheme, type ThemeMode } from "../../common/libs/theme"
+import { SettingsSectionLabel } from "./SettingsSectionLabel"
+
+const MODES: ThemeMode[] = ["system", "light", "dark"]
+const LABELS: Record<ThemeMode, string> = {
+  system: "System",
+  light: "Light",
+  dark: "Dark",
+}
+
+export const SettingsThemePicker = () => {
+  const [theme, setTheme] = useState<ThemeMode>(getStoredTheme)
+
+  const change = (mode: ThemeMode) => {
+    setTheme(mode)
+    applyTheme(mode)
+  }
+
+  return (
+    <div>
+      <SettingsSectionLabel>Preferences</SettingsSectionLabel>
+      <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
+        <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">Theme</p>
+        <div className="flex gap-2">
+          {MODES.map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              onClick={() => change(mode)}
+              className={`flex-1 rounded-xl py-2 text-sm transition-colors ${
+                theme === mode
+                  ? "bg-primary text-white"
+                  : "bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
+              }`}
+            >
+              {LABELS[mode]}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/setting/hooks/useSettingsActions.ts
+++ b/frontend/src/setting/hooks/useSettingsActions.ts
@@ -1,0 +1,126 @@
+import { useRef, useState } from "react"
+
+import { useConfirmDialog } from "../../common/components/ConfirmDialog"
+import { api } from "../../common/libs/api"
+import { getErrorMessage } from "../../common/libs/client"
+import { STORAGE_KEYS } from "../../common/libs/constants"
+import type { UserResponse } from "../../common/libs/types"
+
+interface Args {
+  user: UserResponse | null
+  refreshUser: () => Promise<void>
+}
+
+/** Settings 画面のサーバ操作 (名前更新 / 削除 / export / import) と関連 state を一括提供。 */
+export const useSettingsActions = ({ user, refreshUser }: Args) => {
+  const [error, setError] = useState("")
+  const [success, setSuccess] = useState("")
+  const [editing, setEditing] = useState(false)
+  const [name, setName] = useState("")
+  const [loading, setLoading] = useState(false)
+  const { dialogRef, open: openDeleteDialog } = useConfirmDialog()
+  const { dialogRef: importDialogRef, open: openImportDialog } = useConfirmDialog()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const importDataRef = useRef<unknown>(null)
+
+  const startEdit = () => {
+    setName(user?.name ?? "")
+    setEditing(true)
+  }
+
+  const handleUpdate = async () => {
+    setError("")
+    setLoading(true)
+    try {
+      await api.updateMe({ name })
+      setEditing(false)
+      await refreshUser()
+    } catch (err) {
+      setError(getErrorMessage(err, "Update failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setError("")
+    setLoading(true)
+    try {
+      await api.deleteMe()
+      localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
+      dialogRef.current?.close()
+      window.location.href = "/auth"
+    } catch (err) {
+      setError(getErrorMessage(err, "Delete failed"))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleExport = async () => {
+    try {
+      const data = await api.exportMe()
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" })
+      const a = document.createElement("a")
+      a.href = URL.createObjectURL(blob)
+      a.download = `${user?.name ?? "export"}_expense.json`
+      a.click()
+      URL.revokeObjectURL(a.href)
+    } catch (err) {
+      setError(getErrorMessage(err, "Export failed"))
+    }
+  }
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    e.target.value = ""
+
+    const reader = new FileReader()
+    reader.addEventListener("load", (event) => {
+      try {
+        importDataRef.current = JSON.parse(event.target?.result as string)
+        openImportDialog()
+      } catch {
+        setError("Invalid JSON file")
+      }
+    })
+    reader.readAsText(file)
+  }
+
+  const handleImport = async () => {
+    setError("")
+    setSuccess("")
+    setLoading(true)
+    importDialogRef.current?.close()
+    try {
+      const result = await api.importMe(importDataRef.current)
+      setSuccess(result.message)
+    } catch (err) {
+      setError(getErrorMessage(err, "Import failed"))
+    } finally {
+      importDataRef.current = null
+      setLoading(false)
+    }
+  }
+
+  return {
+    error,
+    success,
+    editing,
+    name,
+    loading,
+    fileInputRef,
+    dialogRef,
+    importDialogRef,
+    setName,
+    setEditing,
+    startEdit,
+    handleUpdate,
+    handleDelete,
+    handleExport,
+    handleFileSelect,
+    handleImport,
+    openDeleteDialog,
+  }
+}

--- a/frontend/src/setting/pages/SettingsPage.tsx
+++ b/frontend/src/setting/pages/SettingsPage.tsx
@@ -1,25 +1,14 @@
-import {
-  CheckIcon,
-  CounterClockwiseClockIcon,
-  DownloadIcon,
-  ExitIcon,
-  Pencil1Icon,
-  ResetIcon,
-  RowsIcon,
-  TrashIcon,
-  UploadIcon,
-} from "@radix-ui/react-icons"
-import { useRef, useState } from "react"
+import { CounterClockwiseClockIcon, RowsIcon } from "@radix-ui/react-icons"
 import { useNavigate, useOutletContext } from "react-router"
 
-import { ConfirmDialog, useConfirmDialog } from "../../common/components/ConfirmDialog"
-import { api } from "../../common/libs/api"
-import { getErrorMessage } from "../../common/libs/client"
-import { STORAGE_KEYS } from "../../common/libs/constants"
-import { type ThemeMode, applyTheme, getStoredTheme } from "../../common/libs/theme"
+import { ConfirmDialog } from "../../common/components/ConfirmDialog"
 import type { UserResponse } from "../../common/libs/types"
+import { SettingsAccountSection } from "../components/SettingsAccountSection"
+import { SettingsDataSection } from "../components/SettingsDataSection"
+import { SettingsProfileHeader } from "../components/SettingsProfileHeader"
 import { SettingsRow, type SettingsRowAction } from "../components/SettingsRow"
-import { SettingsSectionLabel } from "../components/SettingsSectionLabel"
+import { SettingsThemePicker } from "../components/SettingsThemePicker"
+import { useSettingsActions } from "../hooks/useSettingsActions"
 
 interface OutletContext {
   user: UserResponse | null
@@ -30,112 +19,10 @@ interface OutletContext {
 export const SettingsPage = () => {
   const navigate = useNavigate()
   const { user, onLogout, refreshUser } = useOutletContext<OutletContext>()
-  const [error, setError] = useState("")
-  const [success, setSuccess] = useState("")
-  const [editing, setEditing] = useState(false)
-  const [name, setName] = useState("")
-  const [theme, setTheme] = useState<ThemeMode>(getStoredTheme)
-  const [loading, setLoading] = useState(false)
-  const { dialogRef, open: openDialog } = useConfirmDialog()
-  const { dialogRef: importDialogRef, open: openImportDialog } = useConfirmDialog()
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const importDataRef = useRef<unknown>(null)
-
-  const initial = (user?.name ?? "?").charAt(0).toUpperCase()
-
-  const changeTheme = (mode: ThemeMode) => {
-    setTheme(mode)
-    applyTheme(mode)
-  }
-
-  const startEdit = () => {
-    setName(user?.name ?? "")
-    setEditing(true)
-  }
-
-  const handleUpdate = async () => {
-    setError("")
-    setLoading(true)
-    try {
-      await api.updateMe({ name })
-      setEditing(false)
-      await refreshUser()
-    } catch (err) {
-      setError(getErrorMessage(err, "Update failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleDelete = async () => {
-    setError("")
-    setLoading(true)
-    try {
-      await api.deleteMe()
-      localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
-      dialogRef.current?.close()
-      window.location.href = "/auth"
-    } catch (err) {
-      setError(getErrorMessage(err, "Delete failed"))
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleExport = async () => {
-    try {
-      const data = await api.exportMe()
-      const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" })
-      const a = document.createElement("a")
-      a.href = URL.createObjectURL(blob)
-      a.download = `${user?.name ?? "export"}_expense.json`
-      a.click()
-      URL.revokeObjectURL(a.href)
-    } catch (err) {
-      setError(getErrorMessage(err, "Export failed"))
-    }
-  }
-
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0]
-    if (!file) return
-    e.target.value = ""
-
-    const reader = new FileReader()
-    reader.addEventListener("load", (event) => {
-      try {
-        importDataRef.current = JSON.parse(event.target?.result as string)
-        openImportDialog()
-      } catch {
-        setError("Invalid JSON file")
-      }
-    })
-    reader.readAsText(file)
-  }
-
-  const handleImport = async () => {
-    setError("")
-    setSuccess("")
-    setLoading(true)
-    importDialogRef.current?.close()
-    try {
-      const result = await api.importMe(importDataRef.current)
-      setSuccess(result.message)
-    } catch (err) {
-      setError(getErrorMessage(err, "Import failed"))
-    } finally {
-      importDataRef.current = null
-      setLoading(false)
-    }
-  }
+  const actions = useSettingsActions({ user, refreshUser })
 
   const navRows: SettingsRowAction[] = [
-    {
-      label: "Categories",
-      Icon: RowsIcon,
-      onClick: () => navigate("/category"),
-      accent: true,
-    },
+    { label: "Categories", Icon: RowsIcon, onClick: () => navigate("/category"), accent: true },
     {
       label: "Recurring",
       Icon: CounterClockwiseClockIcon,
@@ -144,72 +31,25 @@ export const SettingsPage = () => {
     },
   ]
 
-  const dataRows: SettingsRowAction[] = [
-    {
-      label: "Import data",
-      Icon: DownloadIcon,
-      onClick: () => fileInputRef.current?.click(),
-      accent: true,
-      disabled: loading,
-    },
-    {
-      label: "Export your data",
-      Icon: UploadIcon,
-      onClick: handleExport,
-      accent: true,
-    },
-  ]
-
   return (
     <div className="mx-auto flex max-w-2xl flex-col gap-5 px-4 pb-6">
-      {error && <p className="px-2 text-sm text-red-600 dark:text-red-400">{error}</p>}
-      {success && <p className="px-2 text-sm text-green-600 dark:text-green-400">{success}</p>}
+      {actions.error && (
+        <p className="px-2 text-sm text-red-600 dark:text-red-400">{actions.error}</p>
+      )}
+      {actions.success && (
+        <p className="px-2 text-sm text-green-600 dark:text-green-400">{actions.success}</p>
+      )}
 
-      <div className="flex items-center gap-3.5 px-2 pt-2">
-        <div className="flex size-14 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xl font-bold dark:bg-gray-700">
-          {initial}
-        </div>
-        <div className="min-w-0 flex-1">
-          {editing ? (
-            <div className="flex items-center gap-2">
-              <input
-                type="text"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                maxLength={50}
-                className="min-w-0 flex-1 border-b border-gray-300 px-1 py-0.5 text-lg font-bold tracking-tight outline-none focus:border-primary dark:border-gray-600 dark:bg-transparent dark:text-gray-100"
-              />
-              <button
-                type="button"
-                onClick={handleUpdate}
-                disabled={loading}
-                className="text-primary hover:text-primary-hover disabled:opacity-50"
-              >
-                <CheckIcon className="size-4" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setEditing(false)}
-                disabled={loading}
-                className="text-gray-400 hover:text-gray-600 disabled:opacity-50 dark:text-gray-500 dark:hover:text-gray-300"
-              >
-                <ResetIcon className="size-4" />
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={startEdit}
-              className="flex w-full items-center gap-2 text-left"
-            >
-              <span className="truncate text-xl font-bold tracking-tight">
-                {user?.name ?? "---"}
-              </span>
-              <Pencil1Icon className="size-3.5 shrink-0 text-gray-400 dark:text-gray-500" />
-            </button>
-          )}
-        </div>
-      </div>
+      <SettingsProfileHeader
+        name={user?.name}
+        editing={actions.editing}
+        draftName={actions.name}
+        loading={actions.loading}
+        onDraftChange={actions.setName}
+        onStartEdit={actions.startEdit}
+        onSave={actions.handleUpdate}
+        onCancel={() => actions.setEditing(false)}
+      />
 
       <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
         {navRows.map((row, i) => (
@@ -217,96 +57,34 @@ export const SettingsPage = () => {
         ))}
       </div>
 
-      <div>
-        <SettingsSectionLabel>Preferences</SettingsSectionLabel>
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800">
-          <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">Theme</p>
-          <div className="flex gap-2">
-            {(["system", "light", "dark"] as const).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => changeTheme(mode)}
-                className={`flex-1 rounded-xl py-2 text-sm transition-colors ${
-                  theme === mode
-                    ? "bg-primary text-white"
-                    : "bg-gray-50 text-gray-500 hover:bg-gray-100 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600"
-                }`}
-              >
-                {mode === "system" ? "System" : mode === "light" ? "Light" : "Dark"}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
+      <SettingsThemePicker />
 
-      <div>
-        <SettingsSectionLabel>Your data</SettingsSectionLabel>
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-          {dataRows.map((row, i) => (
-            <SettingsRow key={row.label} row={row} divided={i > 0} />
-          ))}
-        </div>
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json"
-          onChange={handleFileSelect}
-          className="hidden"
-        />
-      </div>
+      <SettingsDataSection
+        loading={actions.loading}
+        fileInputRef={actions.fileInputRef}
+        onExport={actions.handleExport}
+        onFileSelect={actions.handleFileSelect}
+      />
 
-      <div>
-        <SettingsSectionLabel>Account</SettingsSectionLabel>
-        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-          <button
-            type="button"
-            onClick={onLogout}
-            className="flex w-full items-center gap-3 px-4 py-3.5 text-left hover:bg-gray-50 dark:hover:bg-gray-700/40"
-          >
-            <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400">
-              <ExitIcon className="size-4" />
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold">Log out</div>
-              {user?.name && (
-                <div className="truncate text-[11px] text-gray-500 dark:text-gray-400">
-                  {user.name}
-                </div>
-              )}
-            </div>
-          </button>
-          <button
-            type="button"
-            onClick={openDialog}
-            disabled={loading}
-            className="flex w-full items-center gap-3 border-t border-gray-100 px-4 py-3.5 text-left text-red-600 hover:bg-red-50 disabled:opacity-50 dark:border-gray-700 dark:text-red-400 dark:hover:bg-red-950/30"
-          >
-            <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-600 dark:bg-red-950/40 dark:text-red-400">
-              <TrashIcon className="size-4" />
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="text-sm font-semibold">Delete account</div>
-              <div className="truncate text-[11px] text-red-400/80 dark:text-red-300/60">
-                Permanently erase all expenses
-              </div>
-            </div>
-          </button>
-        </div>
-      </div>
+      <SettingsAccountSection
+        userName={user?.name}
+        loading={actions.loading}
+        onLogout={onLogout}
+        onOpenDelete={actions.openDeleteDialog}
+      />
 
       <ConfirmDialog
         message="All your expense data will be permanently deleted. Are you sure?"
-        onConfirm={handleDelete}
-        loading={loading}
-        dialogRef={dialogRef}
+        onConfirm={actions.handleDelete}
+        loading={actions.loading}
+        dialogRef={actions.dialogRef}
       />
       <ConfirmDialog
         message="All existing categories and expenses will be deleted and replaced with the imported data. Continue?"
-        onConfirm={handleImport}
+        onConfirm={actions.handleImport}
         confirmText="Import"
-        loading={loading}
-        dialogRef={importDialogRef}
+        loading={actions.loading}
+        dialogRef={actions.importDialogRef}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
コンポーネントが100行を超えていた12ファイルを分割。子コンポーネント・カスタムフック・ヘルパに切り出し、最大の SettingsPage (313行) や CategoriesPage (335行) も含め全 component を100行以内に収める。

## 結果
全 `*.tsx` で1ファイル100行以下を達成 (api.ts/types.ts等のlibは対象外)。

| 対象 | Before | After |
|---|---|---|
| `CategoriesPage.tsx` | 335 | 96 |
| `SettingsPage.tsx` | 313 | 91 |
| `RecurringExpenseEditPage.tsx` | 271 | 68 |
| `ExpenseInsightPage.tsx` | 264 | 81 |
| `ExpenseDetailPage.tsx` | 257 | 97 |
| `RecurringExpenseListPage.tsx` | 239 | 38 |
| `ExpenseList.tsx` | 217 | 72 |
| `ExpenseFilterSheet.tsx` | 198 | 94 |
| `ExpensesPage.tsx` | 177 | 56 |
| `TopPage.tsx` | 168 | 70 |
| `CategoryEditPage.tsx` | 158 | 60 |
| `InsightYearChart.tsx` | 117 | 44 |

## 主な抽出パターン

### 子コンポーネント
- Category: `CategorySortableRow` `CategoryList` `CategoryMergeModal` `CategoryDeleteModal` `CategoryGlyphPicker`
- Expense form: `ExpenseNameInput` `ExpenseAmountInput` `ExpenseDateTimeInput` `ExpenseCategoryChips` (Detail/New 両方で再利用)
- Expense list: `ExpenseListSearchBar` `ExpenseListScopeChips` `ExpenseListDayGroup`
- Filter sheet: `FilterSheetHeader` `FilterSheetSearchSection` `FilterSheetCategorySection` `FilterSheetAmountSection`
- Insight: `InsightSection` `InsightVibeCard` `InsightCategoryCard` `InsightYearChartSvg`
- Top: `TopMonthSummary` `TopMomentsList`
- Recurring: `RecurringNameAmountFields` `RecurringFrequencyPicker` `RecurringCategoryPicker` `RecurringFormActions` `RecurringSummaryCard` `RecurringDueList` `RecurringFrequencyGroup`
- Settings: `SettingsProfileHeader` `SettingsThemePicker` `SettingsDataSection` `SettingsAccountSection`

### カスタムフック
- `useCategoriesPage` `useCategoryEditForm`
- `useRecurringExpenseForm` `useRecurringList`
- `useExpenseCreateForm` `useExpenseEditForm` `useFilteredExpenses` `useTopMonth`
- `useSettingsActions`

### ライブラリ
- `expense/libs/insightStats.ts` (computeVibes/Categories/Year + 型)
- `expense-recurring/libs/recurringFrequency.ts` (FREQUENCY_OPTIONS / monthlyEquivalent / todayJst / PERIOD_LABEL)

## Test plan
- [x] `make lint` Pass
- [x] typecheck Pass
- [ ] 主要画面の挙動確認: Categories CRUD、定期支払 CRUD、支出 新規/編集/一覧、Insights 表示、Settings 操作