### PR TITLE
ci: setup-uv の python-version-file 入力を修正

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -18,11 +18,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve Python version
+        id: python
+        run: echo "version=$(cat backend/.python-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install uv (with Python and cache)
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version-file: "backend/.python-version"
+          python-version: ${{ steps.python.outputs.version }}
           cache-dependency-glob: "backend/uv.lock"
 
       - name: Install dependencies
@@ -45,11 +49,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve Python version
+        id: python
+        run: echo "version=$(cat backend/.python-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install uv (with Python and cache)
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version-file: "backend/.python-version"
+          python-version: ${{ steps.python.outputs.version }}
           cache-dependency-glob: "backend/uv.lock"
 
       - name: Install Vercel CLI
@@ -80,11 +88,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Resolve Python version
+        id: python
+        run: echo "version=$(cat backend/.python-version)" >> "$GITHUB_OUTPUT"
+
       - name: Install uv (with Python and cache)
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version-file: "backend/.python-version"
+          python-version: ${{ steps.python.outputs.version }}
           cache-dependency-glob: "backend/uv.lock"
 
       - name: Install Vercel CLI


### PR DESCRIPTION
## Summary

- `astral-sh/setup-uv@v7` が `python-version-file` 入力を受け付けないためCIに warning が出ていた
- `.python-version` を `cat` で読み出して `python-version` に渡す step に置き換え
- 9b1280e で混入したと推測

## Test plan

- [ ] このPRのCIでwarningが消えること