### PR TITLE
fix: CORS を Vercel headers に一本化

### DIFF
--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -10,6 +10,12 @@
 - `VERCEL_ENV=production` → Neon
 - Otherwise → local Docker
 
+## CORS
+
+- CORS headers are set at the Vercel edge layer via `backend/vercel.json` (`headers`), not by FastAPI middleware.
+- The OPTIONS preflight is handled by a catch-all route in `backend/src/main.py` that returns 204 (Vercel adds the CORS headers).
+- The frontend origin in `vercel.json` is hard-coded; update it there if the production URL changes.
+
 ## Environment Variables
 
 ### Local + Production
@@ -18,7 +24,7 @@
 | `JWT_SECRET_KEY` | JWT signing secret (32+ chars in production) |
 | `WEBAUTHN_RP_ID` | WebAuthn RP ID |
 | `WEBAUTHN_RP_NAME` | WebAuthn RP name |
-| `FRONTEND_ORIGIN` | CORS origin |
+| `FRONTEND_ORIGIN` | WebAuthn `expected_origin` for register/sign-in verification (NOT used for CORS — that's in `vercel.json`) |
 | `CRON_SECRET` | Bearer token for `/cron/*` endpoints (32+ chars recommended) |
 
 ### Production Only

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, Request, Response
-from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from src.api import (
@@ -13,7 +12,6 @@ from src.api import (
     recurring_expense_router,
     user_router,
 )
-from src.config import get_frontend_origin
 from src.logger import configure_logging
 from src.middleware import RequestLoggingMiddleware, TokenRefreshMiddleware
 
@@ -32,20 +30,19 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 app = FastAPI(title="BurnStyle API", version="1.0.0")
 
-# Middleware (later additions wrap outer layers)
-# Request order: RequestLogging -> CORS -> SecurityHeaders -> TokenRefresh -> Router
+# CORS は vercel.json の headers で edge 層が一括付与する。
+# OPTIONS preflight だけは 2xx で応答する必要があるので、catch-all を定義。
 app.add_middleware(TokenRefreshMiddleware)
 app.add_middleware(SecurityHeadersMiddleware)
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=[get_frontend_origin()],
-    allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allow_headers=["Content-Type", "Authorization"],
-    expose_headers=["X-New-Token", "X-Request-ID"],
-    max_age=0,
-)
 app.add_middleware(RequestLoggingMiddleware)
+
+
+@app.options("/{path:path}")
+async def options_preflight(path: str) -> Response:
+    """CORS preflight 用の catch-all。レスポンス 204 + Vercel が CORS ヘッダを付与。"""
+    del path
+    return Response(status_code=204)
+
 
 # Register routers
 app.include_router(health_router)

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,5 +1,32 @@
 {
   "crons": [
     { "path": "/cron/recurring-expenses/record-due", "schedule": "0 15 * * *" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "https://burn-style.vercel.app"
+        },
+        {
+          "key": "Access-Control-Allow-Methods",
+          "value": "GET, POST, PUT, DELETE, PATCH, OPTIONS"
+        },
+        {
+          "key": "Access-Control-Allow-Headers",
+          "value": "Content-Type, Authorization"
+        },
+        {
+          "key": "Access-Control-Allow-Credentials",
+          "value": "true"
+        },
+        {
+          "key": "Access-Control-Expose-Headers",
+          "value": "X-New-Token, X-Request-ID"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
CORS 制御を Vercel エッジ層 (`vercel.json` の `headers`) に一本化する。FastAPI の `CORSMiddleware` は撤去。

## Why
- 前 PR (#128) で FastAPI 側に一本化したが、デプロイ後も CORS エラーが解消されない
- Vercel Python serverless では `FRONTEND_ORIGIN` env が反映されないか反映タイミングが遅い可能性
- 静的固定で十分なので、Vercel エッジで処理させた方が確実

## 変更
### `backend/vercel.json`
- `headers` ブロックを復活
- `Access-Control-Expose-Headers` に `X-Request-ID` を追加 (ログ追跡用)

### `backend/src/main.py`
- `CORSMiddleware` を削除
- `get_frontend_origin` import 削除 (auth.py の WebAuthn では引き続き使用)
- **`@app.options("/{path:path}")` の catch-all を追加** — preflight には 2xx 応答が必要だが、CORSMiddleware なしでは FastAPI が 405 を返してしまうため、204 で応答する catch-all を定義。Vercel が CORS ヘッダを付与する。

## Test plan
- [x] `make lint` `make test-backend` Pass
- [ ] デプロイ後、`https://burn-style.vercel.app/signin` から API 呼び出しが CORS エラーなく成功
- [ ] レスポンスヘッダに `Access-Control-Allow-Origin` が **1個だけ** 含まれることを確認 (二重ヘッダ無し)
- [ ] preflight (OPTIONS) が 204 で応答することを確認