### PR TITLE
feat(frontend): add specific-date filter to expense filter sheet

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -4,6 +4,7 @@ import type { CategoryResponse } from "../../common/libs/types"
 import { defaultFilter, type ExpenseFilter } from "../libs/expenseFilter"
 import { FilterSheetAmountSection } from "./FilterSheetAmountSection"
 import { FilterSheetCategorySection } from "./FilterSheetCategorySection"
+import { FilterSheetDateSection } from "./FilterSheetDateSection"
 import { FilterSheetHeader } from "./FilterSheetHeader"
 import { FilterSheetRecurringSection } from "./FilterSheetRecurringSection"
 import { FilterSheetScopeSection } from "./FilterSheetScopeSection"
@@ -69,6 +70,10 @@ export const ExpenseFilterSheet = ({
           <FilterSheetScopeSection
             scope={draft.scope}
             onChange={(v) => setDraft({ ...draft, scope: v })}
+          />
+          <FilterSheetDateSection
+            date={draft.date}
+            onChange={(v) => setDraft({ ...draft, date: v })}
           />
           <FilterSheetRecurringSection
             mode={draft.recurringMode}

--- a/frontend/src/expense/components/FilterSheetDateSection.tsx
+++ b/frontend/src/expense/components/FilterSheetDateSection.tsx
@@ -1,0 +1,26 @@
+interface FilterSheetDateSectionProps {
+  date: string | null
+  onChange: (date: string | null) => void
+}
+
+export const FilterSheetDateSection = ({ date, onChange }: FilterSheetDateSectionProps) => (
+  <section>
+    <div className="mb-2 flex items-center justify-between">
+      <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
+        Date
+      </h3>
+      {date && (
+        <button type="button" onClick={() => onChange(null)} className="text-[11px] text-gray-400">
+          clear
+        </button>
+      )}
+    </div>
+    <input
+      type="date"
+      value={date ?? ""}
+      onChange={(e) => onChange(e.target.value || null)}
+      className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+    />
+    <p className="mt-1.5 text-[11px] text-gray-400">Pinning a date overrides the period above.</p>
+  </section>
+)


### PR DESCRIPTION
Expose the existing single-day (date) filter through a new
FilterSheetDateSection so users can pin results to a specific date.
The applyFilter/filterCount/chip plumbing already supported the
date field; only the sheet UI was missing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VRGDdbrCg5JnnPu72U1cud