### PR TITLE
feat: toggle recurring inclusion in expense filter

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterChips.tsx
+++ b/frontend/src/expense/components/ExpenseFilterChips.tsx
@@ -34,7 +34,8 @@ export const ExpenseFilterChips = ({
         : `¥${filter.min.toLocaleString()}+`,
     )
   }
-  if (!filter.includeRecurring) labels.push("No recurring")
+  if (filter.recurringMode === "exclude") labels.push("No recurring")
+  if (filter.recurringMode === "only") labels.push("Recurring only")
 
   if (labels.length === 0) return null
 

--- a/frontend/src/expense/components/ExpenseFilterChips.tsx
+++ b/frontend/src/expense/components/ExpenseFilterChips.tsx
@@ -34,6 +34,7 @@ export const ExpenseFilterChips = ({
         : `¥${filter.min.toLocaleString()}+`,
     )
   }
+  if (!filter.includeRecurring) labels.push("No recurring")
 
   if (labels.length === 0) return null
 

--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -5,6 +5,7 @@ import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
 import { FilterSheetAmountSection } from "./FilterSheetAmountSection"
 import { FilterSheetCategorySection } from "./FilterSheetCategorySection"
 import { FilterSheetHeader } from "./FilterSheetHeader"
+import { FilterSheetRecurringSection } from "./FilterSheetRecurringSection"
 import { FilterSheetScopeSection } from "./FilterSheetScopeSection"
 import { FilterSheetSearchSection } from "./FilterSheetSearchSection"
 import { FilterSheetVibeSection } from "./FilterSheetVibeSection"
@@ -68,6 +69,10 @@ export const ExpenseFilterSheet = ({
           <FilterSheetScopeSection
             scope={draft.scope}
             onChange={(v) => setDraft({ ...draft, scope: v })}
+          />
+          <FilterSheetRecurringSection
+            includeRecurring={draft.includeRecurring}
+            onChange={(v) => setDraft({ ...draft, includeRecurring: v })}
           />
           <FilterSheetCategorySection
             categories={categories}

--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -71,8 +71,8 @@ export const ExpenseFilterSheet = ({
             onChange={(v) => setDraft({ ...draft, scope: v })}
           />
           <FilterSheetRecurringSection
-            includeRecurring={draft.includeRecurring}
-            onChange={(v) => setDraft({ ...draft, includeRecurring: v })}
+            mode={draft.recurringMode}
+            onChange={(v) => setDraft({ ...draft, recurringMode: v })}
           />
           <FilterSheetCategorySection
             categories={categories}

--- a/frontend/src/expense/components/FilterSheetRecurringSection.tsx
+++ b/frontend/src/expense/components/FilterSheetRecurringSection.tsx
@@ -1,15 +1,18 @@
+import type { RecurringMode } from "../libs/expenseFilter"
+
 interface FilterSheetRecurringSectionProps {
-  includeRecurring: boolean
-  onChange: (include: boolean) => void
+  mode: RecurringMode
+  onChange: (mode: RecurringMode) => void
 }
 
-const OPTIONS: { include: boolean; label: string }[] = [
-  { include: true, label: "Include" },
-  { include: false, label: "Exclude" },
+const OPTIONS: { k: RecurringMode; label: string }[] = [
+  { k: "all", label: "All" },
+  { k: "exclude", label: "Exclude" },
+  { k: "only", label: "Only" },
 ]
 
 export const FilterSheetRecurringSection = ({
-  includeRecurring,
+  mode,
   onChange,
 }: FilterSheetRecurringSectionProps) => (
   <section>
@@ -17,20 +20,20 @@ export const FilterSheetRecurringSection = ({
       <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
         Recurring
       </h3>
-      {!includeRecurring && (
-        <button type="button" onClick={() => onChange(true)} className="text-[11px] text-gray-400">
+      {mode !== "all" && (
+        <button type="button" onClick={() => onChange("all")} className="text-[11px] text-gray-400">
           clear
         </button>
       )}
     </div>
     <div className="flex flex-wrap gap-2">
       {OPTIONS.map((o) => {
-        const on = includeRecurring === o.include
+        const on = mode === o.k
         return (
           <button
-            key={String(o.include)}
+            key={o.k}
             type="button"
-            onClick={() => onChange(o.include)}
+            onClick={() => onChange(o.k)}
             className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
               on
                 ? "border-primary bg-primary text-white"

--- a/frontend/src/expense/components/FilterSheetRecurringSection.tsx
+++ b/frontend/src/expense/components/FilterSheetRecurringSection.tsx
@@ -1,0 +1,46 @@
+interface FilterSheetRecurringSectionProps {
+  includeRecurring: boolean
+  onChange: (include: boolean) => void
+}
+
+const OPTIONS: { include: boolean; label: string }[] = [
+  { include: true, label: "Include" },
+  { include: false, label: "Exclude" },
+]
+
+export const FilterSheetRecurringSection = ({
+  includeRecurring,
+  onChange,
+}: FilterSheetRecurringSectionProps) => (
+  <section>
+    <div className="mb-2 flex items-center justify-between">
+      <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Recurring
+      </h3>
+      {!includeRecurring && (
+        <button type="button" onClick={() => onChange(true)} className="text-[11px] text-gray-400">
+          clear
+        </button>
+      )}
+    </div>
+    <div className="flex flex-wrap gap-2">
+      {OPTIONS.map((o) => {
+        const on = includeRecurring === o.include
+        return (
+          <button
+            key={String(o.include)}
+            type="button"
+            onClick={() => onChange(o.include)}
+            className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${
+              on
+                ? "border-primary bg-primary text-white"
+                : "border-gray-200 bg-white text-gray-700 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200"
+            }`}
+          >
+            {o.label}
+          </button>
+        )
+      })}
+    </div>
+  </section>
+)

--- a/frontend/src/expense/libs/expenseFilter.test.ts
+++ b/frontend/src/expense/libs/expenseFilter.test.ts
@@ -32,7 +32,7 @@ describe("defaultFilter", () => {
       vibeSocial: null,
       vibePlanning: null,
       vibeNecessity: null,
-      includeRecurring: true,
+      recurringMode: "all",
     })
   })
 })
@@ -55,13 +55,14 @@ describe("filterCount", () => {
         vibeSocial: null,
         vibePlanning: null,
         vibeNecessity: null,
-        includeRecurring: true,
+        recurringMode: "all",
       }),
     ).toBe(5)
   })
 
-  it("counts excluded recurring", () => {
-    expect(filterCount({ ...defaultFilter(), includeRecurring: false })).toBe(1)
+  it("counts recurringMode when not 'all'", () => {
+    expect(filterCount({ ...defaultFilter(), recurringMode: "exclude" })).toBe(1)
+    expect(filterCount({ ...defaultFilter(), recurringMode: "only" })).toBe(1)
   })
 
   it("does not double-count when only min or only max is set", () => {
@@ -195,22 +196,33 @@ describe("applyFilter", () => {
     expect(result.map((e) => e.uuid)).toEqual(["a"])
   })
 
-  it("excludes recurring-generated expenses when includeRecurring is false", () => {
+  it("recurringMode 'all' includes both recurring and non-recurring", () => {
+    const normal = mkExpense({ uuid: "a", recurring_expense_uuid: null })
+    const recurring = mkExpense({ uuid: "b", recurring_expense_uuid: "r1" })
+    const result = applyFilter([normal, recurring], { ...defaultFilter(), scope: "all" })
+    expect(result.map((e) => e.uuid).toSorted()).toEqual(["a", "b"])
+  })
+
+  it("recurringMode 'exclude' drops recurring-generated expenses", () => {
     const normal = mkExpense({ uuid: "a", recurring_expense_uuid: null })
     const recurring = mkExpense({ uuid: "b", recurring_expense_uuid: "r1" })
     const result = applyFilter([normal, recurring], {
       ...defaultFilter(),
       scope: "all",
-      includeRecurring: false,
+      recurringMode: "exclude",
     })
     expect(result.map((e) => e.uuid)).toEqual(["a"])
   })
 
-  it("includes recurring-generated expenses when includeRecurring is true", () => {
+  it("recurringMode 'only' keeps only recurring-generated expenses", () => {
     const normal = mkExpense({ uuid: "a", recurring_expense_uuid: null })
     const recurring = mkExpense({ uuid: "b", recurring_expense_uuid: "r1" })
-    const result = applyFilter([normal, recurring], { ...defaultFilter(), scope: "all" })
-    expect(result.map((e) => e.uuid).toSorted()).toEqual(["a", "b"])
+    const result = applyFilter([normal, recurring], {
+      ...defaultFilter(),
+      scope: "all",
+      recurringMode: "only",
+    })
+    expect(result.map((e) => e.uuid)).toEqual(["b"])
   })
 
   it("min and max bound the amount inclusively", () => {

--- a/frontend/src/expense/libs/expenseFilter.test.ts
+++ b/frontend/src/expense/libs/expenseFilter.test.ts
@@ -32,6 +32,7 @@ describe("defaultFilter", () => {
       vibeSocial: null,
       vibePlanning: null,
       vibeNecessity: null,
+      includeRecurring: true,
     })
   })
 })
@@ -54,8 +55,13 @@ describe("filterCount", () => {
         vibeSocial: null,
         vibePlanning: null,
         vibeNecessity: null,
+        includeRecurring: true,
       }),
     ).toBe(5)
+  })
+
+  it("counts excluded recurring", () => {
+    expect(filterCount({ ...defaultFilter(), includeRecurring: false })).toBe(1)
   })
 
   it("does not double-count when only min or only max is set", () => {
@@ -187,6 +193,24 @@ describe("applyFilter", () => {
       vibeNecessity: "NEEDED",
     })
     expect(result.map((e) => e.uuid)).toEqual(["a"])
+  })
+
+  it("excludes recurring-generated expenses when includeRecurring is false", () => {
+    const normal = mkExpense({ uuid: "a", recurring_expense_uuid: null })
+    const recurring = mkExpense({ uuid: "b", recurring_expense_uuid: "r1" })
+    const result = applyFilter([normal, recurring], {
+      ...defaultFilter(),
+      scope: "all",
+      includeRecurring: false,
+    })
+    expect(result.map((e) => e.uuid)).toEqual(["a"])
+  })
+
+  it("includes recurring-generated expenses when includeRecurring is true", () => {
+    const normal = mkExpense({ uuid: "a", recurring_expense_uuid: null })
+    const recurring = mkExpense({ uuid: "b", recurring_expense_uuid: "r1" })
+    const result = applyFilter([normal, recurring], { ...defaultFilter(), scope: "all" })
+    expect(result.map((e) => e.uuid).toSorted()).toEqual(["a", "b"])
   })
 
   it("min and max bound the amount inclusively", () => {

--- a/frontend/src/expense/libs/expenseFilter.ts
+++ b/frontend/src/expense/libs/expenseFilter.ts
@@ -20,6 +20,8 @@ export interface ExpenseFilter {
   vibeSocial: VibeSocial | null
   vibePlanning: VibePlanning | null
   vibeNecessity: VibeNecessity | null
+  /** 繰り返し支出から生成された支出を含めるか。false の場合は除外。 */
+  includeRecurring: boolean
 }
 
 export const SCOPE_OPTIONS: { k: FilterScope; label: string; short: string }[] = [
@@ -39,6 +41,7 @@ export const defaultFilter = (): ExpenseFilter => ({
   vibeSocial: null,
   vibePlanning: null,
   vibeNecessity: null,
+  includeRecurring: true,
 })
 
 export const filterCount = (f: ExpenseFilter): number => {
@@ -51,6 +54,7 @@ export const filterCount = (f: ExpenseFilter): number => {
   if (f.vibeSocial) n++
   if (f.vibePlanning) n++
   if (f.vibeNecessity) n++
+  if (!f.includeRecurring) n++
   return n
 }
 
@@ -114,6 +118,7 @@ export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): Expe
     if (f.vibeSocial && e.vibe_social !== f.vibeSocial) return false
     if (f.vibePlanning && e.vibe_planning !== f.vibePlanning) return false
     if (f.vibeNecessity && e.vibe_necessity !== f.vibeNecessity) return false
+    if (!f.includeRecurring && e.recurring_expense_uuid !== null) return false
     return true
   })
 }

--- a/frontend/src/expense/libs/expenseFilter.ts
+++ b/frontend/src/expense/libs/expenseFilter.ts
@@ -6,6 +6,7 @@ import type {
 } from "../../common/libs/types"
 
 export type FilterScope = "week" | "month" | "all"
+export type RecurringMode = "all" | "exclude" | "only"
 
 export interface ExpenseFilter {
   q: string
@@ -20,8 +21,8 @@ export interface ExpenseFilter {
   vibeSocial: VibeSocial | null
   vibePlanning: VibePlanning | null
   vibeNecessity: VibeNecessity | null
-  /** 繰り返し支出から生成された支出を含めるか。false の場合は除外。 */
-  includeRecurring: boolean
+  /** 繰り返し支出から生成された支出の扱い。all=全て / exclude=除外 / only=繰り返しのみ。 */
+  recurringMode: RecurringMode
 }
 
 export const SCOPE_OPTIONS: { k: FilterScope; label: string; short: string }[] = [
@@ -41,7 +42,7 @@ export const defaultFilter = (): ExpenseFilter => ({
   vibeSocial: null,
   vibePlanning: null,
   vibeNecessity: null,
-  includeRecurring: true,
+  recurringMode: "all",
 })
 
 export const filterCount = (f: ExpenseFilter): number => {
@@ -54,7 +55,7 @@ export const filterCount = (f: ExpenseFilter): number => {
   if (f.vibeSocial) n++
   if (f.vibePlanning) n++
   if (f.vibeNecessity) n++
-  if (!f.includeRecurring) n++
+  if (f.recurringMode !== "all") n++
   return n
 }
 
@@ -118,7 +119,8 @@ export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): Expe
     if (f.vibeSocial && e.vibe_social !== f.vibeSocial) return false
     if (f.vibePlanning && e.vibe_planning !== f.vibePlanning) return false
     if (f.vibeNecessity && e.vibe_necessity !== f.vibeNecessity) return false
-    if (!f.includeRecurring && e.recurring_expense_uuid !== null) return false
+    if (f.recurringMode === "exclude" && e.recurring_expense_uuid !== null) return false
+    if (f.recurringMode === "only" && e.recurring_expense_uuid === null) return false
     return true
   })
 }


### PR DESCRIPTION
## Summary
- Add `RecurringMode = "all" | "exclude" | "only"` to `ExpenseFilter`
- Filter sheet exposes three pills (`All` / `Exclude` / `Only`) in a new `Recurring` section
- `applyFilter` drops `recurring_expense_uuid !== null` when `exclude`, drops `=== null` when `only`
- Chips show `No recurring` / `Recurring only`; `filterCount` counts when mode ≠ `all`

Closes #199

## Test plan
- [x] `make lint`
- [x] `make test-backend`
- [x] `cd frontend && npm run test -- --run src/expense/libs/expenseFilter.test.ts`
- [ ] Manual: open filter sheet, switch `Recurring` between `All` / `Exclude` / `Only`, confirm expense list and chip update accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)