### PR TITLE
feat: rename nav Today to Home

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -10,7 +10,7 @@ import { LayoutLaptop } from "./LayoutLaptop"
 import { LayoutPhone } from "./LayoutPhone"
 
 const navItems = [
-  { label: "Today", to: "/", icon: HomeIcon },
+  { label: "Home", to: "/", icon: HomeIcon },
   { label: "Expense", to: "/expense/monthly", icon: RowsIcon },
   { label: "Add", to: "/expense/new", icon: PlusIcon, accent: true },
   { label: "Insights", to: "/insight", icon: BarChartIcon },


### PR DESCRIPTION
Closes #172

## Summary
- ナビゲーションメニューのラベル `Today` → `Home`
- 遷移先・アイコンは据え置き

## Test plan
- [ ] ナビゲーション表示が "Home" に変わること

🤖 Generated with [Claude Code](https://claude.com/claude-code)