### PR TITLE
chore: enlarge category glyph in expense list

### DIFF
--- a/frontend/src/expense/components/ExpenseFlatList.tsx
+++ b/frontend/src/expense/components/ExpenseFlatList.tsx
@@ -38,9 +38,9 @@ export const ExpenseFlatList = ({
             <button
               type="button"
               onClick={() => navigate(`/expense/${e.uuid}`)}
-              className="grid w-full grid-cols-[14px_1fr_auto] items-center gap-1.5 py-2 text-left"
+              className="grid w-full grid-cols-[22px_1fr_auto] items-center gap-2 py-2 text-left"
             >
-              <span className="text-center text-[11px] text-gray-400 dark:text-gray-500">
+              <span className="text-center text-base leading-none text-gray-500 dark:text-gray-400">
                 {c ? categoryGlyph(c) : "·"}
               </span>
               <div className="min-w-0">


### PR DESCRIPTION
## Summary
- 支出リストのカテゴリシンボル列を 14px → 22px に拡張、絵文字が潰れないように
- フォントを `text-[11px]` → `text-base` に引き上げ
- gap も 1.5 → 2 に微調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)