### PR TITLE
feat: new/edit expenseのレイアウト調整

### DIFF
--- a/frontend/src/expense/components/ExpenseAmountInput.tsx
+++ b/frontend/src/expense/components/ExpenseAmountInput.tsx
@@ -10,7 +10,7 @@ export const ExpenseAmountInput = ({ value, onChange }: ExpenseAmountInputProps)
   }
 
   return (
-    <div className="px-5 pt-5 text-center">
+    <div className="px-5 pt-6 text-center">
       <div className="flex items-baseline justify-center gap-1">
         <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
         <input

--- a/frontend/src/expense/components/ExpenseCategoryChips.tsx
+++ b/frontend/src/expense/components/ExpenseCategoryChips.tsx
@@ -18,7 +18,7 @@ export const ExpenseCategoryChips = ({
   if (categories.length === 0) return null
 
   return (
-    <div className="px-4 pt-4">
+    <div className="px-5 pt-5">
       <div className="flex flex-wrap gap-2">
         {categories.map((c) => {
           const active = selectedUuid === c.uuid
@@ -27,7 +27,7 @@ export const ExpenseCategoryChips = ({
               key={c.uuid}
               type="button"
               onClick={() => onSelect(active ? null : c.uuid)}
-              className={`flex items-center gap-1.5 rounded-2xl border px-3 py-2 text-xs font-semibold ${
+              className={`flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-semibold ${
                 active
                   ? "border-primary bg-primary text-white"
                   : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
@@ -41,7 +41,7 @@ export const ExpenseCategoryChips = ({
         <button
           type="button"
           onClick={() => navigate("/category/new")}
-          className="flex items-center rounded-2xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
+          className="flex items-center rounded-xl border border-dashed border-gray-300 bg-transparent px-3 py-2 text-xs font-semibold text-gray-500 dark:border-gray-700 dark:text-gray-400"
         >
           + Category
         </button>

--- a/frontend/src/expense/components/ExpenseDateTimeInput.tsx
+++ b/frontend/src/expense/components/ExpenseDateTimeInput.tsx
@@ -8,7 +8,8 @@ export const ExpenseDateTimeInput = ({ value, onChange }: ExpenseDateTimeInputPr
     type="datetime-local"
     value={value}
     onChange={(e) => onChange(e.target.value)}
+    onClick={(e) => e.currentTarget.showPicker?.()}
     required
-    className="bg-transparent text-[11px] font-medium text-gray-400 tabular-nums outline-none dark:text-gray-500"
+    className="cursor-pointer bg-transparent text-[11px] font-medium text-gray-400 tabular-nums outline-none [&::-webkit-calendar-picker-indicator]:hidden dark:text-gray-500"
   />
 )

--- a/frontend/src/expense/components/ExpenseDateTimeInput.tsx
+++ b/frontend/src/expense/components/ExpenseDateTimeInput.tsx
@@ -4,13 +4,13 @@ interface ExpenseDateTimeInputProps {
 }
 
 export const ExpenseDateTimeInput = ({ value, onChange }: ExpenseDateTimeInputProps) => (
-  <div className="px-5 pt-5 text-center">
+  <div className="px-5 pt-3 text-center">
     <input
       type="datetime-local"
       value={value}
       onChange={(e) => onChange(e.target.value)}
       required
-      className="bg-transparent text-center text-sm font-medium tabular-nums outline-none dark:text-gray-100"
+      className="bg-transparent text-center text-sm font-medium text-gray-500 tabular-nums outline-none dark:text-gray-400"
     />
   </div>
 )

--- a/frontend/src/expense/components/ExpenseDateTimeInput.tsx
+++ b/frontend/src/expense/components/ExpenseDateTimeInput.tsx
@@ -4,13 +4,11 @@ interface ExpenseDateTimeInputProps {
 }
 
 export const ExpenseDateTimeInput = ({ value, onChange }: ExpenseDateTimeInputProps) => (
-  <div className="px-5 pt-3 text-center">
-    <input
-      type="datetime-local"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      required
-      className="bg-transparent text-center text-sm font-medium text-gray-500 tabular-nums outline-none dark:text-gray-400"
-    />
-  </div>
+  <input
+    type="datetime-local"
+    value={value}
+    onChange={(e) => onChange(e.target.value)}
+    required
+    className="bg-transparent text-[11px] font-medium text-gray-400 tabular-nums outline-none dark:text-gray-500"
+  />
 )

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -31,8 +31,11 @@ export const ExpenseDetailPage = () => {
   return (
     <form
       onSubmit={handleUpdate}
-      className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
+      className="relative mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
+      <div className="absolute top-5 right-5 z-10">
+        <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
+      </div>
       <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           Edit expense
@@ -47,7 +50,6 @@ export const ExpenseDetailPage = () => {
         <div className="flex min-h-full flex-col justify-center py-4">
           <ExpenseNameInput value={form.name} onChange={(v) => update("name", v)} />
           <ExpenseAmountInput value={form.amount} onChange={(v) => update("amount", v)} />
-          <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
           <ExpenseCategoryChips
             categories={categories}
             selectedUuid={form.categoryUuid}

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -33,7 +33,7 @@ export const ExpenseDetailPage = () => {
       onSubmit={handleUpdate}
       className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="flex shrink-0 justify-center px-4 pt-8 pb-2">
+      <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           Edit expense
         </span>
@@ -52,7 +52,7 @@ export const ExpenseDetailPage = () => {
           selectedUuid={form.categoryUuid}
           onSelect={(v) => update("categoryUuid", v)}
         />
-        <div className="px-4 pt-5 pb-4">
+        <div className="px-5 pt-5 pb-4">
           <VibePicker
             social={form.vibeSocial}
             planning={form.vibePlanning}
@@ -64,11 +64,11 @@ export const ExpenseDetailPage = () => {
         </div>
       </div>
 
-      <div className="shrink-0 px-4 pt-2 pb-3">
+      <div className="shrink-0 px-5 pt-2 pb-3">
         <button
           type="submit"
           disabled={loading || !form.name || !form.amount}
-          className="w-full rounded-2xl bg-primary px-4 py-4 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
+          className="w-full rounded-xl bg-primary px-4 py-3.5 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
         >
           {loading ? "Updating…" : "Update"}
         </button>

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -31,11 +31,8 @@ export const ExpenseDetailPage = () => {
   return (
     <form
       onSubmit={handleUpdate}
-      className="relative mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
+      className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="absolute top-5 right-5 z-10">
-        <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
-      </div>
       <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           Edit expense
@@ -47,7 +44,13 @@ export const ExpenseDetailPage = () => {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <div className="flex min-h-full flex-col justify-center py-4">
+        <div className="flex min-h-full flex-col justify-center py-8">
+          <div className="flex justify-end px-5">
+            <ExpenseDateTimeInput
+              value={form.expensedAt}
+              onChange={(v) => update("expensedAt", v)}
+            />
+          </div>
           <ExpenseNameInput value={form.name} onChange={(v) => update("name", v)} />
           <ExpenseAmountInput value={form.amount} onChange={(v) => update("amount", v)} />
           <ExpenseCategoryChips

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -44,23 +44,25 @@ export const ExpenseDetailPage = () => {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <ExpenseNameInput value={form.name} onChange={(v) => update("name", v)} />
-        <ExpenseAmountInput value={form.amount} onChange={(v) => update("amount", v)} />
-        <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
-        <ExpenseCategoryChips
-          categories={categories}
-          selectedUuid={form.categoryUuid}
-          onSelect={(v) => update("categoryUuid", v)}
-        />
-        <div className="px-5 pt-5 pb-4">
-          <VibePicker
-            social={form.vibeSocial}
-            planning={form.vibePlanning}
-            necessity={form.vibeNecessity}
-            onSocialChange={(v) => update("vibeSocial", v)}
-            onPlanningChange={(v) => update("vibePlanning", v)}
-            onNecessityChange={(v) => update("vibeNecessity", v)}
+        <div className="flex min-h-full flex-col justify-center py-4">
+          <ExpenseNameInput value={form.name} onChange={(v) => update("name", v)} />
+          <ExpenseAmountInput value={form.amount} onChange={(v) => update("amount", v)} />
+          <ExpenseDateTimeInput value={form.expensedAt} onChange={(v) => update("expensedAt", v)} />
+          <ExpenseCategoryChips
+            categories={categories}
+            selectedUuid={form.categoryUuid}
+            onSelect={(v) => update("categoryUuid", v)}
           />
+          <div className="px-5 pt-5">
+            <VibePicker
+              social={form.vibeSocial}
+              planning={form.vibePlanning}
+              necessity={form.vibeNecessity}
+              onSocialChange={(v) => update("vibeSocial", v)}
+              onPlanningChange={(v) => update("vibePlanning", v)}
+              onNecessityChange={(v) => update("vibeNecessity", v)}
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/expense/pages/ExpenseDetailPage.tsx
+++ b/frontend/src/expense/pages/ExpenseDetailPage.tsx
@@ -45,7 +45,7 @@ export const ExpenseDetailPage = () => {
 
       <div className="flex-1 overflow-y-auto">
         <div className="flex min-h-full flex-col justify-center py-8">
-          <div className="flex justify-end px-5">
+          <div className="flex justify-end pr-2">
             <ExpenseDateTimeInput
               value={form.expensedAt}
               onChange={(v) => update("expensedAt", v)}

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -11,8 +11,11 @@ export const ExpensesPage = () => {
   return (
     <form
       onSubmit={f.handleSubmit}
-      className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
+      className="relative mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
+      <div className="absolute top-5 right-5 z-10">
+        <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
+      </div>
       <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           New expense
@@ -27,7 +30,6 @@ export const ExpensesPage = () => {
         <div className="flex min-h-full flex-col justify-center py-4">
           <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
           <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
-          <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
           <ExpenseCategoryChips
             categories={f.categories}
             selectedUuid={f.categoryUuid}

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -25,7 +25,7 @@ export const ExpensesPage = () => {
 
       <div className="flex-1 overflow-y-auto">
         <div className="flex min-h-full flex-col justify-center py-8">
-          <div className="flex justify-end px-5">
+          <div className="flex justify-end pr-2">
             <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
           </div>
           <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -13,7 +13,7 @@ export const ExpensesPage = () => {
       onSubmit={f.handleSubmit}
       className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="flex shrink-0 justify-center px-4 pt-8 pb-2">
+      <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           New expense
         </span>
@@ -32,7 +32,7 @@ export const ExpensesPage = () => {
           selectedUuid={f.categoryUuid}
           onSelect={f.setCategoryUuid}
         />
-        <div className="px-4 pt-5 pb-4">
+        <div className="px-5 pt-5 pb-4">
           <VibePicker
             social={f.vibeSocial}
             planning={f.vibePlanning}
@@ -44,11 +44,11 @@ export const ExpensesPage = () => {
         </div>
       </div>
 
-      <div className="shrink-0 px-4 pt-2 pb-3">
+      <div className="shrink-0 px-5 pt-2 pb-3">
         <button
           type="submit"
           disabled={f.loading || !f.name || !f.amount}
-          className="w-full rounded-2xl bg-primary px-4 py-4 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
+          className="w-full rounded-xl bg-primary px-4 py-3.5 text-sm font-bold text-white shadow-[0_6px_18px_rgba(47,116,208,0.32)] hover:bg-primary-hover disabled:opacity-50 disabled:shadow-none"
         >
           {f.loading ? "Saving…" : "Save"}
         </button>

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -24,23 +24,25 @@ export const ExpensesPage = () => {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
-        <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
-        <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
-        <ExpenseCategoryChips
-          categories={f.categories}
-          selectedUuid={f.categoryUuid}
-          onSelect={f.setCategoryUuid}
-        />
-        <div className="px-5 pt-5 pb-4">
-          <VibePicker
-            social={f.vibeSocial}
-            planning={f.vibePlanning}
-            necessity={f.vibeNecessity}
-            onSocialChange={f.setVibeSocial}
-            onPlanningChange={f.setVibePlanning}
-            onNecessityChange={f.setVibeNecessity}
+        <div className="flex min-h-full flex-col justify-center py-4">
+          <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
+          <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
+          <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
+          <ExpenseCategoryChips
+            categories={f.categories}
+            selectedUuid={f.categoryUuid}
+            onSelect={f.setCategoryUuid}
           />
+          <div className="px-5 pt-5">
+            <VibePicker
+              social={f.vibeSocial}
+              planning={f.vibePlanning}
+              necessity={f.vibeNecessity}
+              onSocialChange={f.setVibeSocial}
+              onPlanningChange={f.setVibePlanning}
+              onNecessityChange={f.setVibeNecessity}
+            />
+          </div>
         </div>
       </div>
 

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -11,11 +11,8 @@ export const ExpensesPage = () => {
   return (
     <form
       onSubmit={f.handleSubmit}
-      className="relative mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
+      className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="absolute top-5 right-5 z-10">
-        <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
-      </div>
       <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
         <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
           New expense
@@ -27,7 +24,10 @@ export const ExpensesPage = () => {
       )}
 
       <div className="flex-1 overflow-y-auto">
-        <div className="flex min-h-full flex-col justify-center py-4">
+        <div className="flex min-h-full flex-col justify-center py-8">
+          <div className="flex justify-end px-5">
+            <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
+          </div>
           <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
           <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
           <ExpenseCategoryChips


### PR DESCRIPTION
## Summary
- 各セクションの左右パディングを `px-5` に統一（旧: `px-4`/`px-5` 混在）
- header の上余白を `pt-8` → `pt-5` に縮小
- Category chips の `rounded-2xl` を `rounded-xl` に統一（VibeChipと揃え）
- 日時入力の文字色をヒント寄りに（`text-gray-500`）
- submit ボタンを `rounded-xl py-3.5` に微調整

## Test plan
- [ ] new expense / edit expense 双方でレイアウトが揃っている
- [ ] iPhone Safariでキーボード表示時に主要入力欄が隠れない
- [ ] チップの見た目が揃っている

🤖 Generated with [Claude Code](https://claude.com/claude-code)