### PR TITLE
feat: add expense遷移時にiOSキーボードを表示

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -4,6 +4,7 @@ import { Outlet, useNavigate } from "react-router"
 
 import { api } from "../libs/api"
 import { STORAGE_KEYS } from "../libs/constants"
+import { focusShimRef } from "../libs/focusShim"
 import type { UserResponse } from "../libs/types"
 import { LayoutLaptop } from "./LayoutLaptop"
 import { LayoutPhone } from "./LayoutPhone"
@@ -47,6 +48,16 @@ export const AppLayout = () => {
         </main>
       </div>
       <LayoutPhone navItems={navItems} />
+      <input
+        ref={(el) => {
+          focusShimRef.current = el
+        }}
+        type="text"
+        inputMode="numeric"
+        aria-hidden
+        tabIndex={-1}
+        className="pointer-events-none fixed top-0 left-[-9999px] size-px opacity-0"
+      />
     </div>
   )
 }

--- a/frontend/src/common/components/LayoutPhone.tsx
+++ b/frontend/src/common/components/LayoutPhone.tsx
@@ -1,6 +1,8 @@
 import type { ComponentType } from "react"
 import { NavLink } from "react-router"
 
+import { focusShim } from "../libs/focusShim"
+
 interface NavItem {
   label: string
   to: string
@@ -20,6 +22,7 @@ export const LayoutPhone = ({ navItems }: LayoutPhoneProps) => {
           key={item.to}
           to={item.to}
           end
+          onPointerDown={item.to === "/expense/new" ? focusShim : undefined}
           className={({ isActive }) =>
             `flex flex-1 flex-col items-center gap-1 px-1 py-1 text-[10px] font-semibold tracking-wide ${
               isActive && !item.accent ? "text-primary" : "text-gray-400 dark:text-gray-500"

--- a/frontend/src/common/libs/focusShim.ts
+++ b/frontend/src/common/libs/focusShim.ts
@@ -1,0 +1,7 @@
+/** iOSキーボードをユーザージェスチャー内で立ち上げるためのshim input参照。 */
+export const focusShimRef: { current: HTMLInputElement | null } = { current: null }
+
+/** ユーザージェスチャー内で同期的にshim inputへfocusし、iOSテンキーを表示。 */
+export const focusShim = () => {
+  focusShimRef.current?.focus()
+}

--- a/frontend/src/expense/components/ExpenseEmptyState.tsx
+++ b/frontend/src/expense/components/ExpenseEmptyState.tsx
@@ -1,6 +1,8 @@
 import { FileTextIcon, PlusIcon } from "@radix-ui/react-icons"
 import { useNavigate } from "react-router"
 
+import { focusShim } from "../../common/libs/focusShim"
+
 interface ExpenseEmptyStateProps {
   period: string
 }
@@ -21,6 +23,7 @@ export const ExpenseEmptyState = ({ period }: ExpenseEmptyStateProps) => {
       </div>
       <button
         type="button"
+        onPointerDown={focusShim}
         onClick={() => navigate("/expense/new")}
         className="mt-2 inline-flex items-center gap-1.5 rounded-xl bg-primary px-4 py-2.5 text-sm text-white hover:bg-primary-hover"
       >


### PR DESCRIPTION
## Summary
add expense遷移時のiOSキーボード起動問題に対処。
ユーザージェスチャー内でshim inputへ同期focusし、
遷移後の金額inputへfocus移譲することで継続表示。

## 仕組み
1. `AppLayout` にオフスクリーンの shim input を常設
2. Add ボタン (`LayoutPhone` / `ExpenseEmptyState`) の
   `onPointerDown` で shim を focus → iOSキーボード起動
3. React Routerで遷移 → `ExpensesPage` mount
4. 既存useEffectで amount input へ focus → キーボード継続

## 変更ファイル
- `frontend/src/common/libs/focusShim.ts` (新規)
- `frontend/src/common/components/AppLayout.tsx`
- `frontend/src/common/components/LayoutPhone.tsx`
- `frontend/src/expense/components/ExpenseEmptyState.tsx`

Closes #162

## Test plan
- [x] lint・typecheck・vitest 全通過
- [ ] iOS Safari/PWAでAddタブタップ→キーボード即表示
- [ ] 空状態のAdd expenseボタンでも同様
- [ ] デスクトップで挙動の影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)