### PR TITLE
feat: filter sheetにscope切替を追加

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -5,6 +5,7 @@ import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
 import { FilterSheetAmountSection } from "./FilterSheetAmountSection"
 import { FilterSheetCategorySection } from "./FilterSheetCategorySection"
 import { FilterSheetHeader } from "./FilterSheetHeader"
+import { FilterSheetScopeSection } from "./FilterSheetScopeSection"
 import { FilterSheetSearchSection } from "./FilterSheetSearchSection"
 
 interface ExpenseFilterSheetProps {
@@ -65,6 +66,10 @@ export const ExpenseFilterSheet = ({
           <FilterSheetSearchSection
             value={draft.q}
             onChange={(v) => setDraft({ ...draft, q: v })}
+          />
+          <FilterSheetScopeSection
+            scope={draft.scope}
+            onChange={(v) => setDraft({ ...draft, scope: v })}
           />
           <FilterSheetCategorySection
             categories={categories}

--- a/frontend/src/expense/components/FilterSheetScopeSection.tsx
+++ b/frontend/src/expense/components/FilterSheetScopeSection.tsx
@@ -1,0 +1,33 @@
+import { type FilterScope, SCOPE_OPTIONS } from "../libs/expenseFilter"
+
+interface FilterSheetScopeSectionProps {
+  scope: FilterScope
+  onChange: (scope: FilterScope) => void
+}
+
+export const FilterSheetScopeSection = ({ scope, onChange }: FilterSheetScopeSectionProps) => (
+  <section>
+    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+      Period
+    </h3>
+    <div className="flex flex-wrap gap-2">
+      {SCOPE_OPTIONS.map((s) => {
+        const on = scope === s.k
+        return (
+          <button
+            key={s.k}
+            type="button"
+            onClick={() => onChange(s.k)}
+            className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+              on
+                ? "border-primary bg-primary text-white"
+                : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+            }`}
+          >
+            {s.label}
+          </button>
+        )
+      })}
+    </div>
+  </section>
+)


### PR DESCRIPTION
## Summary
- `FilterSheetScopeSection` を新規追加し、filter画面内で Week/Month/All を切替可能に
- `SCOPE_OPTIONS` を再利用、Apply時に `ExpenseFilter.scope` へ反映
- list上部の `ExpenseListScopeChips` は併存（同じ `filter.scope` を読み書きするため自動連動）

Closes #146

## Test plan
- [ ] filter画面に Period セクションが表示される
- [ ] Week/Month/All を選択して Apply → list の表示範囲が切り替わる
- [ ] list上部の chips との状態が同期する

🤖 Generated with [Claude Code](https://claude.com/claude-code)