### PR TITLE
fix: 4桁超の金額でsubmitできない問題を修正

### DIFF
--- a/frontend/src/expense/components/ExpenseAmountInput.tsx
+++ b/frontend/src/expense/components/ExpenseAmountInput.tsx
@@ -19,7 +19,6 @@ export const ExpenseAmountInput = ({ value, onChange, inputRef }: ExpenseAmountI
         ref={inputRef}
         type="text"
         inputMode="numeric"
-        pattern="[0-9]*"
         value={value}
         onChange={(e) => handle(e.target.value)}
         required


### PR DESCRIPTION
## Summary
- closes #164
- `ExpenseAmountInput` の `pattern="[0-9]*"` がカンマ区切り表示と衝突しsubmitをブロックしていたため削除
- `inputMode="numeric"` は維持しiOSの数値キーボード表示は変わらず

## Test plan
- [ ] add expenseで5桁以上の金額を入力しsubmitできることを確認
- [ ] iPhone Chromeで数値キーボードが表示されることを確認
- [ ] 編集画面 (ExpenseDetailPage) でも同様に保存できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)