### PR TITLE
chore: move expense list filter icon to the right

### DIFF
--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -23,8 +23,8 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
   return (
     <>
       <div className="flex shrink-0 items-center justify-between gap-2 pt-2">
-        <ExpenseListFilterButton filterCount={fcount} onClick={() => setSheetOpen(true)} />
         <span className="text-2xl font-bold tabular-nums">¥{total.toLocaleString()}</span>
+        <ExpenseListFilterButton filterCount={fcount} onClick={() => setSheetOpen(true)} />
       </div>
 
       <ExpenseListScopeChips


### PR DESCRIPTION
## Summary
- 支出一覧トップの filter アイコンを右側に配置 (金額は左)

🤖 Generated with [Claude Code](https://claude.com/claude-code)