### PR TITLE
chore: deployワークフローのJS actionsをNode 24で動かす

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ on:
         required: false
         type: string
 
+env:
+  # actions/cache@v4 等のJS actionをNode 24で動かす (Node 20は2026/9/16撤去予定)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   backend:
     uses: ./.github/workflows/deploy_backend.yml

--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -10,6 +10,8 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_BACKEND_PROJECT_ID }}
+  # actions/cache@v4 等のJS actionをNode 24で動かす (Node 20は2026/9/16撤去予定)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   lint-and-test:

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -10,6 +10,8 @@ on:
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_FRONTEND_PROJECT_ID }}
+  # actions/cache@v4 等のJS actionをNode 24で動かす (Node 20は2026/9/16撤去予定)
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary

- `actions/cache@v4` 等のJS actionが Node 20 で動いている旨の deprecation warning が出ていたので先取り対応
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を 3 workflow (`deploy.yml` / `deploy_backend.yml` / `deploy_frontend.yml`) の workflow-level env に追加

## 背景

- 2026/6/2: GitHub Actions ランナーのデフォルトがNode 24化
- 2026/9/16: Node 20撤去予定
- `workflow_call` で呼ばれる子workflowに親のenvは継承されないため、3ファイル全てに追加

## Test plan

- [ ] 次回deploy runで該当warningが消失することを確認