### PR TITLE
feat: vibeラベルを Habitual/Impulsive・Need/Want に変更

### DIFF
--- a/frontend/src/expense/components/VibePicker.tsx
+++ b/frontend/src/expense/components/VibePicker.tsx
@@ -41,25 +41,25 @@ export const VibePicker = ({
 
       <VibeChip
         active={planning === "ROUTINE"}
-        label="Routine"
+        label="Habitual"
         onClick={() => onPlanningChange(planning === "ROUTINE" ? null : "ROUTINE")}
       />
       {separator}
       <VibeChip
         active={planning === "SPONTANEOUS"}
-        label="Spontaneous"
+        label="Impulsive"
         onClick={() => onPlanningChange(planning === "SPONTANEOUS" ? null : "SPONTANEOUS")}
       />
 
       <VibeChip
         active={necessity === "NEEDED"}
-        label="Needed it"
+        label="Need"
         onClick={() => onNecessityChange(necessity === "NEEDED" ? null : "NEEDED")}
       />
       {separator}
       <VibeChip
         active={necessity === "WANTED"}
-        label="Wanted it"
+        label="Want"
         onClick={() => onNecessityChange(necessity === "WANTED" ? null : "WANTED")}
       />
     </div>

--- a/frontend/src/expense/libs/insightStats.ts
+++ b/frontend/src/expense/libs/insightStats.ts
@@ -2,10 +2,10 @@ import type { CategoryResponse, ExpenseResponse } from "../../common/libs/types"
 import type { YearMonth } from "../components/InsightYearChart"
 
 const VIBE_LABELS: { key: string; label: string; field: keyof ExpenseResponse }[] = [
-  { key: "ROUTINE", label: "Routine", field: "vibe_planning" },
-  { key: "SPONTANEOUS", label: "Spontaneous", field: "vibe_planning" },
-  { key: "NEEDED", label: "Needed it", field: "vibe_necessity" },
-  { key: "WANTED", label: "Wanted it", field: "vibe_necessity" },
+  { key: "ROUTINE", label: "Habitual", field: "vibe_planning" },
+  { key: "SPONTANEOUS", label: "Impulsive", field: "vibe_planning" },
+  { key: "NEEDED", label: "Need", field: "vibe_necessity" },
+  { key: "WANTED", label: "Want", field: "vibe_necessity" },
   { key: "SOLO", label: "Solo", field: "vibe_social" },
   { key: "WITH_SOMEONE", label: "With someone", field: "vibe_social" },
 ]


### PR DESCRIPTION
## Summary
- Planning軸: `Routine` / `Spontaneous` → `Habitual` / `Impulsive`
- Necessity軸: `Needed it` / `Wanted it` → `Need` / `Want`
- 他vibeラベル（Solo・Habitual等）と短さ・トーンを揃える
- enum値（`ROUTINE` / `SPONTANEOUS` / `NEEDED` / `WANTED`）は維持

## Test plan
- [ ] new expense / edit画面の vibe chips が新ラベルで表示
- [ ] insight画面の vibe 統計のラベルが切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)