### PR TITLE
fix: vercel.json の CORS ヘッダを削除し FastAPI 側に一本化

### DIFF
--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,32 +1,5 @@
 {
   "crons": [
     { "path": "/cron/recurring-expenses/record-due", "schedule": "0 15 * * *" }
-  ],
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "https://burn-style.vercel.app"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET, POST, PUT, DELETE, PATCH, OPTIONS"
-        },
-        {
-          "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type, Authorization"
-        },
-        {
-          "key": "Access-Control-Allow-Credentials",
-          "value": "true"
-        },
-        {
-          "key": "Access-Control-Expose-Headers",
-          "value": "X-New-Token"
-        }
-      ]
-    }
   ]
 }


### PR DESCRIPTION
## Summary
`backend/vercel.json` の `headers` ブロックが Vercel エッジ層で CORS ヘッダを静的付与していて、FastAPI の `CORSMiddleware` と二重設定になっていた。同名ヘッダ (`Access-Control-Allow-Origin` 等) が2回出力されるとブラウザは仕様違反として CORS エラー扱いとなり、`https://burn-style.vercel.app/signin` から `https://burn-style-api.vercel.app/health` への正常なリクエストもブロックされていた。

## Fix
- `vercel.json` から `headers` ブロックを削除
- CORS は `backend/src/main.py` の `CORSMiddleware` に一本化 (`FRONTEND_ORIGIN` env 経由で動的設定)

## デプロイ後の確認事項
- [ ] Vercel backend project に `FRONTEND_ORIGIN=https://burn-style.vercel.app` が設定されていること
- [ ] レスポンスヘッダの `Access-Control-Allow-Origin` が **1個だけ** で正しい値であること (DevTools Network タブで確認)
- [ ] `/signin` から `/health` 等 API 呼び出しが CORS エラーなく通ること