### PR TITLE
docs: .claude配下のmdを日本語化

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,29 +1,30 @@
-# BurnStyle - Project Guidelines
+# BurnStyle - プロジェクトガイドライン
 
-## Language Policy
-- All text in the repository (code, comments, documentation, commit messages) must be written in English.
-- **Exception**: JSDoc / Python docstrings are written in Japanese (concise, 1–2 lines focusing on WHY).
+## 言語ポリシー
+- リポジトリ内のテキスト (コード・コメント・ドキュメント・コミットメッセージ) は英語で記述する
+- **例外1**: JSDoc / Python docstring は日本語 (簡潔に1〜2行、WHY 中心)
+- **例外2**: `.claude/` 配下の Claude 向け指示ファイル (本ファイル含む) は日本語
 
-## Implementation Policy
-- **Simplicity is the top priority**
-- Meet requirements with minimal code
-- Avoid unnecessary abstraction and over-engineering
-- When in doubt, choose the simpler approach
+## 実装ポリシー
+- **シンプルさを最優先**
+- 最小限のコードで要件を満たす
+- 不要な抽象化・オーバーエンジニアリングを避ける
+- 迷ったらシンプルな方を選ぶ
 
-## Overview
-- Expense management app (full-stack)
-- Backend: FastAPI + SQLAlchemy + PostgreSQL
-- Frontend: React + Vite + Tailwind CSS v4
-- Auth: WebAuthn/Passkey + JWT
-- Client: Web app added to home screen via Google Chrome on iPhone
+## 概要
+- 家計簿アプリ (フルスタック)
+- バックエンド: FastAPI + SQLAlchemy + PostgreSQL
+- フロントエンド: React + Vite + Tailwind CSS v4
+- 認証: WebAuthn/Passkey + JWT
+- クライアント: iPhone の Google Chrome からホーム画面に追加した Web アプリ
 
-## Rule Files
+## ルールファイル
 
-- [Product Concept](rules/concept.md) - Vision, target users & design philosophy
-- [Backend](rules/backend.md) - Python coding conventions
-- [Frontend](rules/frontend.md) - TypeScript / React coding conventions
-- [Development Flow](rules/development.md) - Required lint & test process
-- [Git](rules/git.md) - Conventional Commits / commit language
-- [Infrastructure](rules/infra.md) - Deploy targets & environment variables
+- [プロダクトコンセプト](rules/concept.md) - ビジョン・対象ユーザー・デザイン哲学
+- [バックエンド](rules/backend.md) - Python コーディング規約
+- [フロントエンド](rules/frontend.md) - TypeScript / React コーディング規約
+- [開発フロー](rules/development.md) - 必須の lint / test プロセス
+- [Git](rules/git.md) - Conventional Commits / コミット言語
+- [インフラ](rules/infra.md) - デプロイ先・環境変数
 
-> Architecture, schemas, endpoints, screens, and commands are read directly from the codebase (`backend/src/`, `frontend/src/`, `Makefile`, `docker-compose.yml`).
+> アーキテクチャ・スキーマ・エンドポイント・画面・コマンドは直接コードベース (`backend/src/`, `frontend/src/`, `Makefile`, `docker-compose.yml`) から読み取る。

--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -1,26 +1,26 @@
-# Backend Conventions
+# バックエンド規約
 
-## Python Version
-- Pin to **3.12** in `backend/.python-version` and `requires-python = ">=3.12"` in `backend/pyproject.toml`
-- Do NOT bump to 3.13+ without confirming Vercel's Python runtime supports it — Vercel currently supports up to 3.12, and a mismatch causes `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'` in production (cp3XX wheel bundled by CI fails to load under Vercel's runtime ABI)
-- If upgrade is needed, change `.python-version` + `pyproject.toml` together, then `cd backend && uv lock` to regenerate wheels
+## Python バージョン
+- `backend/.python-version` と `backend/pyproject.toml` の `requires-python = ">=3.12"` で **3.12** に固定
+- Vercel の Python ランタイムが 3.13+ をサポートするまでアップグレード禁止 — 現状 Vercel は 3.12 までサポートで、不一致は本番で `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'` を引き起こす (CI がバンドルする cp3XX wheel が Vercel ランタイム ABI でロード失敗する)
+- アップグレードが必要な場合は `.python-version` と `pyproject.toml` を同時に変更し、`cd backend && uv lock` で wheel を再生成する
 
-## Coding Conventions
-- Add `from __future__ import annotations` at the top of each file
-- **UUID**: Use uuid6 (v7), 32 characters without hyphens
-- **Deletion**: Soft delete via `deleted_at` column
-- `print()` is only allowed in `scripts/` directory
+## コーディング規約
+- 各ファイル先頭に `from __future__ import annotations` を追加
+- **UUID**: uuid6 (v7) を使用、ハイフン無し32文字
+- **削除**: `deleted_at` カラムによる論理削除
+- `print()` は `scripts/` ディレクトリ内でのみ許可
 
-## Logging
-- Use `src.logger.get_logger(name)` — never `print()` in app code
-- Pass structured data via `extra={...}` (e.g. `logger.info("user signed in", extra={"event": "signin"})`)
-- `request_id` and `user_uuid` are auto-injected from contextvars — do not pass them explicitly
+## ロギング
+- アプリケーションコードでは `src.logger.get_logger(name)` を使用 — `print()` は禁止
+- 構造化データは `extra={...}` で渡す (例: `logger.info("user signed in", extra={"event": "signin"})`)
+- `request_id` と `user_uuid` は contextvars から自動注入されるため明示的に渡さない
 
 ## mypy / ruff
-- mypy strict mode required, type annotations on all functions and variables
-- ruff line length: 120
+- mypy strict モード必須、全ての関数・変数に型注釈
+- ruff の行長: 120
 
-## Date / Time
-- For "JST today", use `datetime.now(JST).date()` — `date.today()` is OS-tz dependent and forbidden
-- `python-dateutil` is allowed only for `relativedelta` (month arithmetic). `dateutil.parser` is forbidden
-- For recurring schedules, compute dates from `start_date + n × interval` to avoid drift on month-end edges (do not chain from "last + interval")
+## 日付 / 時刻
+- 「JST の今日」は `datetime.now(JST).date()` を使う — `date.today()` は OS のタイムゾーンに依存するため禁止
+- `python-dateutil` は `relativedelta` (月計算) のみ許可。`dateutil.parser` は禁止
+- 繰り返しスケジュールは `start_date + n × interval` から計算 — 月末のずれを防ぐため「前回 + interval」の連鎖はしない

--- a/.claude/rules/concept.md
+++ b/.claude/rules/concept.md
@@ -1,37 +1,37 @@
-# Product Concept
+# プロダクトコンセプト
 
-## Vision
+## ビジョン
 
-**Track only expenses to help users visualize their individuality**
+**支出だけを記録し、ユーザーの個性を可視化する**
 
-No income or asset management — focused solely on "what you spend money on."
-Understand your own values and lifestyle objectively through spending patterns.
+収入や資産の管理は行わず、「何にお金を使ったか」のみに集中する。
+支出パターンを通じて自身の価値観・ライフスタイルを客観的に理解する。
 
-## Target Users
+## 対象ユーザー
 
-- Personal use (not for organizations or teams)
-- People who want to understand their spending habits
-- People who couldn't keep up with complex budgeting apps
+- 個人利用 (組織・チーム向けではない)
+- 自身の支出習慣を把握したい人
+- 複雑な家計簿アプリを続けられなかった人
 
-## Design Philosophy
+## デザイン哲学
 
-### Simple UI with Intuitive Interaction
+### 直感的に操作できるシンプルな UI
 
-- Minimal input fields (name, amount, date, category)
-- Record an expense with a single tap
-- Passwordless authentication (passkeys) to eliminate login friction
+- 入力項目は最小限 (名前・金額・日付・カテゴリ)
+- ワンタップで支出を記録
+- パスキーによるパスワードレス認証でログイン摩擦を排除
 
-### Insights Through Visualization
+### 可視化による気づき
 
-- Monthly and annual trend charts
-- Category-based spending breakdown
-- Heatmap for daily spending patterns
-- Bubble chart for amount range distribution
+- 月次・年次のトレンドチャート
+- カテゴリ別の支出内訳
+- 日別支出パターンのヒートマップ
+- 金額帯分布のバブルチャート
 
-### Out of Scope
+### スコープ外
 
-- Income management
-- Asset management / bank account linking
-- Budget setting / alerts
-- Team or family sharing
-- Advertisements
+- 収入管理
+- 資産管理・銀行口座連携
+- 予算設定・アラート
+- チーム・家族共有
+- 広告

--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -1,6 +1,6 @@
-# Development Flow
+# 開発フロー
 
-## Required Process
-- Always run `make lint` and `make test-backend` after code changes
-- Fix all errors before considering the task complete
-- Commit and push after file changes
+## 必須プロセス
+- コード変更後は必ず `make lint` と `make test-backend` を実行
+- 全エラーを修正してからタスク完了とする
+- ファイル変更後は commit と push を行う

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,14 +1,14 @@
-# Frontend Conventions
+# フロントエンド規約
 
-## Coding Conventions
-- Use arrow functions for function definitions (`const fn = () => {}`) — `function` declarations are not allowed
-- Prefer `interface` for type definitions — use `type` only when `interface` cannot express it (e.g., union types)
-- Use named exports only — `export default` is not allowed
+## コーディング規約
+- 関数定義はアロー関数 (`const fn = () => {}`) を使う — `function` 宣言は禁止
+- 型定義は `interface` を優先 — union 型など `interface` で表現できない場合のみ `type` を使う
+- 名前付きエクスポートのみ使用 — `export default` は禁止
 
 ## oxlint / oxfmt
-- oxlint: correctness + suspicious categories enabled
-- oxfmt: spaces, double quotes, no semicolons (auto-inserted only for ASI protection), auto import sorting
+- oxlint: correctness + suspicious カテゴリを有効化
+- oxfmt: スペース・ダブルクォート・セミコロンなし (ASI 保護用に自動挿入のみ)・import 自動ソート
 
 ## Tailwind CSS v4
-- Integrated via Vite plugin (`@tailwindcss/vite`)
-- CSS-first configuration (no `tailwind.config.js`)
+- Vite プラグイン (`@tailwindcss/vite`) で統合
+- CSS-first 設定 (`tailwind.config.js` なし)

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,21 +1,21 @@
-# Git & Deploy Guidelines
+# Git & デプロイガイドライン
 
-## Commit Messages
-- Conventional Commits format: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, etc.
-- Written in English
+## コミットメッセージ
+- Conventional Commits 形式: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:` 等
+- 英語で記述
 
-## Deploy
-- **Platform**: Vercel
-- **Trigger**: GitHub Actions `workflow_dispatch` (manual execution)
-- **Environments**: production / preview selectable
+## デプロイ
+- **プラットフォーム**: Vercel
+- **トリガー**: GitHub Actions `workflow_dispatch` (手動実行)
+- **環境**: production / preview から選択
 
-## GitHub Actions Workflows
-| File | Target |
-|------|--------|
-| `deploy_backend.yml` | Backend deploy |
-| `deploy_frontend.yml` | Frontend deploy |
+## GitHub Actions ワークフロー
+| ファイル | 対象 |
+|---------|------|
+| `deploy_backend.yml` | バックエンドデプロイ |
+| `deploy_frontend.yml` | フロントエンドデプロイ |
 
-## Deploy Flow
-1. Manually trigger from GitHub Actions tab
-2. Select environment (production / preview)
-3. Build & deploy via Vercel CLI
+## デプロイフロー
+1. GitHub Actions タブから手動でトリガー
+2. 環境を選択 (production / preview)
+3. Vercel CLI 経由でビルド・デプロイ

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -1,35 +1,35 @@
-# Infrastructure & Deploy
+# インフラ & デプロイ
 
-## Deploy
-- Platform: Vercel (frontend + backend)
-- Production DB: Neon (PostgreSQL)
-- CI/CD: GitHub Actions `workflow_dispatch` (manual trigger), production / preview selectable
-- Workflows: `deploy_backend.yml` / `deploy_frontend.yml`
+## デプロイ
+- プラットフォーム: Vercel (フロントエンド + バックエンド)
+- 本番 DB: Neon (PostgreSQL)
+- CI/CD: GitHub Actions `workflow_dispatch` (手動トリガー)、production / preview 選択可
+- ワークフロー: `deploy_backend.yml` / `deploy_frontend.yml`
 
-## DB Connection Switching
+## DB 接続の切り替え
 - `VERCEL_ENV=production` → Neon
-- Otherwise → local Docker
+- それ以外 → ローカル Docker
 
 ## CORS
 
-- CORS headers are set at the Vercel edge layer via `backend/vercel.json` (`headers`), not by FastAPI middleware.
-- The OPTIONS preflight is handled by a catch-all route in `backend/src/main.py` that returns 204 (Vercel adds the CORS headers).
-- The frontend origin in `vercel.json` is hard-coded; update it there if the production URL changes.
+- CORS ヘッダは FastAPI ミドルウェアではなく `backend/vercel.json` (`headers`) 経由で Vercel エッジ層に設定
+- OPTIONS preflight は `backend/src/main.py` のキャッチオールルートで 204 を返す (CORS ヘッダは Vercel が付与)
+- `vercel.json` 内のフロントエンドオリジンはハードコード — 本番 URL が変わったらここを更新する
 
-## Environment Variables
+## 環境変数
 
-### Local + Production
-| Variable | Purpose |
-|----------|---------|
-| `JWT_SECRET_KEY` | JWT signing secret (32+ chars in production) |
+### ローカル + 本番
+| 変数 | 用途 |
+|------|------|
+| `JWT_SECRET_KEY` | JWT 署名シークレット (本番は32文字以上) |
 | `WEBAUTHN_RP_ID` | WebAuthn RP ID |
-| `WEBAUTHN_RP_NAME` | WebAuthn RP name |
-| `FRONTEND_ORIGIN` | WebAuthn `expected_origin` for register/sign-in verification (NOT used for CORS — that's in `vercel.json`) |
-| `CRON_SECRET` | Bearer token for `/cron/*` endpoints (32+ chars recommended) |
+| `WEBAUTHN_RP_NAME` | WebAuthn RP 名 |
+| `FRONTEND_ORIGIN` | WebAuthn の register/sign-in 検証時の `expected_origin` (CORS には未使用 — それは `vercel.json` 側) |
+| `CRON_SECRET` | `/cron/*` エンドポイント用 Bearer トークン (32文字以上推奨) |
 
-### Production Only
-| Variable | Purpose |
-|----------|---------|
-| `VITE_API_URL` | API endpoint URL |
-| `POSTGRES_URL` | Neon DB connection URL |
-| `VERCEL_ENV` | `production` selects production DB |
+### 本番のみ
+| 変数 | 用途 |
+|------|------|
+| `VITE_API_URL` | API エンドポイント URL |
+| `POSTGRES_URL` | Neon DB 接続 URL |
+| `VERCEL_ENV` | `production` で本番 DB を選択 |


### PR DESCRIPTION
## Summary
- closes #169
- `.claude/CLAUDE.md` および `.claude/rules/*.md` を日本語化し SKILL.md と表記統一
- 言語ポリシーに「`.claude/` 配下は日本語」を例外として明記
- 固有名詞・コードブロック・コマンド・パスは原文維持

## Test plan
- [ ] 各mdの見出し・本文・表が日本語になっていることを確認
- [ ] CLAUDE.md からのリンク先 (rules/*.md) が全て解決することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)