### PR TITLE
chore: left-align categories title; remove plus icon

### DIFF
--- a/frontend/src/category/pages/CategoriesPage.tsx
+++ b/frontend/src/category/pages/CategoriesPage.tsx
@@ -25,17 +25,8 @@ export const CategoriesPage = () => {
 
   return (
     <div className="mx-auto flex h-full max-w-2xl flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center justify-between px-4 pt-3 pb-2">
-        <div className="w-10" />
+      <div className="shrink-0 px-4 pt-3 pb-2">
         <h1 className="text-base font-semibold">Categories</h1>
-        <button
-          type="button"
-          aria-label="New category"
-          onClick={() => navigate("/category/new")}
-          className="flex w-10 items-center justify-end text-2xl leading-none text-primary"
-        >
-          +
-        </button>
       </div>
       {error && (
         <p className="mx-5 shrink-0 pb-2 text-sm text-red-600 dark:text-red-400">{error}</p>


### PR DESCRIPTION
## Summary
- categories ページタイトル "Categories" を左寄せに変更
- ヘッダー右上の "+" (新規カテゴリ) ボタンを削除
- 一覧下部の "New category" ボタンで代替

🤖 Generated with [Claude Code](https://claude.com/claude-code)