### PR TITLE
feat(frontend): make expense date filter a start/end range

### DIFF
--- a/frontend/src/expense/components/ExpenseFilterChips.tsx
+++ b/frontend/src/expense/components/ExpenseFilterChips.tsx
@@ -8,10 +8,18 @@ interface ExpenseFilterChipsProps {
   onClear: () => void
 }
 
-const formatDateChip = (key: string): string => {
+const formatDay = (key: string): string => {
   const d = parseDateKey(key)
   if (!d) return key
   return d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+}
+
+const formatDateRangeChip = (start: string | null, end: string | null): string | null => {
+  if (start && end)
+    return start === end ? formatDay(start) : `${formatDay(start)} – ${formatDay(end)}`
+  if (start) return `From ${formatDay(start)}`
+  if (end) return `Until ${formatDay(end)}`
+  return null
 }
 
 export const ExpenseFilterChips = ({
@@ -22,7 +30,8 @@ export const ExpenseFilterChips = ({
 }: ExpenseFilterChipsProps) => {
   const labels: string[] = []
   if (filter.q) labels.push(`"${filter.q}"`)
-  if (filter.date) labels.push(formatDateChip(filter.date))
+  const dateChip = formatDateRangeChip(filter.dateStart, filter.dateEnd)
+  if (dateChip) labels.push(dateChip)
   for (const uuid of filter.categoryUuids) {
     const c = categories.find((x) => x.uuid === uuid)
     if (c) labels.push(c.name)

--- a/frontend/src/expense/components/ExpenseFilterSheet.tsx
+++ b/frontend/src/expense/components/ExpenseFilterSheet.tsx
@@ -72,8 +72,10 @@ export const ExpenseFilterSheet = ({
             onChange={(v) => setDraft({ ...draft, scope: v })}
           />
           <FilterSheetDateSection
-            date={draft.date}
-            onChange={(v) => setDraft({ ...draft, date: v })}
+            start={draft.dateStart}
+            end={draft.dateEnd}
+            onStartChange={(v) => setDraft({ ...draft, dateStart: v })}
+            onEndChange={(v) => setDraft({ ...draft, dateEnd: v })}
           />
           <FilterSheetRecurringSection
             mode={draft.recurringMode}

--- a/frontend/src/expense/components/FilterSheetDateSection.tsx
+++ b/frontend/src/expense/components/FilterSheetDateSection.tsx
@@ -1,26 +1,54 @@
 interface FilterSheetDateSectionProps {
-  date: string | null
-  onChange: (date: string | null) => void
+  start: string | null
+  end: string | null
+  onStartChange: (v: string | null) => void
+  onEndChange: (v: string | null) => void
 }
 
-export const FilterSheetDateSection = ({ date, onChange }: FilterSheetDateSectionProps) => (
+const inputClass =
+  "min-w-0 flex-1 rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+
+export const FilterSheetDateSection = ({
+  start,
+  end,
+  onStartChange,
+  onEndChange,
+}: FilterSheetDateSectionProps) => (
   <section>
     <div className="mb-2 flex items-center justify-between">
       <h3 className="text-[11px] font-bold tracking-widest text-gray-500 uppercase dark:text-gray-400">
-        Date
+        Date range
       </h3>
-      {date && (
-        <button type="button" onClick={() => onChange(null)} className="text-[11px] text-gray-400">
+      {(start || end) && (
+        <button
+          type="button"
+          onClick={() => {
+            onStartChange(null)
+            onEndChange(null)
+          }}
+          className="text-[11px] text-gray-400"
+        >
           clear
         </button>
       )}
     </div>
-    <input
-      type="date"
-      value={date ?? ""}
-      onChange={(e) => onChange(e.target.value || null)}
-      className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm outline-none focus:ring-2 focus:ring-primary/20 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
-    />
-    <p className="mt-1.5 text-[11px] text-gray-400">Pinning a date overrides the period above.</p>
+    <div className="flex items-center gap-2">
+      <input
+        type="date"
+        value={start ?? ""}
+        max={end ?? undefined}
+        onChange={(e) => onStartChange(e.target.value || null)}
+        className={inputClass}
+      />
+      <span className="shrink-0 text-gray-400">—</span>
+      <input
+        type="date"
+        value={end ?? ""}
+        min={start ?? undefined}
+        onChange={(e) => onEndChange(e.target.value || null)}
+        className={inputClass}
+      />
+    </div>
+    <p className="mt-1.5 text-[11px] text-gray-400">Setting a range overrides the period above.</p>
   </section>
 )

--- a/frontend/src/expense/libs/expenseFilter.test.ts
+++ b/frontend/src/expense/libs/expenseFilter.test.ts
@@ -27,7 +27,8 @@ describe("defaultFilter", () => {
       categoryUuids: [],
       min: 0,
       max: 0,
-      date: null,
+      dateStart: null,
+      dateEnd: null,
       month: null,
       vibeSocial: null,
       vibePlanning: null,
@@ -42,7 +43,7 @@ describe("filterCount", () => {
     expect(filterCount(defaultFilter())).toBe(0)
   })
 
-  it("counts q, scope!=month, categories, amount range, and date", () => {
+  it("counts q, scope!=month, categories, amount range, and date range", () => {
     expect(
       filterCount({
         q: "x",
@@ -50,7 +51,8 @@ describe("filterCount", () => {
         categoryUuids: ["c1"],
         min: 100,
         max: 200,
-        date: "2026-06-16",
+        dateStart: "2026-06-16",
+        dateEnd: "2026-06-20",
         month: null,
         vibeSocial: null,
         vibePlanning: null,
@@ -58,6 +60,14 @@ describe("filterCount", () => {
         recurringMode: "all",
       }),
     ).toBe(5)
+  })
+
+  it("counts the date range once when only start or only end is set", () => {
+    expect(filterCount({ ...defaultFilter(), dateStart: "2026-06-01" })).toBe(1)
+    expect(filterCount({ ...defaultFilter(), dateEnd: "2026-06-30" })).toBe(1)
+    expect(
+      filterCount({ ...defaultFilter(), dateStart: "2026-06-01", dateEnd: "2026-06-30" }),
+    ).toBe(1)
   })
 
   it("counts recurringMode when not 'all'", () => {
@@ -129,7 +139,7 @@ describe("applyFilter", () => {
     expect(result.map((e) => e.uuid).toSorted()).toEqual(["a", "b"])
   })
 
-  it("date filter restricts to a single local day and overrides scope", () => {
+  it("equal start and end restrict to a single local day and override scope", () => {
     const target = mkExpense({
       uuid: "a",
       expensed_at: new Date(2026, 5, 10, 23, 30).toISOString(),
@@ -138,7 +148,56 @@ describe("applyFilter", () => {
     const result = applyFilter([target, other], {
       ...defaultFilter(),
       scope: "all",
-      date: "2026-06-10",
+      dateStart: "2026-06-10",
+      dateEnd: "2026-06-10",
+    })
+    expect(result.map((e) => e.uuid)).toEqual(["a"])
+  })
+
+  it("date range includes both endpoints inclusively", () => {
+    const before = mkExpense({ uuid: "a", expensed_at: new Date(2026, 5, 9, 23, 0).toISOString() })
+    const startDay = mkExpense({
+      uuid: "b",
+      expensed_at: new Date(2026, 5, 10, 0, 30).toISOString(),
+    })
+    const endDay = mkExpense({
+      uuid: "c",
+      expensed_at: new Date(2026, 5, 12, 23, 30).toISOString(),
+    })
+    const after = mkExpense({ uuid: "d", expensed_at: new Date(2026, 5, 13, 0, 10).toISOString() })
+    const result = applyFilter([before, startDay, endDay, after], {
+      ...defaultFilter(),
+      scope: "all",
+      dateStart: "2026-06-10",
+      dateEnd: "2026-06-12",
+    })
+    expect(result.map((e) => e.uuid).toSorted()).toEqual(["b", "c"])
+  })
+
+  it("open-ended start keeps everything on or after the start day", () => {
+    const before = mkExpense({ uuid: "a", expensed_at: new Date(2026, 5, 9, 23, 0).toISOString() })
+    const onOrAfter = mkExpense({
+      uuid: "b",
+      expensed_at: new Date(2026, 5, 10, 0, 0).toISOString(),
+    })
+    const result = applyFilter([before, onOrAfter], {
+      ...defaultFilter(),
+      scope: "all",
+      dateStart: "2026-06-10",
+    })
+    expect(result.map((e) => e.uuid)).toEqual(["b"])
+  })
+
+  it("open-ended end keeps everything on or before the end day", () => {
+    const onOrBefore = mkExpense({
+      uuid: "a",
+      expensed_at: new Date(2026, 5, 10, 23, 30).toISOString(),
+    })
+    const after = mkExpense({ uuid: "b", expensed_at: new Date(2026, 5, 11, 0, 30).toISOString() })
+    const result = applyFilter([onOrBefore, after], {
+      ...defaultFilter(),
+      scope: "all",
+      dateEnd: "2026-06-10",
     })
     expect(result.map((e) => e.uuid)).toEqual(["a"])
   })

--- a/frontend/src/expense/libs/expenseFilter.ts
+++ b/frontend/src/expense/libs/expenseFilter.ts
@@ -14,8 +14,10 @@ export interface ExpenseFilter {
   categoryUuids: string[]
   min: number
   max: number
-  /** 特定日のみ表示する場合に YYYY-MM-DD を指定。設定時は scope を無視。 */
-  date: string | null
+  /** 期間の開始日 (YYYY-MM-DD, 当日含む)。dateStart/dateEnd いずれか設定時は scope を無視。 */
+  dateStart: string | null
+  /** 期間の終了日 (YYYY-MM-DD, 当日含む)。 */
+  dateEnd: string | null
   /** scope=="month" で対象月を YYYY-MM 指定。null なら当月。 */
   month: string | null
   vibeSocial: VibeSocial | null
@@ -37,7 +39,8 @@ export const defaultFilter = (): ExpenseFilter => ({
   categoryUuids: [],
   min: 0,
   max: 0,
-  date: null,
+  dateStart: null,
+  dateEnd: null,
   month: null,
   vibeSocial: null,
   vibePlanning: null,
@@ -51,7 +54,7 @@ export const filterCount = (f: ExpenseFilter): number => {
   if (f.scope !== "month") n++
   if (f.categoryUuids.length > 0) n++
   if (f.min > 0 || f.max > 0) n++
-  if (f.date) n++
+  if (f.dateStart || f.dateEnd) n++
   if (f.vibeSocial) n++
   if (f.vibePlanning) n++
   if (f.vibeNecessity) n++
@@ -91,13 +94,18 @@ export const applyFilter = (expenses: ExpenseResponse[], f: ExpenseFilter): Expe
   const weekStart = new Date(now)
   weekStart.setDate(weekStart.getDate() - 6)
   weekStart.setHours(0, 0, 0, 0)
-  const targetDate = f.date ? parseDateKey(f.date) : null
+  const rangeStart = f.dateStart ? parseDateKey(f.dateStart) : null
+  const rangeEnd = f.dateEnd ? parseDateKey(f.dateEnd) : null
+  // 終了日を含めるため翌日 0:00 を上限 (排他) とする。
+  const rangeEndExclusive = rangeEnd ? new Date(rangeEnd) : null
+  if (rangeEndExclusive) rangeEndExclusive.setDate(rangeEndExclusive.getDate() + 1)
 
   return expenses.filter((e) => {
     const d = new Date(e.expensed_at)
 
-    if (targetDate) {
-      if (!sameLocalDay(d, targetDate)) return false
+    if (rangeStart || rangeEndExclusive) {
+      if (rangeStart && d < rangeStart) return false
+      if (rangeEndExclusive && d >= rangeEndExclusive) return false
     } else if (f.scope === "week") {
       if (d < weekStart) return false
       if (d > now && !sameLocalDay(d, now)) return false

--- a/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
+++ b/frontend/src/expense/pages/ExpenseMonthlyPage.tsx
@@ -29,7 +29,7 @@ export const ExpenseMonthlyPage = () => {
   const initialFilter = useMemo<ExpenseFilter>(() => {
     const dateParam = searchParams.get("date")
     if (dateParam && isValidDateKey(dateParam)) {
-      return { ...defaultFilter(), date: dateParam }
+      return { ...defaultFilter(), dateStart: dateParam, dateEnd: dateParam }
     }
     return defaultFilter()
     // initial読み取りのみで意図的に searchParams 変更には追従しない


### PR DESCRIPTION
## Summary

Follow-up to #201. Turns the single-date expense filter into an inclusive **start / end range**, and fixes the filter form width.

## Changes

- **Range model**: replaced the single `date` field with `dateStart` / `dateEnd` in `ExpenseFilter`. `applyFilter` keeps expenses from the start day 0:00 up to and including the end day (exclusive next-day boundary). Either bound can be set alone (start-only = from that day onward, end-only = up to that day). Setting either bound still overrides the week/month/all scope.
- **Form width**: the two date inputs now sit side by side with a `—` separator (same layout as the amount section), each `flex-1 min-w-0`, so the field no longer stretches full width.
- **Chips**: range-aware label — `Jun 1 – Jun 10`, `From Jun 1`, `Until Jun 10`, or a single day when start == end.
- **Heatmap link**: the single-day URL (`?date=`) on the monthly page now maps to `dateStart == dateEnd`, preserving the existing behavior.

## Test

- `npm test` — 42 passed (added cases for both endpoints inclusive, start-only, end-only, and single-day equivalence)
- typecheck / oxlint / oxfmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRGDdbrCg5JnnPu72U1cud

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRGDdbrCg5JnnPu72U1cud)_