### PR TITLE
feat: top pageカレンダーに日毎の金額を表示

### DIFF
--- a/frontend/src/expense/components/TopHeatmap.tsx
+++ b/frontend/src/expense/components/TopHeatmap.tsx
@@ -6,6 +6,11 @@ interface TopHeatmapProps {
   onSelectDay: (day: number) => void
 }
 
+const compactAmount = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+})
+
 export const TopHeatmap = ({ year, month, today, totals, onSelectDay }: TopHeatmapProps) => {
   const daysInMonth = new Date(year, month, 0).getDate()
   const firstDow = new Date(year, month - 1, 1).getDay()
@@ -42,7 +47,7 @@ export const TopHeatmap = ({ year, month, today, totals, onSelectDay }: TopHeatm
               onClick={() => onSelectDay(day)}
               disabled={isFuture}
               style={cellStyle}
-              className={`flex aspect-square items-center justify-center rounded-md text-[10px] font-semibold disabled:cursor-default ${
+              className={`flex aspect-square flex-col items-center justify-center rounded-md text-[10px] font-semibold disabled:cursor-default ${
                 isFuture
                   ? "border border-dashed border-gray-200 text-gray-300 dark:border-gray-700 dark:text-gray-600"
                   : isToday
@@ -52,7 +57,12 @@ export const TopHeatmap = ({ year, month, today, totals, onSelectDay }: TopHeatm
                       : ""
               }`}
             >
-              {day}
+              <span>{day}</span>
+              {!isFuture && v > 0 && (
+                <span className="mt-0.5 text-[8px] font-medium tabular-nums opacity-80">
+                  {compactAmount.format(v)}
+                </span>
+              )}
             </button>
           )
         })}


### PR DESCRIPTION
## Summary
- `TopHeatmap` の各セルに日付に加えて当日の金額を表示
- `Intl.NumberFormat` の compact 表記（例: `1.2K`, `12K`）を使用しセル幅に収める
- 金額 0 の日と未来日は金額非表示

Closes #145

## Test plan
- [ ] 支出のある日のセルに金額が表示される
- [ ] 支出のない日には金額が表示されない
- [ ] 未来日のセルには金額が表示されない
- [ ] 大きな金額（数万〜数十万）でもセル幅に収まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)