### PR TITLE
ci: Vercel CLI を composite action + cache 化 (#136)

### DIFF
--- a/.github/actions/setup-vercel-cli/action.yml
+++ b/.github/actions/setup-vercel-cli/action.yml
@@ -1,0 +1,19 @@
+name: Setup Vercel CLI
+description: Install Vercel CLI globally with cache. Bump cache key suffix to force a fresh install.
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Vercel CLI
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          /usr/local/lib/node_modules/vercel
+          /usr/local/bin/vercel
+        key: vercel-cli-${{ runner.os }}-v1
+
+    - name: Install Vercel CLI
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm install -g vercel

--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -69,7 +69,7 @@ jobs:
           cache-dependency-glob: "backend/uv.lock"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel
+        uses: ./.github/actions/setup-vercel-cli
 
       - name: Install dependencies
         run: cd backend && uv sync --all-groups
@@ -108,7 +108,7 @@ jobs:
           cache-dependency-glob: "backend/uv.lock"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel
+        uses: ./.github/actions/setup-vercel-cli
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -49,7 +49,7 @@ jobs:
           cache-dependency-path: "frontend/package-lock.json"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel
+        uses: ./.github/actions/setup-vercel-cli
 
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=${{ inputs.environment }} --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary

- Closes #136
- 3jobs (`backend / migrate` / `backend / deploy` / `frontend / deploy`) で重複していた `npm install -g vercel` を `.github/actions/setup-vercel-cli` composite action に集約
- `actions/cache@v4` で `/usr/local/lib/node_modules/vercel` と `/usr/local/bin/vercel` をキャッシュ
- cache key: `vercel-cli-<os>-v1` (vercelをbumpしたい時は suffix を `v2` 等に変更)

## 想定効果

- 現状 12〜17s × 3jobs = 約40s+ → cache hit 時はほぼゼロ秒
- 初回run は従来通り install (save), 2回目以降から短縮

## Test plan

- [ ] このPRマージ後の最初のdeploy run で `Cache Vercel CLI` step が cache save される
- [ ] 次回run で cache hit & `Install Vercel CLI` がスキップされることを確認
- [ ] `vercel build` / `vercel deploy` がCLIから問題なく起動することを確認

## メモ

- `npm install -g vercel` は `vercel@latest` を取りに行く挙動。キャッシュkeyを `v1` に固定したため、明示的にbump (`v2`) するまで同じバージョンのCLIを使い続ける。Vercel側の仕様変更で動かなくなった場合は key bump で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)