### PR TITLE
feat: add per-section clear in filter sheet

### DIFF
--- a/frontend/src/expense/components/FilterSheetAmountSection.tsx
+++ b/frontend/src/expense/components/FilterSheetAmountSection.tsx
@@ -21,9 +21,16 @@ export const FilterSheetAmountSection = ({
   onPreset,
 }: FilterSheetAmountSectionProps) => (
   <section>
-    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-      Amount
-    </h3>
+    <div className="mb-2 flex items-center justify-between">
+      <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Amount
+      </h3>
+      {(min > 0 || max > 0) && (
+        <button type="button" onClick={() => onPreset(0, 0)} className="text-[11px] text-gray-400">
+          clear
+        </button>
+      )}
+    </div>
     <div className="flex items-center gap-2">
       <div className="flex flex-1 items-center gap-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm dark:border-gray-700 dark:bg-gray-800">
         <span className="text-gray-400">¥</span>

--- a/frontend/src/expense/components/FilterSheetScopeSection.tsx
+++ b/frontend/src/expense/components/FilterSheetScopeSection.tsx
@@ -7,9 +7,20 @@ interface FilterSheetScopeSectionProps {
 
 export const FilterSheetScopeSection = ({ scope, onChange }: FilterSheetScopeSectionProps) => (
   <section>
-    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-      Period
-    </h3>
+    <div className="mb-2 flex items-center justify-between">
+      <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Period
+      </h3>
+      {scope !== "month" && (
+        <button
+          type="button"
+          onClick={() => onChange("month")}
+          className="text-[11px] text-gray-400"
+        >
+          clear
+        </button>
+      )}
+    </div>
     <div className="flex flex-wrap gap-2">
       {SCOPE_OPTIONS.map((s) => {
         const on = scope === s.k

--- a/frontend/src/expense/components/FilterSheetSearchSection.tsx
+++ b/frontend/src/expense/components/FilterSheetSearchSection.tsx
@@ -1,5 +1,3 @@
-import { Cross2Icon } from "@radix-ui/react-icons"
-
 interface FilterSheetSearchSectionProps {
   value: string
   onChange: (v: string) => void
@@ -7,27 +5,22 @@ interface FilterSheetSearchSectionProps {
 
 export const FilterSheetSearchSection = ({ value, onChange }: FilterSheetSearchSectionProps) => (
   <section>
-    <h3 className="mb-2 text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-      Search
-    </h3>
-    <div className="relative">
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder="Name…"
-        className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-      />
+    <div className="mb-2 flex items-center justify-between">
+      <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Search
+      </h3>
       {value && (
-        <button
-          type="button"
-          onClick={() => onChange("")}
-          className="absolute top-1/2 right-3 -translate-y-1/2 text-gray-400"
-          aria-label="Clear"
-        >
-          <Cross2Icon className="size-3.5" />
+        <button type="button" onClick={() => onChange("")} className="text-[11px] text-gray-400">
+          clear
         </button>
       )}
     </div>
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder="Name…"
+      className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+    />
   </section>
 )


### PR DESCRIPTION
## Summary
- フィルタシートの各セクション (Search / Period / Amount) に clear ボタンを追加
- 既存の Categories / Vibe のパターンに統一
- Search の input 内 × は削除し、ヘッダーの clear に集約

🤖 Generated with [Claude Code](https://claude.com/claude-code)