### PR TITLE
chore: serve expense list at /

### DIFF
--- a/frontend/src/common/components/AppLayout.tsx
+++ b/frontend/src/common/components/AppLayout.tsx
@@ -10,7 +10,7 @@ import { LayoutLaptop } from "./LayoutLaptop"
 import { LayoutPhone } from "./LayoutPhone"
 
 const navItems = [
-  { label: "Expense", to: "/expense/monthly", icon: RowsIcon },
+  { label: "Expense", to: "/", icon: RowsIcon },
   { label: "Add", to: "/expense/new", icon: PlusIcon, accent: true },
   { label: "Setting", to: "/setting", icon: GearIcon },
 ]

--- a/frontend/src/expense/hooks/useExpenseCreateForm.ts
+++ b/frontend/src/expense/hooks/useExpenseCreateForm.ts
@@ -54,7 +54,7 @@ export const useExpenseCreateForm = () => {
         vibe_planning: vibePlanning,
         vibe_necessity: vibeNecessity,
       })
-      navigate("/expense/monthly")
+      navigate("/")
     } catch (err) {
       setError(getErrorMessage(err, "Failed to create"))
     } finally {

--- a/frontend/src/expense/hooks/useExpenseEditForm.ts
+++ b/frontend/src/expense/hooks/useExpenseEditForm.ts
@@ -100,7 +100,7 @@ export const useExpenseEditForm = (uuid: string | undefined) => {
     try {
       await api.deleteExpense(uuid)
       dialogRef.current?.close()
-      navigate("/expense/monthly")
+      navigate("/")
     } catch (err) {
       setError(getErrorMessage(err, "Delete failed"))
     } finally {

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -23,11 +23,10 @@ export const router = createBrowserRouter([
       </ProtectedRoute>
     ),
     children: [
-      { path: "/", element: <Navigate to="/expense/monthly" replace /> },
+      { path: "/", element: <ExpenseMonthlyPage /> },
       {
         path: "/expense",
         children: [
-          { path: "monthly", element: <ExpenseMonthlyPage /> },
           { path: "new", element: <ExpensesPage /> },
           { path: "recurring", element: <RecurringExpenseListPage /> },
           { path: "recurring/new", element: <RecurringExpenseEditPage /> },
@@ -46,5 +45,5 @@ export const router = createBrowserRouter([
       { path: "/setting", element: <SettingsPage /> },
     ],
   },
-  { path: "*", element: <Navigate to="/expense/monthly" replace /> },
+  { path: "*", element: <Navigate to="/" replace /> },
 ])


### PR DESCRIPTION
## Summary
- 支出一覧を `/` で直接表示するように変更 (`/expense/monthly` を廃止)
- フッターナビとフォームの遷移先を `/` に更新
- フォールバック `*` も `/` リダイレクト

🤖 Generated with [Claude Code](https://claude.com/claude-code)