### PR TITLE
feat: month navigator for expense list

### DIFF
--- a/frontend/src/expense/components/ExpenseList.tsx
+++ b/frontend/src/expense/components/ExpenseList.tsx
@@ -7,6 +7,7 @@ import { ExpenseFilterChips } from "./ExpenseFilterChips"
 import { ExpenseFilterSheet } from "./ExpenseFilterSheet"
 import { ExpenseFlatList } from "./ExpenseFlatList"
 import { ExpenseListFilterButton } from "./ExpenseListFilterButton"
+import { ExpenseListMonthNav } from "./ExpenseListMonthNav"
 import { ExpenseListScopeChips } from "./ExpenseListScopeChips"
 
 interface ExpenseListProps {
@@ -29,8 +30,15 @@ export const ExpenseList = ({ expenses, initialFilter }: ExpenseListProps) => {
 
       <ExpenseListScopeChips
         scope={filter.scope}
-        onChange={(scope) => setFilter({ ...filter, scope })}
+        onChange={(scope) => setFilter({ ...filter, scope, month: null })}
       />
+
+      {filter.scope === "month" && (
+        <ExpenseListMonthNav
+          month={filter.month}
+          onChange={(month) => setFilter({ ...filter, month })}
+        />
+      )}
 
       <ExpenseFilterChips
         filter={filter}

--- a/frontend/src/expense/components/ExpenseListMonthNav.tsx
+++ b/frontend/src/expense/components/ExpenseListMonthNav.tsx
@@ -1,0 +1,52 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons"
+
+import { formatMonthKey, parseMonthKey, shiftMonthKey } from "../libs/expenseFilter"
+
+interface ExpenseListMonthNavProps {
+  month: string | null
+  onChange: (month: string | null) => void
+}
+
+const monthLabel = (key: string): string => {
+  const parsed = parseMonthKey(key)
+  if (!parsed) return key
+  return new Date(parsed.year, parsed.month, 1).toLocaleDateString("en-US", {
+    month: "short",
+    year: "numeric",
+  })
+}
+
+export const ExpenseListMonthNav = ({ month, onChange }: ExpenseListMonthNavProps) => {
+  const now = new Date()
+  const currentKey = formatMonthKey(now.getFullYear(), now.getMonth())
+  const activeKey = month ?? currentKey
+
+  const go = (delta: number) => {
+    const next = shiftMonthKey(activeKey, delta)
+    onChange(next === currentKey ? null : next)
+  }
+
+  return (
+    <div className="flex shrink-0 items-center justify-between pt-2">
+      <button
+        type="button"
+        onClick={() => go(-1)}
+        aria-label="Previous month"
+        className="flex size-7 items-center justify-center rounded-full text-gray-500 dark:text-gray-400"
+      >
+        <ChevronLeftIcon className="size-4" />
+      </button>
+      <span className="text-xs font-bold tracking-widest text-gray-600 uppercase dark:text-gray-300">
+        {monthLabel(activeKey)}
+      </span>
+      <button
+        type="button"
+        onClick={() => go(1)}
+        aria-label="Next month"
+        className="flex size-7 items-center justify-center rounded-full text-gray-500 dark:text-gray-400"
+      >
+        <ChevronRightIcon className="size-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/expense/libs/expenseFilter.test.ts
+++ b/frontend/src/expense/libs/expenseFilter.test.ts
@@ -28,6 +28,7 @@ describe("defaultFilter", () => {
       min: 0,
       max: 0,
       date: null,
+      month: null,
       vibeSocial: null,
       vibePlanning: null,
       vibeNecessity: null,
@@ -49,6 +50,7 @@ describe("filterCount", () => {
         min: 100,
         max: 200,
         date: "2026-06-16",
+        month: null,
         vibeSocial: null,
         vibePlanning: null,
         vibeNecessity: null,
@@ -102,6 +104,13 @@ describe("applyFilter", () => {
     const inMonth = mkExpense({ uuid: "a", expensed_at: new Date(2026, 5, 1).toISOString() })
     const lastMonth = mkExpense({ uuid: "b", expensed_at: new Date(2026, 4, 30).toISOString() })
     const result = applyFilter([inMonth, lastMonth], defaultFilter())
+    expect(result.map((e) => e.uuid)).toEqual(["a"])
+  })
+
+  it("month scope honors explicit month key", () => {
+    const inMonth = mkExpense({ uuid: "a", expensed_at: new Date(2026, 4, 15).toISOString() })
+    const otherMonth = mkExpense({ uuid: "b", expensed_at: new Date(2026, 5, 15).toISOString() })
+    const result = applyFilter([inMonth, otherMonth], { ...defaultFilter(), month: "2026-05" })
     expect(result.map((e) => e.uuid)).toEqual(["a"])
   })
 

--- a/frontend/src/expense/libs/expenseFilter.ts
+++ b/frontend/src/expense/libs/expenseFilter.ts
@@ -15,6 +15,8 @@ export interface ExpenseFilter {
   max: number
   /** 特定日のみ表示する場合に YYYY-MM-DD を指定。設定時は scope を無視。 */
   date: string | null
+  /** scope=="month" で対象月を YYYY-MM 指定。null なら当月。 */
+  month: string | null
   vibeSocial: VibeSocial | null
   vibePlanning: VibePlanning | null
   vibeNecessity: VibeNecessity | null
@@ -33,6 +35,7 @@ export const defaultFilter = (): ExpenseFilter => ({
   min: 0,
   max: 0,
   date: null,
+  month: null,
   vibeSocial: null,
   vibePlanning: null,
   vibeNecessity: null,
@@ -62,6 +65,22 @@ export const parseDateKey = (key: string): Date | null => {
   return new Date(parts[0], parts[1] - 1, parts[2])
 }
 
+export const parseMonthKey = (key: string): { year: number; month: number } | null => {
+  const parts = key.split("-").map(Number)
+  if (parts.length !== 2 || parts.some(Number.isNaN)) return null
+  return { year: parts[0], month: parts[1] - 1 }
+}
+
+export const formatMonthKey = (year: number, month: number): string =>
+  `${year}-${String(month + 1).padStart(2, "0")}`
+
+export const shiftMonthKey = (key: string, delta: number): string => {
+  const parsed = parseMonthKey(key)
+  if (!parsed) return key
+  const d = new Date(parsed.year, parsed.month + delta, 1)
+  return formatMonthKey(d.getFullYear(), d.getMonth())
+}
+
 export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): ExpenseResponse[] => {
   const now = new Date()
   const weekStart = new Date(now)
@@ -78,7 +97,11 @@ export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): Expe
       if (d < weekStart) return false
       if (d > now && !sameLocalDay(d, now)) return false
     } else if (f.scope === "month") {
-      if (d.getFullYear() !== now.getFullYear() || d.getMonth() !== now.getMonth()) return false
+      const target = f.month
+        ? parseMonthKey(f.month)
+        : { year: now.getFullYear(), month: now.getMonth() }
+      if (!target) return false
+      if (d.getFullYear() !== target.year || d.getMonth() !== target.month) return false
     }
 
     if (f.q && !e.name.toLowerCase().includes(f.q.toLowerCase())) return false


### PR DESCRIPTION
## Summary
- 期間絞り込みに「月」軸を追加。Period が "Month" のとき月切替 UI を表示
- 前月 / 次月チェブロン + 中央に月ラベル
- `ExpenseFilter.month` (YYYY-MM) を追加。null=当月で既存挙動と一致
- 月キー操作ヘルパー: `parseMonthKey`, `formatMonthKey`, `shiftMonthKey`
- テスト追加: 明示月キーが適用されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)