### PR TITLE
feat: expense追加画面で日時を設定可能にする

### DIFF
--- a/frontend/src/expense/hooks/useExpenseCreateForm.ts
+++ b/frontend/src/expense/hooks/useExpenseCreateForm.ts
@@ -9,6 +9,7 @@ import type {
   VibePlanning,
   VibeSocial,
 } from "../../common/libs/types"
+import { toLocalDatetime } from "../libs/datetime"
 
 /** 新規 expense 作成フォームの state とハンドラ。 */
 export const useExpenseCreateForm = () => {
@@ -20,6 +21,7 @@ export const useExpenseCreateForm = () => {
 
   const [name, setName] = useState("")
   const [amount, setAmount] = useState("")
+  const [expensedAt, setExpensedAt] = useState(() => toLocalDatetime(new Date().toISOString()))
   const [categoryUuid, setCategoryUuid] = useState<string | null>(null)
   const [vibeSocial, setVibeSocial] = useState<VibeSocial | null>(null)
   const [vibePlanning, setVibePlanning] = useState<VibePlanning | null>(null)
@@ -46,7 +48,7 @@ export const useExpenseCreateForm = () => {
       await api.createExpense({
         name,
         amount: Number(amount.replace(/,/g, "")),
-        expensed_at: new Date().toISOString(),
+        expensed_at: new Date(expensedAt).toISOString(),
         category_uuid: categoryUuid,
         vibe_social: vibeSocial,
         vibe_planning: vibePlanning,
@@ -69,6 +71,8 @@ export const useExpenseCreateForm = () => {
     setName,
     amount,
     setAmount,
+    expensedAt,
+    setExpensedAt,
     categoryUuid,
     setCategoryUuid,
     vibeSocial,

--- a/frontend/src/expense/hooks/useExpenseEditForm.ts
+++ b/frontend/src/expense/hooks/useExpenseEditForm.ts
@@ -11,13 +11,7 @@ import type {
   VibePlanning,
   VibeSocial,
 } from "../../common/libs/types"
-
-const pad = (n: number) => String(n).padStart(2, "0")
-
-const toLocalDatetime = (isoStr: string) => {
-  const d = new Date(isoStr)
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
+import { toLocalDatetime } from "../libs/datetime"
 
 interface FormState {
   name: string

--- a/frontend/src/expense/libs/datetime.ts
+++ b/frontend/src/expense/libs/datetime.ts
@@ -1,0 +1,7 @@
+const pad = (n: number) => String(n).padStart(2, "0")
+
+/** ISO 文字列を datetime-local input 用のローカル日時文字列に変換。 */
+export const toLocalDatetime = (isoStr: string) => {
+  const d = new Date(isoStr)
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`
+}

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -1,5 +1,6 @@
 import { ExpenseAmountInput } from "../components/ExpenseAmountInput"
 import { ExpenseCategoryChips } from "../components/ExpenseCategoryChips"
+import { ExpenseDateTimeInput } from "../components/ExpenseDateTimeInput"
 import { ExpenseNameInput } from "../components/ExpenseNameInput"
 import { VibePicker } from "../components/VibePicker"
 import { useExpenseCreateForm } from "../hooks/useExpenseCreateForm"
@@ -25,6 +26,7 @@ export const ExpensesPage = () => {
       <div className="flex-1 overflow-y-auto">
         <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
         <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
+        <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
         <ExpenseCategoryChips
           categories={f.categories}
           selectedUuid={f.categoryUuid}


### PR DESCRIPTION
## Summary
- expense追加画面に `ExpenseDateTimeInput` を追加し、`expensed_at` を任意指定可能に
- デフォルト値は現在日時
- `toLocalDatetime` を `expense/libs/datetime.ts` に切り出し、create/edit 両フォームで共用

Closes #143

## Test plan
- [ ] 追加画面で日時欄が表示され、デフォルトが現在日時
- [ ] 日時を変更して保存 → 指定した日時で expense が作成される
- [ ] 編集画面の挙動が従来通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)