### PR TITLE
chore: remove Total label from expense list

### DIFF
--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -23,9 +23,6 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
   return (
     <>
       <div className="flex shrink-0 items-baseline justify-end gap-2 pt-2">
-        <span className="text-[10px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-          Total
-        </span>
         <span className="text-2xl font-bold tabular-nums">¥{total.toLocaleString()}</span>
       </div>
 


### PR DESCRIPTION
## Summary
- 支出一覧の合計金額に付いていた "Total" ラベルを削除
- 金額表示自体は残す

🤖 Generated with [Claude Code](https://claude.com/claude-code)