### PR TITLE
fix: support multi-codepoint emojis in category symbol

### DIFF
--- a/backend/alembic/versions/daf5538577db_expand_categories_symbol_length_to_64.py
+++ b/backend/alembic/versions/daf5538577db_expand_categories_symbol_length_to_64.py
@@ -1,0 +1,42 @@
+"""categories.symbol カラムを VARCHAR(8) から VARCHAR(64) に拡張
+
+ZWJ結合絵文字や Variation Selector 付き絵文字を扱えるよう長さを緩和。
+
+Revision ID: daf5538577db
+Revises: 4b55d17ee529
+Create Date: 2026-05-18 18:24:33.811256
+
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "daf5538577db"
+down_revision: str | Sequence[str] | None = "4b55d17ee529"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.alter_column(
+        "categories",
+        "symbol",
+        existing_type=sa.String(length=8),
+        type_=sa.String(length=64),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.alter_column(
+        "categories",
+        "symbol",
+        existing_type=sa.String(length=64),
+        type_=sa.String(length=8),
+        existing_nullable=True,
+    )

--- a/backend/src/model/category.py
+++ b/backend/src/model/category.py
@@ -13,7 +13,7 @@ class Category(Base):
     uuid = Column(String(32), primary_key=True, default=generate_uuid_string)
     user_uuid = Column(String(32), ForeignKey("users.uuid", ondelete="CASCADE"), nullable=False)
     name = Column(String, nullable=False)
-    symbol = Column(String(8), nullable=True)
+    symbol = Column(String(64), nullable=True)
     position = Column(Integer, nullable=False, default=0)
 
     user = relationship("User")

--- a/backend/src/schema/category.py
+++ b/backend/src/schema/category.py
@@ -14,12 +14,12 @@ class CategoryResponse(BaseModel):
 
 class CategoryCreate(BaseModel):
     name: str
-    symbol: str | None = Field(default=None, max_length=8)
+    symbol: str | None = Field(default=None, max_length=64)
 
 
 class CategoryUpdate(BaseModel):
     name: str | None = None
-    symbol: str | None = Field(default=None, max_length=8)
+    symbol: str | None = Field(default=None, max_length=64)
 
 
 class CategoryMergeRequest(BaseModel):

--- a/backend/tests/api/test_categories.py
+++ b/backend/tests/api/test_categories.py
@@ -47,9 +47,15 @@ class TestPostCategory:
 
     def test_rejects_too_long_symbol(self, auth_client: TestClient) -> None:
         res = auth_client.post(
-            "/categories", json={"name": "x", "symbol": "abcdefghi"},
+            "/categories", json={"name": "x", "symbol": "a" * 65},
         )
         assert res.status_code == 422
+
+    def test_accepts_zwj_emoji(self, auth_client: TestClient) -> None:
+        # ZWJ結合絵文字 (👨‍👩‍👧‍👦 = 7コードポイント) を受け入れること
+        res = auth_client.post("/categories", json={"name": "家族", "symbol": "👨‍👩‍👧‍👦"})
+        assert res.status_code == 201
+        assert res.json()["symbol"] == "👨‍👩‍👧‍👦"
 
     def test_rejects_empty_body(self, auth_client: TestClient) -> None:
         res = auth_client.post("/categories", json={})

--- a/frontend/src/category/components/CategoryGlyphPicker.tsx
+++ b/frontend/src/category/components/CategoryGlyphPicker.tsx
@@ -26,10 +26,20 @@ interface CategoryGlyphPickerProps {
   onChange: (g: string) => void
 }
 
+/** グラフェムクラスタ単位で末尾1文字を抽出。Intl.Segmenter 未対応環境はコードポイントフォールバック。 */
+const lastGrapheme = (v: string): string => {
+  if (!v) return ""
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const segments = [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(v)]
+    return segments.length > 0 ? segments[segments.length - 1].segment : ""
+  }
+  const arr = [...v]
+  return arr.length > 0 ? arr[arr.length - 1] : ""
+}
+
 export const CategoryGlyphPicker = ({ glyph, onChange }: CategoryGlyphPickerProps) => {
   const handleInput = (v: string) => {
-    const arr = [...v]
-    onChange(arr.length > 0 ? arr[arr.length - 1] : "")
+    onChange(lastGrapheme(v))
   }
 
   return (
@@ -42,7 +52,7 @@ export const CategoryGlyphPicker = ({ glyph, onChange }: CategoryGlyphPickerProp
         value={glyph}
         onChange={(e) => handleInput(e.target.value)}
         placeholder="Type any emoji or character"
-        maxLength={8}
+        maxLength={64}
         className="w-full rounded-xl border border-gray-200 bg-white px-3.5 py-3 text-center text-lg outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
       />
       <div className="mt-3 mb-2.5 text-[11px] text-gray-400 dark:text-gray-500">Suggestions</div>


### PR DESCRIPTION
## Summary
- カテゴリーシンボルで複数コードポイント絵文字 (Variation Selector / ZWJ結合) が壊れる不具合を修正
- フロント: `Intl.Segmenter` でグラフェムクラスタ単位の末尾抽出に変更 (🛍️, ✈️, 👨‍👩‍👧‍👦 等を正しく保持)
- バックエンド: `categories.symbol` を `VARCHAR(8)` → `VARCHAR(64)` に拡張 (Alembicマイグレーション追加)
- 既存テスト更新 + ZWJ絵文字の受け入れテスト追加

Closes #141

## Test plan
- [x] `make lint` パス
- [x] `make test-backend` 全71件パス
- [ ] 手元で `🛍️` `✈️` `👨‍👩‍👧‍👦` を入力 → 保存 → 表示確認
- [ ] 既存カテゴリーの絵文字が壊れていないか確認
- [ ] Production DBへのマイグレーション適用後の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)