### PR TITLE
ci: mypy キャッシュで lint-and-test を短縮 (#137)

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -32,6 +32,14 @@ jobs:
       - name: Install dependencies
         run: cd backend && uv sync --all-groups
 
+      - name: Cache mypy
+        uses: actions/cache@v4
+        with:
+          path: backend/.mypy_cache
+          key: mypy-${{ runner.os }}-${{ hashFiles('backend/uv.lock', 'backend/**/*.py') }}
+          restore-keys: |
+            mypy-${{ runner.os }}-
+
       - name: mypy
         run: cd backend && uv run mypy .
 


### PR DESCRIPTION
## Summary

- Closes #137
- `backend / lint-and-test` に `actions/cache@v4` で `.mypy_cache` のキャッシュ stepを追加
- key: `mypy-<os>-<hash(uv.lock + **/*.py)>` / restore-keys でフォールバック

## 想定効果

- 現状 mypy 10s → cache hit 時 1〜2s 程度
- restore-keys により、Pythonコード変更時もincremental解析で短縮

## Test plan

- [ ] 本PRマージ後の最初のdeploy run で `Cache mypy` step が cache save される
- [ ] 次回run で cache hit & mypy stepが短縮されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)