### PR TITLE
feat: new expense画面の金額を最上部に移動・初期フォーカス追加

### DIFF
--- a/frontend/src/expense/components/ExpenseAmountInput.tsx
+++ b/frontend/src/expense/components/ExpenseAmountInput.tsx
@@ -1,9 +1,12 @@
+import type { RefObject } from "react"
+
 interface ExpenseAmountInputProps {
   value: string
   onChange: (v: string) => void
+  inputRef?: RefObject<HTMLInputElement | null>
 }
 
-export const ExpenseAmountInput = ({ value, onChange }: ExpenseAmountInputProps) => {
+export const ExpenseAmountInput = ({ value, onChange, inputRef }: ExpenseAmountInputProps) => {
   const handle = (raw: string) => {
     const digits = raw.replace(/[^0-9]/g, "")
     onChange(digits ? Number(digits).toLocaleString() : "")
@@ -14,8 +17,10 @@ export const ExpenseAmountInput = ({ value, onChange }: ExpenseAmountInputProps)
       <div className="flex items-baseline justify-center gap-1">
         <span className="text-2xl font-medium text-gray-500 dark:text-gray-400">¥</span>
         <input
+          ref={inputRef}
           type="text"
           inputMode="numeric"
+          pattern="[0-9]*"
           value={value}
           onChange={(e) => handle(e.target.value)}
           required

--- a/frontend/src/expense/hooks/useExpenseCreateForm.ts
+++ b/frontend/src/expense/hooks/useExpenseCreateForm.ts
@@ -14,7 +14,7 @@ import { toLocalDatetime } from "../libs/datetime"
 /** 新規 expense 作成フォームの state とハンドラ。 */
 export const useExpenseCreateForm = () => {
   const navigate = useNavigate()
-  const nameRef = useRef<HTMLInputElement>(null)
+  const amountRef = useRef<HTMLInputElement>(null)
   const [categories, setCategories] = useState<CategoryResponse[]>([])
   const [error, setError] = useState("")
   const [loading, setLoading] = useState(false)
@@ -37,7 +37,7 @@ export const useExpenseCreateForm = () => {
 
   useEffect(() => {
     fetchData()
-    nameRef.current?.focus()
+    amountRef.current?.focus()
   }, [fetchData])
 
   const handleSubmit = async (e: SubmitEvent<HTMLFormElement>) => {
@@ -63,7 +63,7 @@ export const useExpenseCreateForm = () => {
   }
 
   return {
-    nameRef,
+    amountRef,
     categories,
     error,
     loading,

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -13,10 +13,8 @@ export const ExpensesPage = () => {
       onSubmit={f.handleSubmit}
       className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden"
     >
-      <div className="flex shrink-0 justify-center px-5 pt-5 pb-1">
-        <span className="text-[11px] font-bold tracking-widest text-gray-400 uppercase dark:text-gray-500">
-          New expense
-        </span>
+      <div className="flex shrink-0 justify-end px-5 pt-2">
+        <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
       </div>
 
       {f.error && (
@@ -26,9 +24,6 @@ export const ExpensesPage = () => {
       <div className="flex-1 overflow-y-auto">
         <div className="flex min-h-full flex-col justify-center py-8">
           <ExpenseAmountInput value={f.amount} onChange={f.setAmount} inputRef={f.amountRef} />
-          <div className="flex justify-end pr-2 pt-3">
-            <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
-          </div>
           <ExpenseNameInput value={f.name} onChange={f.setName} />
           <ExpenseCategoryChips
             categories={f.categories}

--- a/frontend/src/expense/pages/ExpensesPage.tsx
+++ b/frontend/src/expense/pages/ExpensesPage.tsx
@@ -25,11 +25,11 @@ export const ExpensesPage = () => {
 
       <div className="flex-1 overflow-y-auto">
         <div className="flex min-h-full flex-col justify-center py-8">
-          <div className="flex justify-end pr-2">
+          <ExpenseAmountInput value={f.amount} onChange={f.setAmount} inputRef={f.amountRef} />
+          <div className="flex justify-end pr-2 pt-3">
             <ExpenseDateTimeInput value={f.expensedAt} onChange={f.setExpensedAt} />
           </div>
-          <ExpenseNameInput value={f.name} onChange={f.setName} inputRef={f.nameRef} />
-          <ExpenseAmountInput value={f.amount} onChange={f.setAmount} />
+          <ExpenseNameInput value={f.name} onChange={f.setName} />
           <ExpenseCategoryChips
             categories={f.categories}
             selectedUuid={f.categoryUuid}


### PR DESCRIPTION
## Summary
- new expense画面の最上部に金額を配置
- 画面表示時に金額入力欄を自動フォーカス
- `pattern="[0-9]*"` を追加しiOSテンキー表示を確実化

Closes #153

## Test plan
- [ ] iOS実機 / Chrome on iPhone でnew expense画面を開く
- [ ] 金額欄が最上部に表示される
- [ ] 開いた直後にテンキーが立ち上がる
- [ ] 金額・日時・名前の入力フローが従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)