### PR TITLE
chore: format dates as YYYY/MM/DD HH:mm in expense list

### DIFF
--- a/frontend/src/expense/components/ExpenseFlatList.tsx
+++ b/frontend/src/expense/components/ExpenseFlatList.tsx
@@ -5,14 +5,9 @@ import type { ExpenseResponse } from "../../common/libs/types"
 
 const pad = (n: number) => String(n).padStart(2, "0")
 
-const dayShort = (iso: string): string => {
+const dateTimeLabel = (iso: string): string => {
   const d = new Date(iso)
-  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
-}
-
-const timeLabel = (iso: string): string => {
-  const d = new Date(iso)
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
+  return `${d.getFullYear()}/${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
 }
 
 interface ExpenseFlatListProps {
@@ -35,27 +30,16 @@ export const ExpenseFlatList = ({
 
   return (
     <ul className="min-h-0 flex-1 divide-y divide-gray-100 overflow-y-auto pb-2 dark:divide-gray-700">
-      {expenses.map((e, i) => {
+      {expenses.map((e) => {
         const c = e.categories[0]
         const hasSymbol = !!c?.symbol?.trim()
-        const showDate =
-          i === 0 ||
-          new Date(expenses[i - 1].expensed_at).toDateString() !==
-            new Date(e.expensed_at).toDateString()
         return (
           <li key={e.uuid}>
             <button
               type="button"
               onClick={() => navigate(`/expense/${e.uuid}`)}
-              className="grid w-full grid-cols-[46px_14px_1fr_auto] items-center gap-1.5 py-2 text-left"
+              className="grid w-full grid-cols-[14px_1fr_auto] items-center gap-1.5 py-2 text-left"
             >
-              <span
-                className={`text-[11px] font-semibold ${
-                  showDate ? "text-gray-500 dark:text-gray-400" : "text-transparent"
-                }`}
-              >
-                {dayShort(e.expensed_at)}
-              </span>
               <span className="text-center text-[11px] text-gray-400 dark:text-gray-500">
                 {c ? categoryGlyph(c) : "·"}
               </span>
@@ -63,8 +47,8 @@ export const ExpenseFlatList = ({
                 <div className="truncate text-sm font-medium">{e.name}</div>
                 <div className="truncate text-[10px] text-gray-400 dark:text-gray-500">
                   {hasSymbol
-                    ? timeLabel(e.expensed_at)
-                    : `${c ? c.name : "Uncategorized"} · ${timeLabel(e.expensed_at)}`}
+                    ? dateTimeLabel(e.expensed_at)
+                    : `${c ? c.name : "Uncategorized"} · ${dateTimeLabel(e.expensed_at)}`}
                 </div>
               </div>
               <span className="text-sm font-medium tabular-nums">¥{e.amount.toLocaleString()}</span>

--- a/frontend/src/expense/components/ExpenseListMonthNav.tsx
+++ b/frontend/src/expense/components/ExpenseListMonthNav.tsx
@@ -10,10 +10,7 @@ interface ExpenseListMonthNavProps {
 const monthLabel = (key: string): string => {
   const parsed = parseMonthKey(key)
   if (!parsed) return key
-  return new Date(parsed.year, parsed.month, 1).toLocaleDateString("en-US", {
-    month: "short",
-    year: "numeric",
-  })
+  return `${parsed.year}/${parsed.month + 1}`
 }
 
 export const ExpenseListMonthNav = ({ month, onChange }: ExpenseListMonthNavProps) => {


### PR DESCRIPTION
## Summary
- 月ナビゲータの表記を `Jun 2026` → `2026/6`
- ExpenseFlatList の各行の日時を `2026/06/07 19:48` 形式に統一
- 左側の日付プレフィックス列を撤去 (各行のメタ行にフル日時を表示)

🤖 Generated with [Claude Code](https://claude.com/claude-code)